### PR TITLE
Signature APIs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ members = [
     "crates/algorithms/aesgcm",
     "crates/algorithms/aesgcm/fuzz",
     "crates/utils/hacl-rs",
+    "crates/primitives/signature",
 ]
 
 [workspace.package]

--- a/benchmarks/benches/ecdsa_p256.rs
+++ b/benchmarks/benches/ecdsa_p256.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 
 use benchmarks::util::*;
 use libcrux_ecdsa::{
-    p256::{Nonce, PrivateKey, PublicKey},
+    p256::{Nonce, SigningKey, VerificationKey},
     DigestAlgorithm,
 };
 
@@ -19,7 +19,7 @@ fn sign(c: &mut Criterion) {
                 let mut rng = rand::rng();
 
                 let sk: [u8; 32] = hex_str_to_array(SK_HEX);
-                let sk = PrivateKey::try_from(&sk).unwrap();
+                let sk = SigningKey::try_from(&sk).unwrap();
                 let nonce = Nonce::random(&mut rng).unwrap();
                 let msg = b"sample";
 
@@ -93,9 +93,9 @@ fn verify(c: &mut Criterion) {
                 let mut rng = rand::rng();
 
                 let pk = hex_str_to_bytes(PK_HEX);
-                let pk = PublicKey::try_from(pk.as_slice()).unwrap();
+                let pk = VerificationKey::try_from(pk.as_slice()).unwrap();
                 let sk: [u8; 32] = hex_str_to_array(SK_HEX);
-                let sk = PrivateKey::try_from(&sk).unwrap();
+                let sk = SigningKey::try_from(&sk).unwrap();
                 let nonce = Nonce::random(&mut rng).unwrap();
                 let msg = b"sample";
                 let sig = libcrux_ecdsa::p256::sign(DigestAlgorithm::Sha256, &msg[..], &sk, &nonce)

--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add key-centric and slice-based signature public APIs
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): 
+  - Rename `PrivateKey` -> `SigningKey`, `PublicKey` -> `VerificationKey`
+  - Add key-centric and slice-based signature public APIs
 
 ## [0.0.4] (2025-11-05)
 

--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add key-centric and slice-based signature public APIs
+
 ## [0.0.4] (2025-11-05)
 
 - [#1061](https://github.com/cryspen/libcrux/pull/1061): Add `std` feature gate for `libcrux-ecdsa`

--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1241](https://github.com/cryspen/libcrux/pull/1241): 
   - Rename `PrivateKey` -> `SigningKey`, `PublicKey` -> `VerificationKey`
-  - Add key-centric and slice-based signature public APIs
+  - Add key-centric signature public APIs
 
 ## [0.0.4] (2025-11-05)
 

--- a/crates/algorithms/ecdsa/Cargo.toml
+++ b/crates/algorithms/ecdsa/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
-name = "libcrux-ecdsa"
 description = "Formally verified ECDSA signature library"
+name = "libcrux-ecdsa"
 readme = "Readme.md"
 version = "0.0.4"
 
 authors.workspace = true
-license.workspace = true
-homepage.workspace = true
 edition.workspace = true
+homepage.workspace = true
+license.workspace = true
 repository.workspace = true
 
 [dependencies]
@@ -15,14 +15,20 @@ libcrux-p256 = { version = "=0.0.4", path = "../p256", features = [
     "expose-hacl",
 ] }
 libcrux-sha2 = { version = "=0.0.4", path = "../sha2" }
+libcrux-secrets = { version = "=0.0.4", path = "../secrets" }
+libcrux-traits = { version = "=0.0.4", path = "../traits" }
 rand = { version = "0.9", optional = true, default-features = false }
 
 [features]
 default = ["rand", "std"]
 rand = ["dep:rand"]
 std = ["rand?/std"]
+check-secret-independence = [
+    "libcrux-secrets/check-secret-independence",
+    "libcrux-traits/check-secret-independence",
+]
 
 [dev-dependencies]
-rand_core = { version = "0.9" , features = ["os_rng"] }
+rand_core = { version = "0.9", features = ["os_rng"] }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.138"

--- a/crates/algorithms/ecdsa/Cargo.toml
+++ b/crates/algorithms/ecdsa/Cargo.toml
@@ -15,8 +15,8 @@ libcrux-p256 = { version = "=0.0.4", path = "../p256", features = [
     "expose-hacl",
 ] }
 libcrux-sha2 = { version = "=0.0.4", path = "../sha2" }
-libcrux-secrets = { version = "=0.0.4", path = "../secrets" }
-libcrux-traits = { version = "=0.0.4", path = "../traits" }
+libcrux-secrets = { version = "=0.0.4", path = "../../utils/secrets" }
+libcrux-traits = { version = "=0.0.4", path = "../../../traits" }
 rand = { version = "0.9", optional = true, default-features = false }
 
 [features]

--- a/crates/algorithms/ecdsa/Cargo.toml
+++ b/crates/algorithms/ecdsa/Cargo.toml
@@ -23,7 +23,10 @@ rand = { version = "0.9", optional = true, default-features = false }
 default = ["rand", "std"]
 rand = ["dep:rand"]
 std = ["rand?/std"]
-check-secret-independence = [
+
+# This doesn't check the secret independence of the implementation, but sets the
+# exposed API into secret independence checking mode.
+expose-secret-independence = [
     "libcrux-secrets/check-secret-independence",
     "libcrux-traits/check-secret-independence",
 ]

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -228,7 +228,7 @@ macro_rules! impl_mod {
             ) -> Result<KeyPair, slice::KeygenError> {
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
-                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify())?;
+                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes)?;
 
                 Ok(KeyPair {
                     signing_key: SigningKey::from(signing_key),

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -294,7 +294,6 @@ macro_rules! impl_mod {
 }
 
 pub mod sha2_256 {
-
     impl_mod!(
         EcdsaP256,
         Sha2_256,
@@ -304,7 +303,6 @@ pub mod sha2_256 {
 }
 
 pub mod sha2_384 {
-
     impl_mod!(
         EcdsaP256,
         Sha2_384,
@@ -314,7 +312,6 @@ pub mod sha2_384 {
 }
 
 pub mod sha2_512 {
-
     impl_mod!(
         EcdsaP256,
         Sha2_512,

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -172,29 +172,42 @@ macro_rules! impl_mod {
                 RAND_KEYGEN_LEN
             );
 
-            // error type including wrong length
+            /// An error when signing.
             #[derive(Debug)]
             pub enum SigningError {
+                /// The length of the provided signing key is incorrect.
                 WrongSigningKeyLength,
+                /// The length of the provided signature buffer is incorrect.
                 WrongSignatureLength,
-                InvalidArgument,
+                /// The length of the provided payload is invalid.
+                InvalidPayloadLength,
+                /// An unknown error occurred.
                 UnknownError,
             }
 
-            // error type including wrong length
+            /// An error when verifying a signature.
             #[derive(Debug)]
             pub enum VerificationError {
+                /// The length of the provided verification key is incorrect.
                 WrongVerificationKeyLength,
+                /// The length of the provided signature is incorrect.
                 WrongSignatureLength,
-                WrongPayloadLength,
+                /// The length of the provided payload is invalid.
+                InvalidPayloadLength,
+                /// An unknown error occurred.
                 UnknownError,
             }
 
+            /// An error when generating a signature key pair.
             #[derive(Debug)]
             pub enum KeygenError {
+                /// The provided randomness is invalid.
                 InvalidRandomness,
+                /// The length of the provided signing key buffer is incorrect.
                 WrongSigningKeyLength,
+                /// The length of the provided verification key buffer is incorrecct.
                 WrongVerificationKeyLength,
+                /// An unknown error occurred.
                 UnknownError,
             }
         }
@@ -236,7 +249,7 @@ macro_rules! impl_mod {
                     payload
                         .len()
                         .try_into()
-                        .map_err(|_| slice::SigningError::InvalidArgument)?,
+                        .map_err(|_| slice::SigningError::InvalidPayloadLength)?,
                     payload,
                     key.declassify_ref(),
                     &nonce.0,
@@ -257,7 +270,7 @@ macro_rules! impl_mod {
                     payload
                         .len()
                         .try_into()
-                        .map_err(|_| slice::VerificationError::WrongPayloadLength)?,
+                        .map_err(|_| slice::VerificationError::InvalidPayloadLength)?,
                     payload,
                     key,
                     <&[u8; 32]>::try_from(&signature[0..32]).unwrap(),

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -100,13 +100,15 @@ macro_rules! impl_mod {
         use super::*;
 
         #[doc(inline)]
-        pub use self::{
+        /// XXX: Decide whether we need these here (or need them to be public).
+        pub(crate) use self::{
             arrayref::{
                 KeyPair, Signature, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
             },
             slice::*,
         };
 
+        /// XXX: Decide whether we need these here (or need them to be public).
         pub(crate) mod arrayref {
             #[derive(Debug, PartialEq)]
             pub(crate) struct $ty;
@@ -121,7 +123,9 @@ macro_rules! impl_mod {
                 WrongLengthError
             );
         }
-        pub mod slice {
+
+        /// XXX: Decide whether we need these here (or need them to be public).
+        pub(crate) mod slice {
             //! Slice-based APIs for ECDSA-P256.
             //!
             //! ```rust
@@ -236,9 +240,11 @@ macro_rules! impl_mod {
                 })
             }
         }
+
+        /// XXX: Decide whether we need these here (or need them to be public).
         impl arrayref::$ty {
             /// Sign the `payload` with the `key`.
-            pub fn sign(
+            pub(crate) fn sign(
                 key: &[U8; Self::SIGNING_KEY_LEN],
                 payload: &[u8],
                 signature: &mut [u8; Self::SIGNATURE_LEN],
@@ -261,7 +267,7 @@ macro_rules! impl_mod {
             }
 
             /// Verify the `payload` and `signature` with the `key`.
-            pub fn verify(
+            pub(crate) fn verify(
                 key: &[u8; Self::VERIFICATION_KEY_LEN],
                 payload: &[u8],
                 signature: &[u8; Self::SIGNATURE_LEN],
@@ -281,7 +287,7 @@ macro_rules! impl_mod {
                 }
                 Ok(())
             }
-            pub fn keygen(
+            pub(crate) fn keygen(
                 signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
                 verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -301,9 +307,11 @@ macro_rules! impl_mod {
                 Ok(())
             }
         }
+
+        /// XXX: Decide whether we need these here (or need them to be public).
         impl slice::$ty {
             /// Sign the `payload` with the `key`.
-            pub fn sign(
+            pub(crate) fn sign(
                 key: &[U8],
                 payload: &[u8],
                 signature: &mut [u8],
@@ -320,7 +328,7 @@ macro_rules! impl_mod {
                     .map_err(slice::SigningError::from)
             }
             /// Verify the `payload` and `signature` with the `key`.
-            pub fn verify(
+            pub(crate) fn verify(
                 key: &[u8],
                 payload: &[u8],
                 signature: &[u8],
@@ -335,7 +343,7 @@ macro_rules! impl_mod {
                 arrayref::$ty::verify(key, payload, signature)
                     .map_err(slice::VerificationError::from)
             }
-            pub fn keygen(
+            pub(crate) fn keygen(
                 signing_key: &mut [U8],
                 verification_key: &mut [u8],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -350,9 +358,11 @@ macro_rules! impl_mod {
                 arrayref::$ty::keygen(signing_key, verification_key, randomness)
             }
         }
+
+        /// XXX: Decide whether we need these here (or need them to be public).
         impl<'a> SigningKeyRef<'a> {
             /// Sign the `payload`.
-            pub fn sign(
+            pub(crate) fn sign(
                 &self,
                 payload: &[u8],
                 signature: &mut [u8],
@@ -361,9 +371,11 @@ macro_rules! impl_mod {
                 slice::$ty::sign(self.as_ref(), payload, signature, nonce)
             }
         }
+
+        /// XXX: Decide whether we need these here (or need them to be public).
         impl<'a> VerificationKeyRef<'a> {
             /// Verify the `payload` and `signature`.
-            pub fn verify(
+            pub(crate) fn verify(
                 &self,
                 payload: &[u8],
                 signature: &[u8],

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -1,0 +1,399 @@
+use crate::p256::Nonce;
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+
+macro_rules! impl_mod {
+    ($ty:ident, $module:ident,
+            $sign_fn:ident,
+            $verify_fn:ident) => {
+        use libcrux_secrets::{DeclassifyRef, U8};
+
+        const SIGNING_KEY_LEN: usize = 32;
+        const VERIFICATION_KEY_LEN: usize = 64;
+        const SIGNATURE_LEN: usize = 64;
+        const RAND_KEYGEN_LEN: usize = 32;
+
+        use super::*;
+        // arrayref API
+        #[doc(inline)]
+        pub use arrayref::*;
+
+        // TODO: different error type?
+        #[derive(Debug)]
+        /// An incorrect length when converting from slice.
+        pub struct WrongLengthError;
+
+        pub mod arrayref {
+            #[derive(Debug, PartialEq)]
+            pub struct $ty;
+            use super::*;
+            impl_key_centric_types!(
+                $ty,
+                SIGNING_KEY_LEN,
+                VERIFICATION_KEY_LEN,
+                SIGNATURE_LEN,
+                RAND_KEYGEN_LEN,
+                WrongLengthError,
+                WrongLengthError
+            );
+        }
+        pub mod slice {
+            #[derive(Debug, PartialEq)]
+            pub struct $ty;
+            use super::*;
+            impl_sign_traits!(
+                $ty,
+                SIGNING_KEY_LEN,
+                VERIFICATION_KEY_LEN,
+                SIGNATURE_LEN,
+                RAND_KEYGEN_LEN
+            );
+
+            // error type including wrong length
+            #[derive(Debug)]
+            pub enum SigningError {
+                WrongSigningKeyLength,
+                WrongSignatureLength,
+                InvalidArgument,
+                UnknownError,
+            }
+
+            // error type including wrong length
+            #[derive(Debug)]
+            pub enum VerificationError {
+                WrongVerificationKeyLength,
+                WrongSignatureLength,
+                WrongPayloadLength,
+                UnknownError,
+            }
+
+            #[derive(Debug)]
+            pub enum KeygenError {
+                InvalidRandomness,
+                WrongSigningKeyLength,
+                WrongVerificationKeyLength,
+                UnknownError,
+            }
+        }
+
+        impl arrayref::$ty {
+            #[cfg(feature = "rand")]
+            pub fn generate_key_pair(
+                rng: &mut impl rand::CryptoRng,
+            ) -> Result<KeyPair, slice::KeygenError> {
+                use libcrux_secrets::Classify;
+
+                let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+                rng.fill_bytes(&mut bytes);
+                let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
+                let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+                arrayref::$ty::keygen_derand(
+                    &mut signing_key,
+                    &mut verification_key,
+                    bytes.classify(),
+                )?;
+
+                Ok(KeyPair {
+                    signing_key: SigningKey::from(signing_key),
+                    verification_key: VerificationKey::from(verification_key),
+                })
+            }
+        }
+        impl arrayref::$ty {
+            pub fn sign(
+                key: &[U8; Self::SIGNING_KEY_LEN],
+                payload: &[u8],
+                signature: &mut [u8; Self::SIGNATURE_LEN],
+                nonce: &Nonce,
+            ) -> Result<(), slice::SigningError> {
+                let result = libcrux_p256::$sign_fn(
+                    signature,
+                    payload
+                        .len()
+                        .try_into()
+                        .map_err(|_| slice::SigningError::InvalidArgument)?,
+                    payload,
+                    key.declassify_ref(),
+                    &nonce.0,
+                );
+                if !result {
+                    return Err(slice::SigningError::UnknownError);
+                }
+                Ok(())
+            }
+            pub fn verify(
+                key: &[u8; Self::VERIFICATION_KEY_LEN],
+                payload: &[u8],
+                signature: &[u8; Self::SIGNATURE_LEN],
+            ) -> Result<(), slice::VerificationError> {
+                let result = libcrux_p256::$verify_fn(
+                    payload
+                        .len()
+                        .try_into()
+                        .map_err(|_| slice::VerificationError::WrongPayloadLength)?,
+                    payload,
+                    key,
+                    <&[u8; 32]>::try_from(&signature[0..32]).unwrap(),
+                    <&[u8; 32]>::try_from(&signature[32..]).unwrap(),
+                );
+                if !result {
+                    return Err(slice::VerificationError::UnknownError);
+                }
+                Ok(())
+            }
+            pub fn keygen_derand(
+                signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
+                verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
+                randomness: [U8; Self::RAND_KEYGEN_LEN],
+            ) -> Result<(), slice::KeygenError> {
+                use libcrux_traits::ecdh::arrayref::*;
+
+                libcrux_p256::P256::secret_to_public(verification_key, &randomness).map_err(
+                    |err| match err {
+                        libcrux_traits::ecdh::arrayref::SecretToPublicError::InvalidSecret => {
+                            slice::KeygenError::InvalidRandomness
+                        }
+                        libcrux_traits::ecdh::arrayref::SecretToPublicError::Unknown => {
+                            slice::KeygenError::UnknownError
+                        }
+                    },
+                )?;
+                *signing_key = randomness;
+
+                Ok(())
+            }
+        }
+        impl slice::$ty {
+            pub fn sign(
+                key: &[U8],
+                payload: &[u8],
+                signature: &mut [u8],
+                nonce: &Nonce,
+            ) -> Result<(), slice::SigningError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSigningKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSignatureLength)?;
+
+                arrayref::$ty::sign(&key, payload, signature, nonce)
+                    .map_err(slice::SigningError::from)
+            }
+            pub fn verify(
+                key: &[u8],
+                payload: &[u8],
+                signature: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongVerificationKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongSignatureLength)?;
+
+                arrayref::$ty::verify(key, payload, signature)
+                    .map_err(slice::VerificationError::from)
+            }
+            pub fn keygen_derand(
+                signing_key: &mut [U8],
+                verification_key: &mut [u8],
+                randomness: [U8; Self::RAND_KEYGEN_LEN],
+            ) -> Result<(), slice::KeygenError> {
+                let signing_key = signing_key
+                    .try_into()
+                    .map_err(|_| slice::KeygenError::WrongSigningKeyLength)?;
+                let verification_key = verification_key
+                    .try_into()
+                    .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
+
+                arrayref::$ty::keygen_derand(signing_key, verification_key, randomness)
+            }
+        }
+        impl<'a> SigningKeyRef<'a> {
+            pub fn sign(
+                &self,
+                payload: &[u8],
+                signature: &mut [u8],
+                nonce: &Nonce,
+            ) -> Result<(), slice::SigningError> {
+                slice::$ty::sign(self.as_ref(), payload, signature, nonce)
+            }
+        }
+        impl<'a> VerificationKeyRef<'a> {
+            pub fn verify(
+                &self,
+                payload: &[u8],
+                signature: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                slice::$ty::verify(self.as_ref(), payload, signature)
+            }
+        }
+
+        // key-centric API
+        impl SigningKey {
+            pub fn sign(
+                &self,
+                payload: &[u8],
+                nonce: &Nonce,
+            ) -> Result<Signature, slice::SigningError> {
+                let mut signature = [0u8; SIGNATURE_LEN];
+                arrayref::$ty::sign(self.as_ref(), payload, &mut signature, nonce)
+                    .map(|_| Signature::from(signature))
+            }
+        }
+        impl VerificationKey {
+            pub fn verify(
+                &self,
+                payload: &[u8],
+                signature: &Signature,
+            ) -> Result<(), slice::VerificationError> {
+                arrayref::$ty::verify(self.as_ref(), payload, signature.as_ref())
+            }
+        }
+    };
+}
+
+pub mod sha2_256 {
+
+    impl_mod!(
+        EcdsaP256,
+        Sha2_256,
+        ecdsa_sign_p256_sha2,
+        ecdsa_verif_p256_sha2
+    );
+}
+
+pub mod sha2_384 {
+
+    impl_mod!(
+        EcdsaP256,
+        Sha2_384,
+        ecdsa_sign_p256_sha384,
+        ecdsa_verif_p256_sha384
+    );
+}
+
+pub mod sha2_512 {
+
+    impl_mod!(
+        EcdsaP256,
+        Sha2_512,
+        ecdsa_sign_p256_sha512,
+        ecdsa_verif_p256_sha512
+    );
+}
+
+#[test]
+#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+fn key_centric_owned() {
+    use rand::TryRngCore;
+    let mut rng = rand_core::OsRng;
+    let mut rng = rng.unwrap_mut();
+    use libcrux_traits::signature::SignConsts;
+
+    use sha2_256::{EcdsaP256, KeyPair, SigningKey, VerificationKey};
+
+    // keys can be created from arrays
+    let _signing_key = SigningKey::from([0u8; EcdsaP256::SIGNING_KEY_LEN]);
+    let _verification_key = VerificationKey::from([0u8; EcdsaP256::VERIFICATION_KEY_LEN]);
+
+    // key-centric API
+    let KeyPair {
+        signing_key,
+        verification_key,
+    } = EcdsaP256::generate_key_pair(&mut rng).unwrap();
+
+    let signature = signing_key
+        .sign(b"payload", &Nonce::random(&mut rng).unwrap())
+        .unwrap();
+    verification_key.verify(b"payload", &signature).unwrap();
+}
+
+#[test]
+#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+fn key_centric_refs() {
+    use libcrux_traits::signature::SignConsts;
+    use sha2_256::{EcdsaP256, SigningKeyRef, VerificationKeyRef};
+
+    use rand::{RngCore, TryRngCore};
+    let mut rng = rand_core::OsRng;
+    let mut rng = rng.unwrap_mut();
+
+    let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
+
+    let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
+    rng.fill_bytes(&mut bytes);
+    EcdsaP256::keygen_derand(&mut signing_key, &mut verification_key, bytes).unwrap();
+
+    // create references from slice
+    let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+    let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+
+    let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
+    signing_key
+        .sign(
+            b"payload",
+            &mut signature,
+            &Nonce::random(&mut rng).unwrap(),
+        )
+        .unwrap();
+    verification_key.verify(b"payload", &signature).unwrap();
+}
+
+#[test]
+#[cfg(not(feature = "check-secret-independence"))]
+fn arrayref_apis() {
+    use libcrux_traits::signature::SignConsts;
+    use sha2_256::EcdsaP256;
+
+    use rand::{RngCore, TryRngCore};
+    let mut rng = rand_core::OsRng;
+    let mut rng = rng.unwrap_mut();
+
+    let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
+
+    let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
+    rng.fill_bytes(&mut bytes);
+    EcdsaP256::keygen_derand(&mut signing_key, &mut verification_key, bytes).unwrap();
+
+    // arrayref API
+    let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
+    EcdsaP256::sign(
+        &signing_key,
+        b"payload",
+        &mut signature,
+        &Nonce::random(&mut rng).unwrap(),
+    )
+    .unwrap();
+    EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
+}
+#[test]
+#[cfg(not(feature = "check-secret-independence"))]
+fn slice_apis() {
+    use libcrux_traits::signature::SignConsts;
+    use sha2_256::slice::EcdsaP256;
+
+    use rand::{RngCore, TryRngCore};
+    let mut rng = rand_core::OsRng;
+    let mut rng = rng.unwrap_mut();
+
+    let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
+
+    let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
+    rng.fill_bytes(&mut bytes);
+    EcdsaP256::keygen_derand(&mut signing_key, &mut verification_key, bytes).unwrap();
+
+    // slice API
+    let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
+    EcdsaP256::sign(
+        &signing_key,
+        b"payload",
+        &mut signature,
+        &Nonce::random(&mut rng).unwrap(),
+    )
+    .unwrap();
+    EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
+}

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -55,7 +55,7 @@ macro_rules! impl_mod {
             //! // keygen
             //! let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
             //! rng.fill_bytes(&mut bytes);
-            //! EcdsaP256::keygen_derand(&mut signing_key, &mut verification_key, bytes).unwrap();
+            //! EcdsaP256::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
             //!
             //! // sign
             //! let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
@@ -117,11 +117,7 @@ macro_rules! impl_mod {
                 rng.fill_bytes(&mut bytes);
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
-                arrayref::$ty::keygen_derand(
-                    &mut signing_key,
-                    &mut verification_key,
-                    bytes.classify(),
-                )?;
+                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify())?;
 
                 Ok(KeyPair {
                     signing_key: SigningKey::from(signing_key),
@@ -174,7 +170,7 @@ macro_rules! impl_mod {
                 }
                 Ok(())
             }
-            pub fn keygen_derand(
+            pub fn keygen(
                 signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
                 verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -230,7 +226,7 @@ macro_rules! impl_mod {
                 arrayref::$ty::verify(key, payload, signature)
                     .map_err(slice::VerificationError::from)
             }
-            pub fn keygen_derand(
+            pub fn keygen(
                 signing_key: &mut [U8],
                 verification_key: &mut [u8],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -242,7 +238,7 @@ macro_rules! impl_mod {
                     .try_into()
                     .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
 
-                arrayref::$ty::keygen_derand(signing_key, verification_key, randomness)
+                arrayref::$ty::keygen(signing_key, verification_key, randomness)
             }
         }
         impl<'a> SigningKeyRef<'a> {
@@ -361,7 +357,7 @@ fn key_centric_refs() {
 
     let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
     rng.fill_bytes(&mut bytes);
-    EcdsaP256::keygen_derand(&mut signing_key, &mut verification_key, bytes).unwrap();
+    EcdsaP256::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
 
     // create references from slice
     let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -188,14 +188,14 @@ macro_rules! impl_mod {
             /// An error when verifying a signature.
             #[derive(Debug)]
             pub enum VerificationError {
+                /// The provided signature is invalid.
+                InvalidSignature,
                 /// The length of the provided verification key is incorrect.
                 WrongVerificationKeyLength,
                 /// The length of the provided signature is incorrect.
                 WrongSignatureLength,
                 /// The length of the provided payload is invalid.
                 InvalidPayloadLength,
-                /// An unknown error occurred.
-                UnknownError,
             }
 
             /// An error when generating a signature key pair.
@@ -277,7 +277,7 @@ macro_rules! impl_mod {
                     <&[u8; 32]>::try_from(&signature[32..]).unwrap(),
                 );
                 if !result {
-                    return Err(slice::VerificationError::UnknownError);
+                    return Err(slice::VerificationError::InvalidSignature);
                 }
                 Ok(())
             }

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -70,6 +70,8 @@ macro_rules! impl_mod {
             //! // verify
             //! EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
             //! ```
+            
+            /// Slice-based APIs for ECDSA-P256.
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -1,5 +1,5 @@
 use crate::p256::Nonce;
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
 
 macro_rules! impl_mod {
     ($ty:ident, $module:ident,
@@ -73,7 +73,7 @@ macro_rules! impl_mod {
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;
-            impl_sign_traits!(
+            impl_sign_consts!(
                 $ty,
                 SIGNING_KEY_LEN,
                 VERIFICATION_KEY_LEN,

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -268,19 +268,17 @@ macro_rules! impl_mod {
                 verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
             ) -> Result<(), slice::KeygenError> {
-                use libcrux_traits::ecdh::arrayref::*;
+                use libcrux_p256::ecdh_api::EcdhArrayref;
 
-                libcrux_p256::P256::secret_to_public(verification_key, &randomness).map_err(
-                    |err| match err {
-                        libcrux_traits::ecdh::arrayref::SecretToPublicError::InvalidSecret => {
+                libcrux_p256::P256::generate_pair(verification_key, signing_key, &randomness)
+                    .map_err(|err| match err {
+                        libcrux_traits::ecdh::arrayref::GenerateSecretError::InvalidRandomness => {
                             slice::KeygenError::InvalidRandomness
                         }
-                        libcrux_traits::ecdh::arrayref::SecretToPublicError::Unknown => {
+                        libcrux_traits::ecdh::arrayref::GenerateSecretError::Unknown => {
                             slice::KeygenError::UnknownError
                         }
-                    },
-                )?;
-                *signing_key = randomness;
+                    })?;
 
                 Ok(())
             }

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -156,6 +156,11 @@ macro_rules! impl_mod {
             //! ```
 
             /// Slice-based APIs for ECDSA-P256.
+            ///
+            /// This struct provides slice-based APIs for ECDSA-P256, as well as an implementation
+            /// of the [`SignConsts`] trait, which can be used to retrieve constants defining
+            /// the verification key length, signing key length, signature length, and the
+            /// length of the randomness required for key generation for the signature scheme.
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -30,7 +30,7 @@
 //! # // key generation
 //! # let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
 //! # let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
-//! # EcdsaP256::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+//! # EcdsaP256::keygen(&mut signing_key, &mut verification_key, [1; 32]).unwrap();
 //! #
 //! # use rand::TryRngCore;
 //! # use libcrux_ecdsa::p256::Nonce;
@@ -70,7 +70,7 @@
 //! // keygen
 //! let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
 //! let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
-//! EcdsaP256::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+//! EcdsaP256::keygen(&mut signing_key, &mut verification_key, [1; 32]);
 //!
 //! // signature buffer
 //! let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
@@ -446,7 +446,7 @@ fn key_centric_refs() {
     let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
 
-    let mut bytes = [0u8; EcdsaP256::RAND_KEYGEN_LEN];
+    let mut bytes = [1u8; EcdsaP256::RAND_KEYGEN_LEN];
     rng.fill_bytes(&mut bytes);
     EcdsaP256::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
 

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -7,7 +7,7 @@ macro_rules! impl_mod {
     ($ty:ident, $module:ident,
             $sign_fn:ident,
             $verify_fn:ident) => {
-        use libcrux_secrets::{DeclassifyRef, U8};
+        use libcrux_secrets::{Classify, DeclassifyRef, U8};
 
         const SIGNING_KEY_LEN: usize = 32;
         const VERIFICATION_KEY_LEN: usize = 64;
@@ -109,11 +109,18 @@ macro_rules! impl_mod {
 
         impl KeyPair {
             #[cfg(feature = "rand")]
+            /// Generate an ECDSA-P256 key pair
             pub fn generate(rng: &mut impl rand::CryptoRng) -> Result<KeyPair, slice::KeygenError> {
-                use libcrux_secrets::Classify;
-
                 let mut bytes = [0u8; arrayref::$ty::RAND_KEYGEN_LEN];
                 rng.fill_bytes(&mut bytes);
+
+                Self::generate_derand(bytes.classify())
+            }
+
+            /// Generate an ECDSA-P256 key pair (derand)
+            pub fn generate_derand(
+                bytes: [U8; RAND_KEYGEN_LEN],
+            ) -> Result<KeyPair, slice::KeygenError> {
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
                 arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify())?;

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -108,26 +108,15 @@ macro_rules! impl_mod {
             }
         }
 
-        impl slice::$ty {
+        impl KeyPair {
             #[cfg(feature = "rand")]
-            pub fn generate_key_pair(
-                rng: &mut impl rand::CryptoRng,
-            ) -> Result<KeyPair, slice::KeygenError> {
-                arrayref::$ty::generate_key_pair(rng)
-            }
-        }
-
-        impl arrayref::$ty {
-            #[cfg(feature = "rand")]
-            pub fn generate_key_pair(
-                rng: &mut impl rand::CryptoRng,
-            ) -> Result<KeyPair, slice::KeygenError> {
+            pub fn generate(rng: &mut impl rand::CryptoRng) -> Result<KeyPair, slice::KeygenError> {
                 use libcrux_secrets::Classify;
 
-                let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+                let mut bytes = [0u8; arrayref::$ty::RAND_KEYGEN_LEN];
                 rng.fill_bytes(&mut bytes);
-                let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
-                let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+                let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
+                let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
                 arrayref::$ty::keygen_derand(
                     &mut signing_key,
                     &mut verification_key,
@@ -352,7 +341,7 @@ fn key_centric_owned() {
     let KeyPair {
         signing_key,
         verification_key,
-    } = EcdsaP256::generate_key_pair(&mut rng).unwrap();
+    } = KeyPair::generate(&mut rng).unwrap();
 
     let signature = signing_key
         .sign(b"payload", &Nonce::random(&mut rng).unwrap())

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -1,5 +1,7 @@
 use crate::p256::Nonce;
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
+use libcrux_traits::signature::{
+    impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
+};
 
 macro_rules! impl_mod {
     ($ty:ident, $module:ident,
@@ -16,11 +18,6 @@ macro_rules! impl_mod {
 
         #[doc(inline)]
         pub use arrayref::*;
-
-        // TODO: different error type?
-        #[derive(Debug)]
-        /// An incorrect length when converting from slice.
-        pub struct WrongLengthError;
 
         pub(crate) mod arrayref {
             #[derive(Debug, PartialEq)]
@@ -70,7 +67,7 @@ macro_rules! impl_mod {
             //! // verify
             //! EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
             //! ```
-            
+
             /// Slice-based APIs for ECDSA-P256.
             #[derive(Debug, PartialEq)]
             pub struct $ty;

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -284,7 +284,7 @@ pub mod sha2_512 {
 }
 
 #[test]
-#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
 fn key_centric_owned() {
     use rand::TryRngCore;
     let mut rng = rand_core::OsRng;
@@ -310,7 +310,7 @@ fn key_centric_owned() {
 }
 
 #[test]
-#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
 fn key_centric_refs() {
     use libcrux_traits::signature::SignConsts;
     use sha2_256::{EcdsaP256, SigningKeyRef, VerificationKeyRef};
@@ -342,7 +342,7 @@ fn key_centric_refs() {
 }
 
 #[test]
-#[cfg(not(feature = "check-secret-independence"))]
+#[cfg(not(feature = "expose-secret-independence"))]
 fn arrayref_apis() {
     use libcrux_traits::signature::SignConsts;
     use sha2_256::EcdsaP256;
@@ -370,7 +370,7 @@ fn arrayref_apis() {
     EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
 }
 #[test]
-#[cfg(not(feature = "check-secret-independence"))]
+#[cfg(not(feature = "expose-secret-independence"))]
 fn slice_apis() {
     use libcrux_traits::signature::SignConsts;
     use sha2_256::slice::EcdsaP256;

--- a/crates/algorithms/ecdsa/src/key_centric_apis.rs
+++ b/crates/algorithms/ecdsa/src/key_centric_apis.rs
@@ -13,7 +13,7 @@ macro_rules! impl_mod {
         const RAND_KEYGEN_LEN: usize = 32;
 
         use super::*;
-        // arrayref API
+
         #[doc(inline)]
         pub use arrayref::*;
 

--- a/crates/algorithms/ecdsa/src/lib.rs
+++ b/crates/algorithms/ecdsa/src/lib.rs
@@ -28,3 +28,5 @@ pub type DigestAlgorithm = libcrux_sha2::Algorithm;
 /// The number of iteration for rejection sampling.
 #[cfg(feature = "rand")]
 pub(crate) const RAND_LIMIT: usize = 100;
+
+pub mod key_centric_apis;

--- a/crates/algorithms/ecdsa/src/lib.rs
+++ b/crates/algorithms/ecdsa/src/lib.rs
@@ -29,4 +29,4 @@ pub type DigestAlgorithm = libcrux_sha2::Algorithm;
 #[cfg(feature = "rand")]
 pub(crate) const RAND_LIMIT: usize = 100;
 
-pub mod key_centric_apis;
+pub(crate) mod key_centric_apis;

--- a/crates/algorithms/ecdsa/src/lib.rs
+++ b/crates/algorithms/ecdsa/src/lib.rs
@@ -17,6 +17,7 @@ pub enum Error {
     NoCompressedPoint,
     NoUnCompressedPoint,
     SigningError,
+    SecretToPublicError,
     InvalidSignature,
     RandError,
     UnsupportedHash,

--- a/crates/algorithms/ecdsa/src/p256.rs
+++ b/crates/algorithms/ecdsa/src/p256.rs
@@ -18,7 +18,7 @@ pub struct Signature {
 }
 
 /// An ECDSA P-256 nonce
-pub struct Nonce([u8; 32]);
+pub struct Nonce(pub(super) [u8; 32]);
 
 /// An ECDSA P-256 private key
 pub struct PrivateKey([u8; 32]);

--- a/crates/algorithms/ecdsa/src/p256.rs
+++ b/crates/algorithms/ecdsa/src/p256.rs
@@ -27,6 +27,14 @@ pub struct SigningKey([u8; 32]);
 #[derive(Debug)]
 pub struct VerificationKey(pub [u8; 64]);
 
+/// An ECDSA P-256
+pub struct ECDSAKeyPair {
+    /// An ECDSA P-256 signing key
+    pub signing_key: SigningKey,
+    /// An ECDSA P-256 verification key
+    pub verification_key: VerificationKey,
+}
+
 mod conversions {
     use super::*;
 

--- a/crates/algorithms/ecdsa/src/p256.rs
+++ b/crates/algorithms/ecdsa/src/p256.rs
@@ -33,18 +33,30 @@ const RAND_KEYGEN_LEN: usize = 32;
 
 impl ECDSAKeyPair {
     pub fn generate(rng: &mut impl CryptoRng) -> Result<Self, Error> {
-        let mut bytes = [0u8; RAND_KEYGEN_LEN];
-        rng.fill_bytes(&mut bytes);
+        let mut verification_key = [0u8; 64];
 
-        Self::generate_derand(bytes.classify())
+        let signing_key = SigningKey::random(rng)?;
+        // create verification key
+        libcrux_p256::P256::secret_to_public(&mut verification_key, signing_key.as_ref())
+            .map_err(|_| Error::SecretToPublicError)?;
+
+        Ok(ECDSAKeyPair {
+            signing_key,
+            verification_key: VerificationKey::try_from(&verification_key)?,
+        })
     }
 
     /// Generate an ECDSA-P256 key pair (derand)
     pub fn generate_derand(randomness: [U8; RAND_KEYGEN_LEN]) -> Result<ECDSAKeyPair, Error> {
-        let mut signing_key = [0u8; 32];
+        let signing_key = randomness;
         let mut verification_key = [0u8; 64];
 
-        libcrux_p256::P256::generate_pair(&mut verification_key, &mut signing_key, &randomness);
+        // validate the signing key
+        crate::p256::validate_scalar_(&signing_key)?;
+
+        // create verification key
+        libcrux_p256::P256::secret_to_public(&mut verification_key, &signing_key)
+            .map_err(|_| Error::SecretToPublicError)?;
 
         Ok(ECDSAKeyPair {
             signing_key: SigningKey::try_from(&signing_key)?,

--- a/crates/algorithms/ecdsa/tests/self.rs
+++ b/crates/algorithms/ecdsa/tests/self.rs
@@ -4,7 +4,7 @@ mod util;
 mod rand {
     use crate::util::*;
     use libcrux_ecdsa::{
-        p256::{Nonce, PrivateKey, PublicKey},
+        p256::{Nonce, SigningKey, VerificationKey},
         *,
     };
     use rand_core::OsRng;
@@ -20,9 +20,9 @@ mod rand {
         let mut rng = os_rng.unwrap_mut();
 
         let pk = hex_str_to_bytes(PK_HEX);
-        let pk = PublicKey::try_from(pk.as_slice()).unwrap();
+        let pk = VerificationKey::try_from(pk.as_slice()).unwrap();
         let sk: [u8; 32] = hex_str_to_array(SK_HEX);
-        let sk = PrivateKey::try_from(&sk).unwrap();
+        let sk = SigningKey::try_from(&sk).unwrap();
         let nonce = Nonce::random(&mut rng).unwrap();
         let msg = b"sample";
 

--- a/crates/algorithms/ecdsa/tests/wycheproof.rs
+++ b/crates/algorithms/ecdsa/tests/wycheproof.rs
@@ -1,6 +1,6 @@
 mod util;
 use libcrux_ecdsa::{
-    p256::{self, PublicKey},
+    p256::{self, VerificationKey},
     DigestAlgorithm, Error,
 };
 use util::*;
@@ -106,7 +106,7 @@ fn test_wycheproof() {
         assert_eq!(testGroup.sha, "SHA-256");
 
         let pk = hex_str_to_bytes(&testGroup.key.uncompressed);
-        let pk = PublicKey::try_from(pk.as_slice()).unwrap();
+        let pk = VerificationKey::try_from(pk.as_slice()).unwrap();
 
         for test in testGroup.tests.iter() {
             println!("Test {:?}: {:?}", test.tcId, test.comment);

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add key-centric and slice-based signature public APIs
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): 
+    - Add `Ed25519KeyPair` type
+    - Add key-centric and slice-based signature public APIs
 
 ## [0.0.4] (2025-11-05)
 

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add key-centric and slice-based signature public APIs
+
 ## [0.0.4] (2025-11-05)
 
 ## [0.0.3] (2025-06-30)

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - [#1241](https://github.com/cryspen/libcrux/pull/1241): 
     - Add `Ed25519KeyPair` type
-    - Add key-centric and slice-based signature public APIs
+    - Add key-centric signature public APIs
 
 ## [0.0.4] (2025-11-05)
 

--- a/crates/algorithms/ed25519/Cargo.toml
+++ b/crates/algorithms/ed25519/Cargo.toml
@@ -16,6 +16,9 @@ libcrux-sha2 = { version = "=0.0.4", path = "../sha2", features = [
     "expose-hacl",
 ] }
 libcrux-macros = { version = "=0.0.3", path = "../../utils/macros" }
+libcrux-traits = { version = "=0.0.4", path = "../../../traits" }
+libcrux-secrets = { version = "=0.0.4", path = "../../utils/secrets" }
+
 rand_core = { version = "0.9", optional = true }
 tls_codec = { version = "0.4.2", features = ["derive"], optional = true }
 
@@ -26,3 +29,7 @@ wycheproof = "0.6.0"
 [features]
 rand = ["dep:rand_core"]
 codec = ["tls_codec/std"]
+check-secret-independence = [
+    "libcrux-traits/check-secret-independence",
+    "libcrux-secrets/check-secret-independence",
+]

--- a/crates/algorithms/ed25519/Cargo.toml
+++ b/crates/algorithms/ed25519/Cargo.toml
@@ -29,7 +29,10 @@ wycheproof = "0.6.0"
 [features]
 rand = ["dep:rand_core"]
 codec = ["tls_codec/std"]
-check-secret-independence = [
+
+# This doesn't check the secret independence of the implementation, but sets the
+# exposed API into secret independence checking mode.
+expose-secret-independence = [
     "libcrux-traits/check-secret-independence",
     "libcrux-secrets/check-secret-independence",
 ]

--- a/crates/algorithms/ed25519/src/impl_hacl.rs
+++ b/crates/algorithms/ed25519/src/impl_hacl.rs
@@ -114,10 +114,16 @@ pub fn secret_to_public(pk: &mut [u8; 32], sk: &[u8; 32]) {
     crate::hacl::ed25519::secret_to_public(pk, sk)
 }
 
+/// An Ed25519 key pair.
+pub struct Ed25519KeyPair {
+    /// An Ed25519 signing key
+    pub signing_key: SigningKey,
+    /// An Ed25519 verification key
+    pub verification_key: VerificationKey,
+}
+
 #[cfg(feature = "rand")]
-pub fn generate_key_pair(
-    rng: &mut impl rand_core::CryptoRng,
-) -> Result<(SigningKey, VerificationKey), Error> {
+pub fn generate_key_pair(rng: &mut impl rand_core::CryptoRng) -> Result<Ed25519KeyPair, Error> {
     use rand_core::TryRngCore;
 
     const LIMIT: usize = 100;
@@ -143,5 +149,8 @@ pub fn generate_key_pair(
 
     secret_to_public(&mut pk, &sk);
 
-    Ok((SigningKey { value: sk }, VerificationKey { value: pk }))
+    Ok(Ed25519KeyPair {
+        signing_key: SigningKey { value: sk },
+        verification_key: VerificationKey { value: pk },
+    })
 }

--- a/crates/algorithms/ed25519/src/impl_hacl.rs
+++ b/crates/algorithms/ed25519/src/impl_hacl.rs
@@ -18,7 +18,7 @@ pub enum Error {
 #[derive(Default, Clone, Copy)]
 #[cfg_attr(feature = "codec", derive(TlsSerialize, TlsDeserialize, TlsSize))]
 pub struct VerificationKey {
-    value: [u8; 32],
+    pub(crate) value: [u8; 32],
 }
 
 impl VerificationKey {
@@ -42,7 +42,16 @@ impl AsRef<[u8; 32]> for VerificationKey {
 /// An Ed25519 private, signing  key
 #[derive(Default)]
 pub struct SigningKey {
-    value: [u8; 32],
+    pub(crate) value: [u8; 32],
+}
+
+#[repr(transparent)]
+/// An Ed25519 signature
+pub struct Signature(pub(crate) [u8; 64]);
+impl From<[u8; 64]> for Signature {
+    fn from(value: [u8; 64]) -> Self {
+        Signature(value)
+    }
 }
 
 impl SigningKey {

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,6 +1,6 @@
 use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
 
-use libcrux_secrets::{Classify, DeclassifyRef};
+use libcrux_secrets::{Classify, DeclassifyRef, U8};
 const VERIFICATION_KEY_LEN: usize = 32;
 const SIGNING_KEY_LEN: usize = 32;
 const SIGNATURE_LEN: usize = 64;

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -218,7 +218,7 @@ impl KeyPair {
     pub fn generate_derand(bytes: [U8; RAND_KEYGEN_LEN]) -> KeyPair {
         let mut signing_key = [0u8; arrayref::Ed25519::SIGNING_KEY_LEN].classify();
         let mut verification_key = [0u8; arrayref::Ed25519::VERIFICATION_KEY_LEN];
-        arrayref::Ed25519::keygen(&mut signing_key, &mut verification_key, bytes.classify());
+        arrayref::Ed25519::keygen(&mut signing_key, &mut verification_key, bytes);
 
         KeyPair {
             signing_key: SigningKey::from(signing_key),

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,4 +1,6 @@
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
+use libcrux_traits::signature::{
+    impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
+};
 
 use libcrux_secrets::{Classify, DeclassifyRef, U8};
 const VERIFICATION_KEY_LEN: usize = 32;
@@ -11,11 +13,6 @@ pub use slice::Ed25519;
 
 #[doc(inline)]
 pub use arrayref::{SigningError, VerificationError};
-
-// TODO: different error type?
-#[derive(Debug)]
-/// An incorrect length when converting from slice.
-pub struct WrongLengthError;
 
 impl_key_centric_types!(
     arrayref::Ed25519,

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -86,13 +86,13 @@ pub mod slice {
     }
 }
 
-impl slice::Ed25519 {
+impl KeyPair {
     #[cfg(feature = "rand")]
-    pub fn generate_key_pair(rng: &mut impl rand_core::CryptoRng) -> KeyPair {
-        let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+    pub fn generate(rng: &mut impl rand_core::CryptoRng) -> KeyPair {
+        let mut bytes = [0u8; arrayref::Ed25519::RAND_KEYGEN_LEN];
         rng.fill_bytes(&mut bytes);
-        let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
-        let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+        let mut signing_key = [0u8; arrayref::Ed25519::SIGNING_KEY_LEN].classify();
+        let mut verification_key = [0u8; arrayref::Ed25519::VERIFICATION_KEY_LEN];
         arrayref::Ed25519::keygen_derand(&mut signing_key, &mut verification_key, bytes.classify());
 
         KeyPair {

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,6 +1,6 @@
 use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
 
-use libcrux_secrets::{Classify, DeclassifyRef, U8};
+use libcrux_secrets::{Classify, DeclassifyRef};
 const VERIFICATION_KEY_LEN: usize = 32;
 const SIGNING_KEY_LEN: usize = 32;
 const SIGNATURE_LEN: usize = 64;
@@ -8,28 +8,49 @@ const RAND_KEYGEN_LEN: usize = SIGNING_KEY_LEN;
 
 // arrayref API
 #[doc(inline)]
-pub use arrayref::*;
+use arrayref::*;
 
 // TODO: different error type?
 #[derive(Debug)]
 /// An incorrect length when converting from slice.
 pub struct WrongLengthError;
 
-pub mod arrayref {
+impl_key_centric_types!(
+    Ed25519,
+    SIGNING_KEY_LEN,
+    VERIFICATION_KEY_LEN,
+    SIGNATURE_LEN,
+    RAND_KEYGEN_LEN,
+    WrongLengthError,
+    WrongLengthError
+);
+
+pub(crate) mod arrayref {
+    // Private [`Ed25519`] struct used for internal implementations
     #[derive(Debug, PartialEq)]
-    pub struct Ed25519;
-    use super::*;
-    impl_key_centric_types!(
-        Ed25519,
-        SIGNING_KEY_LEN,
-        VERIFICATION_KEY_LEN,
-        SIGNATURE_LEN,
-        RAND_KEYGEN_LEN,
-        WrongLengthError,
-        WrongLengthError
-    );
+    pub(crate) struct Ed25519;
 }
 pub mod slice {
+    //! Slice-based APIs for Ed25519.
+    //!
+    //! ```rust
+    //! use libcrux_traits::signature::SignConsts;
+    //! use libcrux_ed25519::key_centric_apis::slice::Ed25519;
+    //!
+    //! // generate keypair
+    //! let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    //! let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    //! Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    //!
+    //! // create signature buffer
+    //! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    //!
+    //! // sign
+    //! Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+    //!
+    //! // verify
+    //! Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+    //!  ```
     #[derive(Debug, PartialEq)]
     pub struct Ed25519;
     use super::*;
@@ -65,7 +86,7 @@ pub mod slice {
     }
 }
 
-impl arrayref::Ed25519 {
+impl slice::Ed25519 {
     #[cfg(feature = "rand")]
     pub fn generate_key_pair(rng: &mut impl rand_core::CryptoRng) -> KeyPair {
         let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
@@ -81,6 +102,14 @@ impl arrayref::Ed25519 {
     }
 }
 impl arrayref::Ed25519 {
+    /// The hacl implementation requires that
+    /// - the private key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn sign(
         key: &[U8; Self::SIGNING_KEY_LEN],
         payload: &[u8],
@@ -100,6 +129,15 @@ impl arrayref::Ed25519 {
         Ok(())
     }
 
+    /// The hacl implementation requires that
+    /// - the public key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
+    #[inline(always)]
     pub fn verify(
         key: &[u8; Self::VERIFICATION_KEY_LEN],
         payload: &[u8],
@@ -129,6 +167,14 @@ impl arrayref::Ed25519 {
     }
 }
 impl slice::Ed25519 {
+    /// The hacl implementation requires that
+    /// - the private key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn sign(
         key: &[U8],
         payload: &[u8],
@@ -143,6 +189,15 @@ impl slice::Ed25519 {
 
         arrayref::Ed25519::sign(&key, payload, signature).map_err(slice::SigningError::from)
     }
+
+    /// The hacl implementation requires that
+    /// - the public key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn verify(
         key: &[u8],
         payload: &[u8],
@@ -157,6 +212,7 @@ impl slice::Ed25519 {
 
         arrayref::Ed25519::verify(key, payload, signature).map_err(slice::VerificationError::from)
     }
+
     pub fn keygen_derand(
         signing_key: &mut [U8],
         verification_key: &mut [u8],
@@ -175,11 +231,27 @@ impl slice::Ed25519 {
     }
 }
 impl<'a> SigningKeyRef<'a> {
+    /// The hacl implementation requires that
+    /// - the private key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn sign(&self, payload: &[u8], signature: &mut [u8]) -> Result<(), slice::SigningError> {
         slice::Ed25519::sign(self.as_ref(), payload, signature)
     }
 }
 impl<'a> VerificationKeyRef<'a> {
+    /// The hacl implementation requires that
+    /// - the public key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), slice::VerificationError> {
         slice::Ed25519::verify(self.as_ref(), payload, signature)
     }
@@ -187,6 +259,14 @@ impl<'a> VerificationKeyRef<'a> {
 
 // key-centric API
 impl SigningKey {
+    /// The hacl implementation requires that
+    /// - the private key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn sign(&self, payload: &[u8]) -> Result<Signature, slice::SigningError> {
         let mut signature = [0u8; SIGNATURE_LEN];
         arrayref::Ed25519::sign(self.as_ref(), payload, &mut signature)
@@ -194,6 +274,14 @@ impl SigningKey {
     }
 }
 impl VerificationKey {
+    /// The hacl implementation requires that
+    /// - the public key is a 32 byte buffer
+    /// - the signature is a 64 byte buffer,
+    /// - the payload buffer is not shorter than payload_len.
+    ///
+    /// We enforce the first two using types, and the latter by using `payload.len()` and `payload_len`.
+    /// This has the caveat that `payload_len` must be <= u32::MAX, so we return an error if that is
+    /// not the case.
     pub fn verify(
         &self,
         payload: &[u8],
@@ -219,7 +307,7 @@ fn key_centric_owned() {
     let KeyPair {
         signing_key,
         verification_key,
-    } = Ed25519::generate_key_pair(&mut rng);
+    } = slice::Ed25519::generate_key_pair(&mut rng);
 
     let signature = signing_key.sign(b"payload").unwrap();
     verification_key.verify(b"payload", &signature).unwrap();
@@ -253,20 +341,6 @@ fn arrayref_apis() {
     Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
 
     // arrayref API
-    let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
-    Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
-    Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
-}
-#[test]
-#[cfg(not(feature = "expose-secret-independence"))]
-fn slice_apis() {
-    use libcrux_traits::signature::SignConsts;
-
-    let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
-    let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
-
-    // slice API
     let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
     Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
     Ed25519::verify(&verification_key, b"payload", &signature).unwrap();

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,4 +1,4 @@
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
 
 use libcrux_secrets::{Classify, DeclassifyRef};
 const VERIFICATION_KEY_LEN: usize = 32;
@@ -86,7 +86,7 @@ pub mod slice {
     #[derive(Debug, PartialEq)]
     pub struct Ed25519;
     use super::*;
-    impl_sign_traits!(
+    impl_sign_consts!(
         Ed25519,
         SIGNING_KEY_LEN,
         VERIFICATION_KEY_LEN,

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -40,7 +40,7 @@ pub mod slice {
     //! // generate keypair
     //! let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
     //! let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    //! Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    //! Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
     //!
     //! // create signature buffer
     //! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
@@ -93,7 +93,7 @@ impl KeyPair {
         rng.fill_bytes(&mut bytes);
         let mut signing_key = [0u8; arrayref::Ed25519::SIGNING_KEY_LEN].classify();
         let mut verification_key = [0u8; arrayref::Ed25519::VERIFICATION_KEY_LEN];
-        arrayref::Ed25519::keygen_derand(&mut signing_key, &mut verification_key, bytes.classify());
+        arrayref::Ed25519::keygen(&mut signing_key, &mut verification_key, bytes.classify());
 
         KeyPair {
             signing_key: SigningKey::from(signing_key),
@@ -157,7 +157,7 @@ impl arrayref::Ed25519 {
             Err(slice::VerificationError::InvalidSignature)
         }
     }
-    pub fn keygen_derand(
+    pub fn keygen(
         signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
         verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
         randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -213,7 +213,7 @@ impl slice::Ed25519 {
         arrayref::Ed25519::verify(key, payload, signature).map_err(slice::VerificationError::from)
     }
 
-    pub fn keygen_derand(
+    pub fn keygen(
         signing_key: &mut [U8],
         verification_key: &mut [u8],
         randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -225,7 +225,7 @@ impl slice::Ed25519 {
             .try_into()
             .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
 
-        arrayref::Ed25519::keygen_derand(signing_key, verification_key, randomness);
+        arrayref::Ed25519::keygen(signing_key, verification_key, randomness);
 
         Ok(())
     }
@@ -320,7 +320,7 @@ fn key_centric_refs() {
 
     let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
 
     // create references from slice
     let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
@@ -338,7 +338,7 @@ fn arrayref_apis() {
 
     let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
 
     // arrayref API
     let mut signature = [0u8; Ed25519::SIGNATURE_LEN];

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,0 +1,273 @@
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+
+use libcrux_secrets::{Classify, DeclassifyRef, U8};
+const VERIFICATION_KEY_LEN: usize = 32;
+const SIGNING_KEY_LEN: usize = 32;
+const SIGNATURE_LEN: usize = 64;
+const RAND_KEYGEN_LEN: usize = SIGNING_KEY_LEN;
+
+// arrayref API
+#[doc(inline)]
+pub use arrayref::*;
+
+// TODO: different error type?
+#[derive(Debug)]
+/// An incorrect length when converting from slice.
+pub struct WrongLengthError;
+
+pub mod arrayref {
+    #[derive(Debug, PartialEq)]
+    pub struct Ed25519;
+    use super::*;
+    impl_key_centric_types!(
+        Ed25519,
+        SIGNING_KEY_LEN,
+        VERIFICATION_KEY_LEN,
+        SIGNATURE_LEN,
+        RAND_KEYGEN_LEN,
+        WrongLengthError,
+        WrongLengthError
+    );
+}
+pub mod slice {
+    #[derive(Debug, PartialEq)]
+    pub struct Ed25519;
+    use super::*;
+    impl_sign_traits!(
+        Ed25519,
+        SIGNING_KEY_LEN,
+        VERIFICATION_KEY_LEN,
+        SIGNATURE_LEN,
+        RAND_KEYGEN_LEN
+    );
+
+    // error type including wrong length
+    #[derive(Debug)]
+    pub enum SigningError {
+        WrongSigningKeyLength,
+        WrongSignatureLength,
+        WrongPayloadLength,
+    }
+
+    // error type including wrong length
+    #[derive(Debug)]
+    pub enum VerificationError {
+        InvalidSignature,
+        WrongVerificationKeyLength,
+        WrongSignatureLength,
+        WrongPayloadLength,
+    }
+
+    #[derive(Debug)]
+    pub enum KeygenError {
+        WrongSigningKeyLength,
+        WrongVerificationKeyLength,
+    }
+}
+
+impl arrayref::Ed25519 {
+    #[cfg(feature = "rand")]
+    pub fn generate_key_pair(rng: &mut impl rand_core::CryptoRng) -> KeyPair {
+        let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+        rng.fill_bytes(&mut bytes);
+        let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
+        let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+        arrayref::Ed25519::keygen_derand(&mut signing_key, &mut verification_key, bytes.classify());
+
+        KeyPair {
+            signing_key: SigningKey::from(signing_key),
+            verification_key: VerificationKey::from(verification_key),
+        }
+    }
+}
+impl arrayref::Ed25519 {
+    pub fn sign(
+        key: &[U8; Self::SIGNING_KEY_LEN],
+        payload: &[u8],
+        signature: &mut [u8; Self::SIGNATURE_LEN],
+        // TODO: arrayref::SigningError?
+    ) -> Result<(), slice::SigningError> {
+        crate::hacl::ed25519::sign(
+            signature,
+            key.declassify_ref(),
+            payload
+                .len()
+                .try_into()
+                .map_err(|_| slice::SigningError::WrongPayloadLength)?,
+            payload,
+        );
+
+        Ok(())
+    }
+
+    pub fn verify(
+        key: &[u8; Self::VERIFICATION_KEY_LEN],
+        payload: &[u8],
+        signature: &[u8; Self::SIGNATURE_LEN],
+    ) -> Result<(), slice::VerificationError> {
+        if crate::hacl::ed25519::verify(
+            key,
+            payload
+                .len()
+                .try_into()
+                .map_err(|_| slice::VerificationError::WrongPayloadLength)?,
+            payload,
+            signature,
+        ) {
+            Ok(())
+        } else {
+            Err(slice::VerificationError::InvalidSignature)
+        }
+    }
+    pub fn keygen_derand(
+        signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
+        verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
+        randomness: [U8; Self::RAND_KEYGEN_LEN],
+    ) {
+        *signing_key = randomness;
+        crate::secret_to_public(verification_key, signing_key.declassify_ref());
+    }
+}
+impl slice::Ed25519 {
+    pub fn sign(
+        key: &[U8],
+        payload: &[u8],
+        signature: &mut [u8],
+    ) -> Result<(), slice::SigningError> {
+        let key = key
+            .try_into()
+            .map_err(|_| slice::SigningError::WrongSigningKeyLength)?;
+        let signature = signature
+            .try_into()
+            .map_err(|_| slice::SigningError::WrongSignatureLength)?;
+
+        arrayref::Ed25519::sign(&key, payload, signature).map_err(slice::SigningError::from)
+    }
+    pub fn verify(
+        key: &[u8],
+        payload: &[u8],
+        signature: &[u8],
+    ) -> Result<(), slice::VerificationError> {
+        let key = key
+            .try_into()
+            .map_err(|_| slice::VerificationError::WrongVerificationKeyLength)?;
+        let signature = signature
+            .try_into()
+            .map_err(|_| slice::VerificationError::WrongSignatureLength)?;
+
+        arrayref::Ed25519::verify(key, payload, signature).map_err(slice::VerificationError::from)
+    }
+    pub fn keygen_derand(
+        signing_key: &mut [U8],
+        verification_key: &mut [u8],
+        randomness: [U8; Self::RAND_KEYGEN_LEN],
+    ) -> Result<(), slice::KeygenError> {
+        let signing_key = signing_key
+            .try_into()
+            .map_err(|_| slice::KeygenError::WrongSigningKeyLength)?;
+        let verification_key = verification_key
+            .try_into()
+            .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
+
+        arrayref::Ed25519::keygen_derand(signing_key, verification_key, randomness);
+
+        Ok(())
+    }
+}
+impl<'a> SigningKeyRef<'a> {
+    pub fn sign(&self, payload: &[u8], signature: &mut [u8]) -> Result<(), slice::SigningError> {
+        slice::Ed25519::sign(self.as_ref(), payload, signature)
+    }
+}
+impl<'a> VerificationKeyRef<'a> {
+    pub fn verify(&self, payload: &[u8], signature: &[u8]) -> Result<(), slice::VerificationError> {
+        slice::Ed25519::verify(self.as_ref(), payload, signature)
+    }
+}
+
+// key-centric API
+impl SigningKey {
+    pub fn sign(&self, payload: &[u8]) -> Result<Signature, slice::SigningError> {
+        let mut signature = [0u8; SIGNATURE_LEN];
+        arrayref::Ed25519::sign(self.as_ref(), payload, &mut signature)
+            .map(|_| Signature::from(signature))
+    }
+}
+impl VerificationKey {
+    pub fn verify(
+        &self,
+        payload: &[u8],
+        signature: &Signature,
+    ) -> Result<(), slice::VerificationError> {
+        arrayref::Ed25519::verify(self.as_ref(), payload, signature.as_ref())
+    }
+}
+
+#[test]
+#[cfg(feature = "rand")]
+fn key_centric_owned() {
+    use rand::TryRngCore;
+    let mut rng = rand::rngs::OsRng;
+    let mut rng = rng.unwrap_mut();
+    use libcrux_traits::signature::SignConsts;
+
+    // keys can be created from arrays
+    let _signing_key = SigningKey::from([0u8; Ed25519::SIGNING_KEY_LEN].classify());
+    let _verification_key = VerificationKey::from([0u8; Ed25519::VERIFICATION_KEY_LEN]);
+
+    // key-centric API
+    let KeyPair {
+        signing_key,
+        verification_key,
+    } = Ed25519::generate_key_pair(&mut rng);
+
+    let signature = signing_key.sign(b"payload").unwrap();
+    verification_key.verify(b"payload", &signature).unwrap();
+}
+
+#[test]
+#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+fn key_centric_refs() {
+    use libcrux_traits::signature::SignConsts;
+
+    let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+
+    // create references from slice
+    let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+    let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+
+    let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    signing_key.sign(b"payload", &mut signature).unwrap();
+    verification_key.verify(b"payload", &signature).unwrap();
+}
+
+#[test]
+#[cfg(not(feature = "check-secret-independence"))]
+fn arrayref_apis() {
+    use libcrux_traits::signature::SignConsts;
+
+    let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+
+    // arrayref API
+    let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+    Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+}
+#[test]
+#[cfg(not(feature = "check-secret-independence"))]
+fn slice_apis() {
+    use libcrux_traits::signature::SignConsts;
+
+    let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    Ed25519::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+
+    // slice API
+    let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+    Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+}

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -226,7 +226,7 @@ fn key_centric_owned() {
 }
 
 #[test]
-#[cfg(all(feature = "rand", not(feature = "check-secret-independence")))]
+#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
 fn key_centric_refs() {
     use libcrux_traits::signature::SignConsts;
 
@@ -244,7 +244,7 @@ fn key_centric_refs() {
 }
 
 #[test]
-#[cfg(not(feature = "check-secret-independence"))]
+#[cfg(not(feature = "expose-secret-independence"))]
 fn arrayref_apis() {
     use libcrux_traits::signature::SignConsts;
 
@@ -258,7 +258,7 @@ fn arrayref_apis() {
     Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
 }
 #[test]
-#[cfg(not(feature = "check-secret-independence"))]
+#[cfg(not(feature = "expose-secret-independence"))]
 fn slice_apis() {
     use libcrux_traits::signature::SignConsts;
 

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -288,7 +288,7 @@ fn key_centric_refs() {
 
     let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+    Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
 
     // create references from slice
     let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
@@ -304,12 +304,12 @@ fn key_centric_refs() {
 fn arrayref_apis() {
     use libcrux_traits::signature::SignConsts;
 
-    let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
-    let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
-    Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+    let mut signing_key = [0u8; arrayref::Ed25519::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; arrayref::Ed25519::VERIFICATION_KEY_LEN];
+    arrayref::Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
 
     // arrayref API
-    let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
-    Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
-    Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+    let mut signature = [0u8; arrayref::Ed25519::SIGNATURE_LEN];
+    arrayref::Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+    arrayref::Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
 }

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -92,23 +92,30 @@ pub(crate) mod arrayref {
     #[derive(Debug, PartialEq)]
     pub(crate) struct Ed25519;
 
+    /// An error when signing.
     #[derive(Debug, PartialEq)]
     pub enum SigningError {
-        WrongPayloadLength,
+        /// The length of the provided payload is invalid.
+        InvalidPayloadLength,
     }
 
     impl From<SigningError> for super::slice::SigningError {
         fn from(e: SigningError) -> Self {
             match e {
-                SigningError::WrongPayloadLength => super::slice::SigningError::WrongPayloadLength,
+                SigningError::InvalidPayloadLength => {
+                    super::slice::SigningError::InvalidPayloadLength
+                }
             }
         }
     }
 
+    /// An error when verifying a signature.
     #[derive(Debug)]
     pub enum VerificationError {
+        /// The provided signature is invalid.
         InvalidSignature,
-        WrongPayloadLength,
+        /// The length of the provided payload is invalid.
+        InvalidPayloadLength,
     }
 
     impl From<VerificationError> for super::slice::VerificationError {
@@ -117,8 +124,8 @@ pub(crate) mod arrayref {
                 VerificationError::InvalidSignature => {
                     super::slice::VerificationError::InvalidSignature
                 }
-                VerificationError::WrongPayloadLength => {
-                    super::slice::VerificationError::WrongPayloadLength
+                VerificationError::InvalidPayloadLength => {
+                    super::slice::VerificationError::InvalidPayloadLength
                 }
             }
         }
@@ -163,26 +170,36 @@ pub mod slice {
         RAND_KEYGEN_LEN
     );
 
-    // error type including wrong length
+    /// An error when signing.
     #[derive(Debug)]
     pub enum SigningError {
+        /// The length of the provided signing key is incorrect.
         WrongSigningKeyLength,
+        /// The length of the provided signature buffer is incorrect.
         WrongSignatureLength,
-        WrongPayloadLength,
+        /// The length of the provided payload is invalid.
+        InvalidPayloadLength,
     }
 
-    // error type including wrong length
+    /// An error when verifying a signature.
     #[derive(Debug)]
     pub enum VerificationError {
+        /// The provided signature is invalid.
         InvalidSignature,
+        /// The length of the provided verification key is incorrect.
         WrongVerificationKeyLength,
+        /// The length of the provided signature is incorrect.
         WrongSignatureLength,
-        WrongPayloadLength,
+        /// The length of the provided payload is invalid.
+        InvalidPayloadLength,
     }
 
+    /// An error when generating a signature key pair.
     #[derive(Debug)]
     pub enum KeygenError {
+        /// The length of the provided signing key buffer is incorrect.
         WrongSigningKeyLength,
+        /// The length of the provided verification key buffer is incorrect.
         WrongVerificationKeyLength,
     }
 }
@@ -218,7 +235,7 @@ impl arrayref::Ed25519 {
         let payload_len: u32 = payload
             .len()
             .try_into()
-            .map_err(|_| arrayref::SigningError::WrongPayloadLength)?;
+            .map_err(|_| arrayref::SigningError::InvalidPayloadLength)?;
 
         crate::hacl::ed25519::sign(signature, key.declassify_ref(), payload_len, payload);
 
@@ -234,7 +251,7 @@ impl arrayref::Ed25519 {
         let payload_len: u32 = payload
             .len()
             .try_into()
-            .map_err(|_| arrayref::VerificationError::WrongPayloadLength)?;
+            .map_err(|_| arrayref::VerificationError::InvalidPayloadLength)?;
 
         if crate::hacl::ed25519::verify(key, payload_len, payload, signature) {
             Ok(())

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -6,9 +6,11 @@ const SIGNING_KEY_LEN: usize = 32;
 const SIGNATURE_LEN: usize = 64;
 const RAND_KEYGEN_LEN: usize = SIGNING_KEY_LEN;
 
-// arrayref API
 #[doc(inline)]
-use arrayref::*;
+pub use slice::Ed25519;
+
+#[doc(inline)]
+pub use arrayref::{SigningError, VerificationError};
 
 // TODO: different error type?
 #[derive(Debug)]
@@ -16,7 +18,7 @@ use arrayref::*;
 pub struct WrongLengthError;
 
 impl_key_centric_types!(
-    Ed25519,
+    arrayref::Ed25519,
     SIGNING_KEY_LEN,
     VERIFICATION_KEY_LEN,
     SIGNATURE_LEN,
@@ -26,7 +28,6 @@ impl_key_centric_types!(
 );
 
 pub(crate) mod arrayref {
-    // Private [`Ed25519`] struct used for internal implementations
     #[derive(Debug, PartialEq)]
     pub(crate) struct Ed25519;
 
@@ -83,7 +84,9 @@ pub mod slice {
     //! // verify
     //! Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
     //!  ```
+
     #[derive(Debug, PartialEq)]
+    /// Slice-based APIs for Ed25519.
     pub struct Ed25519;
     use super::*;
     impl_sign_consts!(

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -146,8 +146,13 @@ pub mod slice {
     //! Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
     //!  ```
 
-    #[derive(Debug, PartialEq)]
     /// Slice-based APIs for Ed25519.
+    ///
+    /// This struct provides slice-based APIs for Ed25519, as well as an implementation
+    /// of the [`SignConsts`] trait, which can be used to retrieve constants defining
+    /// the verification key length, signing key length, signature length, and the
+    /// length of the randomness required for key generation for the signature scheme.
+    #[derive(Debug, PartialEq)]
     pub struct Ed25519;
     use super::*;
     impl_sign_consts!(

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -120,9 +120,16 @@ pub mod slice {
 
 impl KeyPair {
     #[cfg(feature = "rand")]
+    /// Generate an Ed25519 key pair
     pub fn generate(rng: &mut impl rand_core::CryptoRng) -> KeyPair {
         let mut bytes = [0u8; arrayref::Ed25519::RAND_KEYGEN_LEN];
         rng.fill_bytes(&mut bytes);
+
+        Self::generate_derand(bytes.classify())
+    }
+
+    /// Generate an Ed25519 key pair (derand)
+    pub fn generate_derand(bytes: [U8; RAND_KEYGEN_LEN]) -> KeyPair {
         let mut signing_key = [0u8; arrayref::Ed25519::SIGNING_KEY_LEN].classify();
         let mut verification_key = [0u8; arrayref::Ed25519::VERIFICATION_KEY_LEN];
         arrayref::Ed25519::keygen(&mut signing_key, &mut verification_key, bytes.classify());

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -1,3 +1,67 @@
+//! This module includes key-centric and slice-based APIs for Ed25519.
+//!
+//! ### Key-centric APIs
+//! This module provides key-centric APIs for Ed25519.
+//!
+//! #### Key-centric (owned)
+//! ```rust
+//! use libcrux_ed25519::key_centric_apis::{SigningKey, KeyPair, VerificationKey};
+//!
+//! // generate key pair
+//! let KeyPair { signing_key, verification_key } = KeyPair::generate_derand([0u8; 32]);
+//!
+//! // sign and verify
+//! let signature = signing_key.sign(b"payload").unwrap();
+//! verification_key.verify(b"payload", &signature).unwrap();
+//! ```
+//!
+//! #### Key-centric (reference)
+//! ```rust
+//! # use libcrux_ed25519::key_centric_apis::{
+//! #     Ed25519, SigningKeyRef, VerificationKeyRef,
+//! # };
+//! # use libcrux_traits::signature::SignConsts;
+//! #
+//! # // key generation
+//! # let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+//! # let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+//! # Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+//! #
+//! // create key structs from references
+//! let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+//! let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+//!
+//! // signature buffer
+//! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+//!
+//! // sign and verify
+//! signing_key
+//!     .sign(b"payload", &mut signature)
+//!     .unwrap();
+//! verification_key
+//!     .verify(b"payload", &signature)
+//!     .unwrap();
+//! ```
+//!
+//! ### Slice-based APIs
+//! This module also provides slice-based APIs via the struct [`Ed25519`].
+//!
+//! ```rust
+//! use libcrux_ed25519::key_centric_apis::Ed25519;
+//! use libcrux_traits::signature::SignConsts;
+//!
+//! // keygen
+//! let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+//! let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+//! Ed25519::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+//!
+//! // signature buffer
+//! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+//!
+//! // sign and verify
+//! Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+//! Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+//! ```
 use libcrux_traits::signature::{
     impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
 };

--- a/crates/algorithms/ed25519/src/key_centric_apis.rs
+++ b/crates/algorithms/ed25519/src/key_centric_apis.rs
@@ -307,7 +307,7 @@ fn key_centric_owned() {
     let KeyPair {
         signing_key,
         verification_key,
-    } = slice::Ed25519::generate_key_pair(&mut rng);
+    } = KeyPair::generate(&mut rng);
 
     let signature = signing_key.sign(b"payload").unwrap();
     verification_key.verify(b"payload", &signature).unwrap();

--- a/crates/algorithms/ed25519/src/lib.rs
+++ b/crates/algorithms/ed25519/src/lib.rs
@@ -8,5 +8,6 @@ mod hacl {
 }
 
 mod impl_hacl;
+pub mod key_centric_apis;
 
 pub use impl_hacl::*;

--- a/crates/algorithms/ed25519/src/lib.rs
+++ b/crates/algorithms/ed25519/src/lib.rs
@@ -8,6 +8,6 @@ mod hacl {
 }
 
 mod impl_hacl;
-pub mod key_centric_apis;
+pub(crate) mod key_centric_apis;
 
 pub use impl_hacl::*;

--- a/crates/primitives/signature/CHANGELOG.md
+++ b/crates/primitives/signature/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/crates/primitives/signature/Cargo.toml
+++ b/crates/primitives/signature/Cargo.toml
@@ -9,11 +9,11 @@ repository.workspace = true
 version.workspace = true
 
 [dependencies]
-libcrux-ecdsa = { version = "0.0.4", path = "../../../ecdsa", optional = true }
-libcrux-ed25519 = { version = "0.0.4", path = "../../../ed25519", optional = true }
+libcrux-ecdsa = { version = "0.0.4", path = "../../algorithms/ecdsa", optional = true }
+libcrux-ed25519 = { version = "0.0.4", path = "../../algorithms/ed25519", optional = true }
 libcrux-ml-dsa = { version = "0.0.4", path = "../../../libcrux-ml-dsa", optional = true }
 libcrux-traits = { version = "0.0.4", path = "../../../traits", optional = true }
-libcrux-secrets = { version = "0.0.4", path = "../../../secrets", optional = true }
+libcrux-secrets = { version = "0.0.4", path = "../../utils/secrets", optional = true }
 
 [features]
 default = ["ed25519", "ecdsa", "mldsa", "rand"]

--- a/crates/primitives/signature/Cargo.toml
+++ b/crates/primitives/signature/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+authors.workspace = true
+edition.workspace = true
+homepage.workspace = true
+license.workspace = true
+name = "libcrux-signature"
+readme.workspace = true
+repository.workspace = true
+version.workspace = true
+
+[dependencies]
+libcrux-ecdsa = { version = "0.0.4", path = "../../../ecdsa", optional = true }
+libcrux-ed25519 = { version = "0.0.4", path = "../../../ed25519", optional = true }
+libcrux-ml-dsa = { version = "0.0.4", path = "../../../libcrux-ml-dsa", optional = true }
+libcrux-traits = { version = "0.0.4", path = "../../../traits", optional = true }
+libcrux-secrets = { version = "0.0.4", path = "../../../secrets", optional = true }
+
+[features]
+default = ["ed25519", "ecdsa", "mldsa", "rand"]
+rand = ["libcrux-ed25519?/rand", "libcrux-ecdsa?/rand", "libcrux-ml-dsa?/rand"]
+
+check-secret-independence = [
+    "libcrux-secrets/check-secret-independence",
+    "libcrux-traits/check-secret-independence",
+    "libcrux-ml-dsa?/expose-secret-independence",
+    "libcrux-ed25519?/expose-secret-independence",
+    "libcrux-ecdsa?/expose-secret-independence",
+]
+
+ecdsa = ["dep:libcrux-ecdsa", "any"]
+ed25519 = ["dep:libcrux-ed25519", "any"]
+mldsa = ["dep:libcrux-ml-dsa", "any"]
+
+any = ["dep:libcrux-traits", "dep:libcrux-secrets"]
+
+[dev-dependencies]
+rand = "0.9"

--- a/crates/primitives/signature/Readme.md
+++ b/crates/primitives/signature/Readme.md
@@ -1,0 +1,3 @@
+# Signature
+
+This crate provides a usable interface to `libcrux-ecdsa` (P256), `libcrux-ed25519` and `libcrux-ml-dsa`.

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -14,7 +14,7 @@ pub mod ecdsa {
     pub mod p256 {
         //! ```rust
         //! use libcrux_signature::ecdsa::p256::{
-        //!   Nonce, sha2_256::{EcdsaP256, KeyPair, SigningKey, VerificationKey}
+        //!   Nonce, sha2_256::{KeyPair, SigningKey, VerificationKey}
         //! };
         //!
         //! // generate a new nonce
@@ -24,7 +24,7 @@ pub mod ecdsa {
         //!
         //! // generate a new signature keypair from random bytes
         //! let KeyPair { signing_key, verification_key } =
-        //! EcdsaP256::generate_key_pair(&mut rng.unwrap_mut()).unwrap();
+        //!     KeyPair::generate(&mut rng.unwrap_mut()).unwrap();
         //!
         //! // sign
         //! let signature = signing_key.sign(b"payload", &nonce).unwrap();
@@ -40,14 +40,14 @@ pub mod ecdsa {
 #[cfg(feature = "ed25519")]
 pub mod ed25519 {
     //! ```rust
-    //! use libcrux_signature::ed25519::{Ed25519, KeyPair};
+    //! use libcrux_signature::ed25519::KeyPair;
     //!
     //! use rand::TryRngCore;
     //! let mut rng = rand::rngs::OsRng;
     //! // generate a new signature keypair from random bytes
     //! // requires `rand` feature
     //! let KeyPair { signing_key, verification_key }
-    //!     = Ed25519::generate_key_pair(&mut rng.unwrap_mut());
+    //!     = KeyPair::generate(&mut rng.unwrap_mut());
     //!
     //! // sign
     //! let signature = signing_key.sign(b"payload").unwrap();
@@ -56,7 +56,7 @@ pub mod ed25519 {
     //! verification_key.verify(b"payload", &signature).unwrap();
     //! ```
     pub use libcrux_ed25519::key_centric_apis::{
-        Ed25519, KeyPair, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
+        slice, KeyPair, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
     };
 }
 
@@ -72,7 +72,7 @@ pub mod mldsa {
     //! // generate a new signature keypair from random bytes
     //! // requires `rand` feature
     //! let KeyPair { signing_key, verification_key }
-    //!     = MlDsa44::generate_key_pair(&mut rng.unwrap_mut());
+    //!     = KeyPair::generate(&mut rng.unwrap_mut());
     //!
     //! // sign
     //! let signature = signing_key.sign(b"payload", b"context", [2; 32]).unwrap();

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -2,8 +2,8 @@
 //!
 //! We currently support three signature algorithms:
 //!
-//! - ecdsa-p256
-//! - ed25519
+//! - ECDSA-P256
+//! - Ed25519
 //! - ML-DSA
 
 #[doc(inline)]
@@ -12,7 +12,13 @@ pub use libcrux_traits::signature::{SignConsts, WrongLengthError};
 
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa {
+    //! APIs for ECDSA
     pub mod p256 {
+        //! APIs for ECDSA-P256
+        //!
+        //! ### Key-centric APIs
+        //!
+        //! #### Key-centric (owned)
         //! ```rust
         //! use libcrux_signature::ecdsa::p256::{
         //!   Nonce, sha2_256::{KeyPair, SigningKey, VerificationKey}
@@ -33,6 +39,66 @@ pub mod ecdsa {
         //! // verify
         //! verification_key.verify(b"payload", &signature).unwrap();
         //! ```
+        //!
+        //! #### Key-centric (reference)
+        //! ```rust
+        //! # use libcrux_signature::ecdsa::p256::{
+        //! #   Nonce, sha2_256::{SigningKeyRef, VerificationKeyRef, EcdsaP256}
+        //! # };
+        //! # use libcrux_signature::SignConsts;
+        //! #
+        //! # use rand::{RngCore, TryRngCore};
+        //! # let mut rng = rand::rngs::OsRng;
+        //! # let mut rng = rng.unwrap_mut();
+        //! # // generate a new nonce
+        //! # let nonce = Nonce::random(&mut rng).unwrap();
+        //! #
+        //! # let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
+        //! # let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
+        //! # let mut bytes = [1u8; EcdsaP256::RAND_KEYGEN_LEN];
+        //! # rng.fill_bytes(&mut bytes);
+        //! # EcdsaP256::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+        //!
+        //! // create the key structs from byte slices
+        //! let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+        //! let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+        //!
+        //! // signature buffer
+        //! let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
+        //!
+        //! // sign
+        //! signing_key.sign(b"payload", &mut signature, &nonce).unwrap();
+        //!
+        //! // verify
+        //! verification_key.verify(b"payload", &signature).unwrap();
+        //! ```
+        //! ### Slice-based
+        //! ```rust
+        //! # use libcrux_signature::ecdsa::p256::{sha2_256::EcdsaP256, Nonce};
+        //! # use libcrux_signature::SignConsts;
+        //! #
+        //! # use rand::{RngCore, TryRngCore};
+        //! # let mut rng = rand::rngs::OsRng;
+        //! # let mut rng = rng.unwrap_mut();
+
+        //! # // generate a new nonce
+        //! # let nonce = Nonce::random(&mut rng).unwrap();
+        //! #
+        //! # let mut signing_key = [0u8; EcdsaP256::SIGNING_KEY_LEN];
+        //! # let mut verification_key = [0u8; EcdsaP256::VERIFICATION_KEY_LEN];
+        //! # let mut bytes = [1u8; EcdsaP256::RAND_KEYGEN_LEN];
+        //! # rng.fill_bytes(&mut bytes);
+        //! # EcdsaP256::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+        //! #
+        //! // signature buffer
+        //! let mut signature = [0u8; EcdsaP256::SIGNATURE_LEN];
+        //!
+        //! // sign
+        //! EcdsaP256::sign(&signing_key, b"payload", &mut signature, &nonce).unwrap();
+        //!
+        //! // verify
+        //! EcdsaP256::verify(&verification_key, b"payload", &signature).unwrap();
+        //! ```
         #[doc(inline)]
         pub use libcrux_ecdsa::{
             key_centric_apis::{sha2_256, sha2_384, sha2_512},
@@ -43,11 +109,17 @@ pub mod ecdsa {
 
 #[cfg(feature = "ed25519")]
 pub mod ed25519 {
+    //! APIs for Ed25519
+    //!
+    //! ### Key-centric APIs
+    //!
+    //! #### Key-centric (owned)
     //! ```rust
     //! use libcrux_signature::ed25519::KeyPair;
     //!
     //! use rand::TryRngCore;
     //! let mut rng = rand::rngs::OsRng;
+    //!
     //! // generate a new signature keypair from random bytes
     //! // requires `rand` feature
     //! let KeyPair { signing_key, verification_key }
@@ -59,6 +131,59 @@ pub mod ed25519 {
     //! // verify
     //! verification_key.verify(b"payload", &signature).unwrap();
     //! ```
+    //! #### Key-centric (reference)
+    //! ```rust
+    //! # use libcrux_signature::ed25519::{
+    //! #   SigningKeyRef, VerificationKeyRef, Ed25519,
+    //! # };
+    //! # use libcrux_signature::SignConsts;
+    //! #
+    //! # use rand::{RngCore, TryRngCore};
+    //! # let mut rng = rand::rngs::OsRng;
+    //! # let mut rng = rng.unwrap_mut();
+    //! #
+    //! # let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    //! # let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    //! # let mut bytes = [1u8; Ed25519::RAND_KEYGEN_LEN];
+    //! # rng.fill_bytes(&mut bytes);
+    //! # Ed25519::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+    //! // create the key structs from byte slices
+    //! let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+    //! let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+    //!
+    //! // signature buffer
+    //! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    //!
+    //! // sign
+    //! signing_key.sign(b"payload", &mut signature).unwrap();
+    //!
+    //! // verify
+    //! verification_key.verify(b"payload", &signature).unwrap();
+    //! ```
+    //! ### Slice-based
+    //! ```rust
+    //! # use libcrux_signature::ed25519::Ed25519;
+    //! # use libcrux_signature::SignConsts;
+    //! #
+    //! # use rand::{RngCore, TryRngCore};
+    //! # let mut rng = rand::rngs::OsRng;
+    //! # let mut rng = rng.unwrap_mut();
+    //! #
+    //! # let mut signing_key = [0u8; Ed25519::SIGNING_KEY_LEN];
+    //! # let mut verification_key = [0u8; Ed25519::VERIFICATION_KEY_LEN];
+    //! # let mut bytes = [1u8; Ed25519::RAND_KEYGEN_LEN];
+    //! # rng.fill_bytes(&mut bytes);
+    //! # Ed25519::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+    //! #
+    //! // signature buffer
+    //! let mut signature = [0u8; Ed25519::SIGNATURE_LEN];
+    //!
+    //! // sign
+    //! Ed25519::sign(&signing_key, b"payload", &mut signature).unwrap();
+    //!
+    //! // verify
+    //! Ed25519::verify(&verification_key, b"payload", &signature).unwrap();
+    //! ```
     #[doc(inline)]
     pub use libcrux_ed25519::key_centric_apis::{
         slice, Ed25519, KeyPair, SigningError, SigningKey, SigningKeyRef, VerificationError,
@@ -68,37 +193,88 @@ pub mod ed25519 {
 
 #[cfg(feature = "mldsa")]
 pub mod mldsa {
+    //! APIs for ML-DSA
+    //!
+    //! ### Key-centric APIs
+    //!
+    //! #### Key-centric (owned)
     //! ```rust
     //! use libcrux_signature::mldsa::ml_dsa_44::{SigningKey, KeyPair, VerificationKey};
     //!
-
-    //! use rand::TryRngCore;
+    //! use rand::{RngCore, TryRngCore};
     //! let mut rng = rand::rngs::OsRng;
+    //! let mut rng = rng.unwrap_mut();
     //!
     //! // generate a new signature keypair from random bytes
     //! // requires `rand` feature
     //! let KeyPair { signing_key, verification_key }
-    //!     = KeyPair::generate(&mut rng.unwrap_mut());
+    //!     = KeyPair::generate(&mut rng);
     //!
     //! // sign
-    //! let signature = signing_key.sign(b"payload", b"context", [2; 32]).unwrap();
+    //! let mut signing_randomness = [0; 32];
+    //! rng.fill_bytes(&mut signing_randomness);
+    //! let signature = signing_key.sign(b"payload", b"context", signing_randomness).unwrap();
     //!
     //! // verify
     //! verification_key.verify(b"payload", &signature, b"context").unwrap();
     //! ```
-    //!
+    //! #### Key-centric (reference)
     //! ```rust
-    //! use libcrux_signature::mldsa::ml_dsa_44::{MlDsa44, SigningKeyRef};
-    //! use libcrux_traits::signature::SignConsts;
+    //! # use libcrux_signature::mldsa::ml_dsa_44::{
+    //! #   SigningKeyRef, VerificationKeyRef, MlDsa44,
+    //! # };
+    //! # use libcrux_signature::SignConsts;
+    //! #
+    //! # use rand::{RngCore, TryRngCore};
+    //! # let mut rng = rand::rngs::OsRng;
+    //! # let mut rng = rng.unwrap_mut();
+    //! #
+    //! # let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+    //! # let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+    //! # let mut bytes = [1u8; MlDsa44::RAND_KEYGEN_LEN];
+    //! # rng.fill_bytes(&mut bytes);
+    //! # MlDsa44::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+    //! #
+    //! // create the key structs from byte slices
+    //! let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+    //! let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
     //!
-    //!
-    //! // signing key from bytes
-    //! let signing_key = SigningKeyRef::from_slice(&[1; 2560]).unwrap();
-    //!
-    //! // sign with randomness
+    //! // signature buffer
     //! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
-    //! signing_key.sign(b"payload", &mut signature, b"context", [2; 32]).unwrap();
     //!
+    //! // sign
+    //! let mut signing_randomness = [0; 32];
+    //! rng.fill_bytes(&mut signing_randomness);
+    //! signing_key.sign(b"payload", &mut signature, b"context", signing_randomness).unwrap();
+    //!
+    //! // verify
+    //! verification_key.verify(b"payload", &signature, b"context").unwrap();
+    //! ```
+    //! ### Slice-based
+    //! ```rust
+    //! # use libcrux_signature::mldsa::ml_dsa_44::MlDsa44;
+    //! # use libcrux_signature::SignConsts;
+    //! #
+    //! # use rand::{RngCore, TryRngCore};
+    //! # let mut rng = rand::rngs::OsRng;
+    //! # let mut rng = rng.unwrap_mut();
+    //! #
+    //! # let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+    //! # let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+    //! # let mut bytes = [1u8; MlDsa44::RAND_KEYGEN_LEN];
+    //! # rng.fill_bytes(&mut bytes);
+    //! # MlDsa44::keygen(&mut signing_key, &mut verification_key, bytes).unwrap();
+    //! #
+    //! // signature buffer
+    //! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+    //!
+    //! // sign
+    //! let mut signing_randomness = [0; 32];
+    //! rng.fill_bytes(&mut signing_randomness);
+    //! MlDsa44::sign(&signing_key, b"payload", &mut signature, b"context", signing_randomness).unwrap();
+    //!
+    //! // verify
+    //! MlDsa44::verify(&verification_key, b"payload", &signature, b"context").unwrap();
     //! ```
     #[doc(inline)]
     pub use libcrux_ml_dsa::key_centric_apis::{ml_dsa_44, ml_dsa_65, ml_dsa_87};

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -1,0 +1,92 @@
+#[cfg(any(feature = "ecdsa", feature = "ed25519", feature = "mldsa"))]
+pub use libcrux_traits::signature::{SignConsts, SignTypes};
+
+#[cfg(feature = "ecdsa")]
+pub mod ecdsa {
+    pub mod p256 {
+        //! ```rust
+        //! use libcrux_signature::ecdsa::p256::{
+        //!   Nonce, sha2_256::{EcdsaP256, KeyPair, SigningKey, VerificationKey}
+        //! };
+        //!
+        //! // generate a new nonce
+        //! use rand::TryRngCore;
+        //! let mut rng = rand::rngs::OsRng;
+        //! let nonce = Nonce::random(&mut rng.unwrap_mut()).unwrap();
+        //!
+        //! // generate a new signature keypair from random bytes
+        //! let KeyPair { signing_key, verification_key } =
+        //! EcdsaP256::generate_key_pair(&mut rng.unwrap_mut()).unwrap();
+        //!
+        //! // sign
+        //! let signature = signing_key.sign(b"payload", &nonce).unwrap();
+        //!
+        //! // verify
+        //! verification_key.verify(b"payload", &signature).unwrap();
+        //! ```
+        pub use libcrux_ecdsa::key_centric_apis::{sha2_256, sha2_384, sha2_512};
+        pub use libcrux_ecdsa::p256::Nonce;
+    }
+}
+
+#[cfg(feature = "ed25519")]
+pub mod ed25519 {
+    //! ```rust
+    //! use libcrux_signature::ed25519::{Ed25519, KeyPair};
+    //!
+    //! use rand::TryRngCore;
+    //! let mut rng = rand::rngs::OsRng;
+    //! // generate a new signature keypair from random bytes
+    //! // requires `rand` feature
+    //! let KeyPair { signing_key, verification_key }
+    //!     = Ed25519::generate_key_pair(&mut rng.unwrap_mut());
+    //!
+    //! // sign
+    //! let signature = signing_key.sign(b"payload").unwrap();
+    //!
+    //! // verify
+    //! verification_key.verify(b"payload", &signature).unwrap();
+    //! ```
+    pub use libcrux_ed25519::key_centric_apis::{
+        Ed25519, KeyPair, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
+    };
+}
+
+#[cfg(feature = "mldsa")]
+pub mod mldsa {
+    //! ```rust
+    //! use libcrux_signature::mldsa::{MlDsa44, SigningKey, KeyPair, VerificationKey};
+    //!
+
+    //! use rand::TryRngCore;
+    //! let mut rng = rand::rngs::OsRng;
+    //!
+    //! // generate a new signature keypair from random bytes
+    //! // requires `rand` feature
+    //! let KeyPair { signing_key, verification_key }
+    //!     = MlDsa44::generate_key_pair(&mut rng.unwrap_mut());
+    //!
+    //! // sign
+    //! let signature = signing_key.sign(b"payload", b"context", [2; 32]).unwrap();
+    //!
+    //! // verify
+    //! verification_key.verify(b"payload", &signature, b"context").unwrap();
+    //! ```
+    //!
+    //! ```rust
+    //! use libcrux_signature::mldsa::{MlDsa44, SigningKeyRef};
+    //! use libcrux_traits::signature::SignConsts;
+    //!
+    //!
+    //! // signing key from bytes
+    //! let signing_key = SigningKeyRef::from_slice(&[1; 2560]).unwrap();
+    //!
+    //! // sign with randomness
+    //! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+    //! signing_key.sign(b"payload", &mut signature, b"context", [2; 32]).unwrap();
+    //!
+    //! ```
+    pub use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::{
+        KeyPair, MlDsa44, Signature, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
+    };
+}

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -32,8 +32,11 @@ pub mod ecdsa {
         //! // verify
         //! verification_key.verify(b"payload", &signature).unwrap();
         //! ```
-        pub use libcrux_ecdsa::key_centric_apis::{sha2_256, sha2_384, sha2_512};
-        pub use libcrux_ecdsa::p256::Nonce;
+        #[doc(inline)]
+        pub use libcrux_ecdsa::{
+            key_centric_apis::{sha2_256, sha2_384, sha2_512},
+            p256::Nonce,
+        };
     }
 }
 
@@ -55,8 +58,10 @@ pub mod ed25519 {
     //! // verify
     //! verification_key.verify(b"payload", &signature).unwrap();
     //! ```
+    #[doc(inline)]
     pub use libcrux_ed25519::key_centric_apis::{
-        slice, KeyPair, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
+        slice, Ed25519, KeyPair, SigningError, SigningKey, SigningKeyRef, VerificationError,
+        VerificationKey, VerificationKeyRef,
     };
 }
 
@@ -94,5 +99,6 @@ pub mod mldsa {
     //! signing_key.sign(b"payload", &mut signature, b"context", [2; 32]).unwrap();
     //!
     //! ```
+    #[doc(inline)]
     pub use libcrux_ml_dsa::key_centric_apis::{ml_dsa_44, ml_dsa_65, ml_dsa_87};
 }

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -7,7 +7,7 @@
 //! - ML-DSA
 
 #[cfg(any(feature = "ecdsa", feature = "ed25519", feature = "mldsa"))]
-pub use libcrux_traits::signature::{SignConsts, SignTypes};
+pub use libcrux_traits::signature::SignConsts;
 
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa {

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -6,8 +6,9 @@
 //! - ed25519
 //! - ML-DSA
 
+#[doc(inline)]
 #[cfg(any(feature = "ecdsa", feature = "ed25519", feature = "mldsa"))]
-pub use libcrux_traits::signature::SignConsts;
+pub use libcrux_traits::signature::{SignConsts, WrongLengthError};
 
 #[cfg(feature = "ecdsa")]
 pub mod ecdsa {

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -1,3 +1,11 @@
+//! This crate provides signature functionality.
+//!
+//! We currently support three signature algorithms:
+//!
+//! - ecdsa-p256
+//! - ed25519
+//! - ML-DSA
+
 #[cfg(any(feature = "ecdsa", feature = "ed25519", feature = "mldsa"))]
 pub use libcrux_traits::signature::{SignConsts, SignTypes};
 

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -63,7 +63,7 @@ pub mod ed25519 {
 #[cfg(feature = "mldsa")]
 pub mod mldsa {
     //! ```rust
-    //! use libcrux_signature::mldsa::{MlDsa44, SigningKey, KeyPair, VerificationKey};
+    //! use libcrux_signature::mldsa::ml_dsa_44::{SigningKey, KeyPair, VerificationKey};
     //!
 
     //! use rand::TryRngCore;
@@ -82,7 +82,7 @@ pub mod mldsa {
     //! ```
     //!
     //! ```rust
-    //! use libcrux_signature::mldsa::{MlDsa44, SigningKeyRef};
+    //! use libcrux_signature::mldsa::ml_dsa_44::{MlDsa44, SigningKeyRef};
     //! use libcrux_traits::signature::SignConsts;
     //!
     //!
@@ -94,7 +94,5 @@ pub mod mldsa {
     //! signing_key.sign(b"payload", &mut signature, b"context", [2; 32]).unwrap();
     //!
     //! ```
-    pub use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::{
-        KeyPair, MlDsa44, Signature, SigningKey, SigningKeyRef, VerificationKey, VerificationKeyRef,
-    };
+    pub use libcrux_ml_dsa::key_centric_apis::{ml_dsa_44, ml_dsa_65, ml_dsa_87};
 }

--- a/crates/primitives/signature/src/lib.rs
+++ b/crates/primitives/signature/src/lib.rs
@@ -24,7 +24,11 @@ pub mod ecdsa {
         //!   Nonce, sha2_256::{KeyPair, SigningKey, VerificationKey}
         //! };
         //!
-        //! // generate a new nonce
+        //! // Generate a new nonce.
+        //! // Ensure you use good randomness.
+        //! // It is not recommended to use OsRng directly!
+        //! // Instead it is highly encouraged to use RNGs like NISTs DRBG to account for
+        //! // bad system entropy.
         //! use rand::TryRngCore;
         //! let mut rng = rand::rngs::OsRng;
         //! let nonce = Nonce::random(&mut rng.unwrap_mut()).unwrap();
@@ -117,6 +121,10 @@ pub mod ed25519 {
     //! ```rust
     //! use libcrux_signature::ed25519::KeyPair;
     //!
+    //! // Ensure you use good randomness.
+    //! // It is not recommended to use OsRng directly!
+    //! // Instead it is highly encouraged to use RNGs like NISTs DRBG to account for
+    //! // bad system entropy.
     //! use rand::TryRngCore;
     //! let mut rng = rand::rngs::OsRng;
     //!
@@ -201,6 +209,10 @@ pub mod mldsa {
     //! ```rust
     //! use libcrux_signature::mldsa::ml_dsa_44::{SigningKey, KeyPair, VerificationKey};
     //!
+    //! // Ensure you use good randomness.
+    //! // It is not recommended to use OsRng directly!
+    //! // Instead it is highly encouraged to use RNGs like NISTs DRBG to account for
+    //! // bad system entropy.
     //! use rand::{RngCore, TryRngCore};
     //! let mut rng = rand::rngs::OsRng;
     //! let mut rng = rng.unwrap_mut();

--- a/libcrux-ml-dsa/CHANGELOG.md
+++ b/libcrux-ml-dsa/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - [#1225](https://github.com/cryspen/libcrux/pull/1225): In tests, use the latest versions of ACVP KATs exported by `libcrux-kats`.
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add key-centric and slice-based signature public APIs
 
 ## [0.0.4] (2025-11-05)
 

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -55,7 +55,10 @@ test-utils = []                                                  # exposing inte
 
 # This doesn't check the secret independence of the implementation, but sets the
 # exposed API into secret independence checking mode.
-expose-secret-independence = ["libcrux-secrets/check-secret-independence"]
+expose-secret-independence = [
+    "libcrux-secrets/check-secret-independence",
+    "libcrux-traits/check-secret-independence",
+]
 
 # Features for the different key sizes of ML-DSA
 mldsa44 = []

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -22,6 +22,9 @@ libcrux-sha3 = { version = "0.0.4", path = "../crates/algorithms/sha3" }
 libcrux-intrinsics = { version = "0.0.4", path = "../crates/utils/intrinsics" }
 libcrux-platform = { version = "0.0.2", path = "../crates/sys/platform" }
 libcrux-macros = { version = "=0.0.3",  path = "../crates/utils/macros" }
+libcrux-traits = { version = "=0.0.4", path = "../traits/" }
+libcrux-secrets = { version = "=0.0.4", path = "../crates/utils/secrets" }
+rand = { version = "0.9", default-features = false, optional = true }
 hax-lib.workspace = true
 
 [dev-dependencies]
@@ -42,11 +45,17 @@ pqcrypto-mldsa = { version = "0.1.0" } #, default-features = false
 core-models = { path = "../crates/utils/core-models", version = "0.0.4" }
 
 [features]
+rand = ["dep:rand"]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]
 simd128 = ["libcrux-sha3/simd128", "libcrux-intrinsics/simd128"]
 simd256 = ["libcrux-sha3/simd256", "libcrux-intrinsics/simd256"]
 acvp = []                                                        # expose internal API for ACVP testing
 test-utils = []                                                  # exposing internal functions for testing
+
+
+# This doesn't check the secret independence of the implementation, but sets the
+# exposed API into secret independence checking mode.
+expose-secret-independence = ["libcrux-secrets/check-secret-independence"]
 
 # Features for the different key sizes of ML-DSA
 mldsa44 = []

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -144,15 +144,15 @@ macro_rules! impl_mod {
             }
         }
 
-        impl arrayref::$ty {
+        impl KeyPair {
             #[cfg(feature = "rand")]
-            pub fn generate_key_pair(rng: &mut impl rand::CryptoRng) -> KeyPair {
+            pub fn generate(rng: &mut impl rand::CryptoRng) -> KeyPair {
                 use libcrux_secrets::Classify;
 
-                let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+                let mut bytes = [0u8; arrayref::$ty::RAND_KEYGEN_LEN];
                 rng.fill_bytes(&mut bytes);
-                let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
-                let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+                let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
+                let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
                 arrayref::$ty::keygen_derand(
                     &mut signing_key,
                     &mut verification_key,
@@ -558,7 +558,7 @@ fn key_centric_owned() {
     let KeyPair {
         signing_key,
         verification_key,
-    } = MlDsa44::generate_key_pair(&mut rng);
+    } = KeyPair::generate(&mut rng);
 
     let signature = signing_key.sign(b"payload", context, [0u8; 32]).unwrap();
     verification_key

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -14,6 +14,8 @@ macro_rules! impl_mod {
 
         #[doc(inline)]
         pub use arrayref::*;
+        #[doc(inline)]
+        pub use slice::$ty;
 
         // TODO: different error type?
         #[derive(Debug)]
@@ -22,7 +24,7 @@ macro_rules! impl_mod {
 
         pub(crate) mod arrayref {
             #[derive(Debug, PartialEq)]
-            pub struct $ty;
+            pub(crate) struct $ty;
             use super::*;
             impl_key_centric_types!(
                 $ty,
@@ -70,6 +72,7 @@ macro_rules! impl_mod {
             //! .unwrap();
             //! ```
 
+            /// Slice-based APIs for ML-DSA.
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,0 +1,540 @@
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+
+// placeholder error implementation
+// TODO: more specific error
+#[derive(Debug)]
+pub struct Error;
+macro_rules! impl_mod {
+    ($ty:ident, $module:ident) => {
+        use libcrux_secrets::{Declassify, DeclassifyRef, DeclassifyRefMut, U8};
+
+        pub(super) const VERIFICATION_KEY_LEN: usize =
+            crate::ml_dsa_generic::$module::VERIFICATION_KEY_SIZE;
+        pub(super) const SIGNING_KEY_LEN: usize = crate::ml_dsa_generic::$module::SIGNING_KEY_SIZE;
+        pub(super) const SIGNATURE_LEN: usize = crate::ml_dsa_generic::$module::SIGNATURE_SIZE;
+        pub(super) const RAND_KEYGEN_LEN: usize = 32;
+
+        use super::*;
+        // arrayref API
+        #[doc(inline)]
+        pub use arrayref::*;
+
+        // TODO: different error type?
+        #[derive(Debug)]
+        /// An incorrect length when converting from slice.
+        pub struct WrongLengthError;
+
+        pub mod arrayref {
+            #[derive(Debug, PartialEq)]
+            pub struct $ty;
+            use super::*;
+            impl_key_centric_types!(
+                $ty,
+                SIGNING_KEY_LEN,
+                VERIFICATION_KEY_LEN,
+                SIGNATURE_LEN,
+                RAND_KEYGEN_LEN,
+                WrongLengthError,
+                WrongLengthError
+            );
+        }
+        pub mod slice {
+            #[derive(Debug, PartialEq)]
+            pub struct $ty;
+            use super::*;
+            impl_sign_traits!(
+                $ty,
+                SIGNING_KEY_LEN,
+                VERIFICATION_KEY_LEN,
+                SIGNATURE_LEN,
+                RAND_KEYGEN_LEN
+            );
+
+            // error type including wrong length
+            #[derive(Debug)]
+            pub enum SigningError {
+                RejectionSamplingError,
+                ContextTooLongError,
+                WrongSigningKeyLength,
+                WrongSignatureLength,
+            }
+
+            impl From<crate::SigningError> for SigningError {
+                fn from(e: crate::SigningError) -> Self {
+                    match e {
+                        crate::SigningError::RejectionSamplingError => {
+                            SigningError::RejectionSamplingError
+                        }
+                        crate::SigningError::ContextTooLongError => {
+                            SigningError::ContextTooLongError
+                        }
+                    }
+                }
+            }
+
+            // error type including wrong length
+            #[derive(Debug)]
+            pub enum VerificationError {
+                MalformedHintError,
+                SignerResponseExceedsBoundError,
+                CommitmentHashesDontMatchError,
+                VerificationContextTooLongError,
+                WrongVerificationKeyLength,
+                WrongSignatureLength,
+            }
+
+            impl From<crate::VerificationError> for VerificationError {
+                fn from(e: crate::VerificationError) -> Self {
+                    match e {
+                        crate::VerificationError::MalformedHintError => {
+                            VerificationError::MalformedHintError
+                        }
+                        crate::VerificationError::SignerResponseExceedsBoundError => {
+                            VerificationError::SignerResponseExceedsBoundError
+                        }
+                        crate::VerificationError::CommitmentHashesDontMatchError => {
+                            VerificationError::CommitmentHashesDontMatchError
+                        }
+                        crate::VerificationError::VerificationContextTooLongError => {
+                            VerificationError::VerificationContextTooLongError
+                        }
+                    }
+                }
+            }
+
+            #[derive(Debug)]
+            pub enum KeygenError {
+                WrongSigningKeyLength,
+                WrongVerificationKeyLength,
+            }
+        }
+
+        impl arrayref::$ty {
+            #[cfg(feature = "rand")]
+            pub fn generate_key_pair(rng: &mut impl rand::CryptoRng) -> KeyPair {
+                use libcrux_secrets::Classify;
+
+                let mut bytes = [0u8; Self::RAND_KEYGEN_LEN];
+                rng.fill_bytes(&mut bytes);
+                let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
+                let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
+                arrayref::$ty::keygen_derand(&mut signing_key, &mut verification_key, bytes.classify());
+
+                KeyPair {
+                    signing_key: SigningKey::from(signing_key),
+                    verification_key: VerificationKey::from(verification_key),
+                }
+            }
+        }
+        impl arrayref::$ty {
+            pub fn sign(
+                key: &[U8; Self::SIGNING_KEY_LEN],
+                payload: &[u8],
+                signature: &mut [u8; Self::SIGNATURE_LEN],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), crate::SigningError> {
+                crate::ml_dsa_generic::multiplexing::$module::sign_mut(
+                    // length is already validated
+                    key.declassify_ref().try_into().unwrap(),
+                    payload,
+                    context,
+                    randomness.declassify(),
+                    signature,
+                )
+            }
+            pub fn sign_pre_hashed_shake128(
+                key: &[U8; Self::SIGNING_KEY_LEN],
+                payload: &[u8],
+                signature: &mut [u8; Self::SIGNATURE_LEN],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), crate::SigningError> {
+                // TODO: use mut version
+                let mut pre_hash_buffer = [0; 256];
+                let signature_out =
+                    crate::ml_dsa_generic::multiplexing::$module::sign_pre_hashed_shake128(
+                        key.declassify_ref().try_into().unwrap(),
+                        payload,
+                        context,
+                        &mut pre_hash_buffer,
+                        randomness.declassify(),
+                    )?;
+
+                signature.copy_from_slice(signature_out.as_slice());
+
+                Ok(())
+            }
+
+            pub fn verify(
+                key: &[u8; Self::VERIFICATION_KEY_LEN],
+                payload: &[u8],
+                signature: &[u8; Self::SIGNATURE_LEN],
+                context: &[u8],
+            ) -> Result<(), crate::VerificationError> {
+                crate::ml_dsa_generic::multiplexing::$module::verify(
+                    key, payload, context, signature,
+                )
+            }
+            pub fn verify_pre_hashed_shake128(
+                key: &[u8; Self::VERIFICATION_KEY_LEN],
+                payload: &[u8],
+                signature: &[u8; Self::SIGNATURE_LEN],
+                context: &[u8],
+            ) -> Result<(), crate::VerificationError> {
+                let mut pre_hash_buffer = [0; 256];
+                crate::ml_dsa_generic::multiplexing::$module::verify_pre_hashed_shake128(
+                    key,
+                    payload,
+                    context,
+                    &mut pre_hash_buffer,
+                    signature,
+                )
+            }
+            pub fn keygen_derand(
+                signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
+                verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
+                randomness: [U8; Self::RAND_KEYGEN_LEN],
+            ) {
+                crate::ml_dsa_generic::multiplexing::$module::generate_key_pair(
+                    randomness.declassify(),
+                    signing_key.declassify_ref_mut(),
+                    verification_key,
+                );
+            }
+        }
+        impl slice::$ty {
+            pub fn sign(
+                key: &[U8],
+                payload: &[u8],
+                signature: &mut [u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), slice::SigningError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSigningKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSignatureLength)?;
+
+                arrayref::$ty::sign(&key, payload, signature, context, randomness)
+                    .map_err(slice::SigningError::from)
+            }
+            pub fn sign_pre_hashed_shake128(
+                key: &[U8],
+                payload: &[u8],
+                signature: &mut [u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), slice::SigningError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSigningKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::SigningError::WrongSignatureLength)?;
+
+                arrayref::$ty::sign_pre_hashed_shake128(
+                    &key, payload, signature, context, randomness,
+                )
+                .map_err(slice::SigningError::from)
+            }
+            pub fn verify(
+                key: &[u8],
+                payload: &[u8],
+                signature: &[u8],
+                context: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongVerificationKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongSignatureLength)?;
+
+                arrayref::$ty::verify(key, payload, signature, context)
+                    .map_err(slice::VerificationError::from)
+            }
+            pub fn verify_pre_hashed_shake128(
+                key: &[u8],
+                payload: &[u8],
+                signature: &[u8],
+                context: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                let key = key
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongVerificationKeyLength)?;
+                let signature = signature
+                    .try_into()
+                    .map_err(|_| slice::VerificationError::WrongSignatureLength)?;
+
+                arrayref::$ty::verify_pre_hashed_shake128(key, payload, signature, context)
+                    .map_err(slice::VerificationError::from)
+            }
+            pub fn keygen_derand(
+                signing_key: &mut [U8],
+                verification_key: &mut [u8],
+                randomness: [U8; Self::RAND_KEYGEN_LEN],
+            ) -> Result<(), slice::KeygenError> {
+                let signing_key = signing_key
+                    .try_into()
+                    .map_err(|_| slice::KeygenError::WrongSigningKeyLength)?;
+                let verification_key = verification_key
+                    .try_into()
+                    .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
+
+                arrayref::$ty::keygen_derand(signing_key, verification_key, randomness);
+
+                Ok(())
+            }
+        }
+        impl<'a> SigningKeyRef<'a> {
+            pub fn sign(
+                &self,
+                payload: &[u8],
+                signature: &mut [u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), slice::SigningError> {
+                slice::$ty::sign(self.as_ref(), payload, signature, context, randomness)
+            }
+            pub fn sign_pre_hashed_shake128(
+                &self,
+                payload: &[u8],
+                signature: &mut [u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<(), slice::SigningError> {
+                slice::$ty::sign_pre_hashed_shake128(
+                    self.as_ref(),
+                    payload,
+                    signature,
+                    context,
+                    randomness,
+                )
+            }
+        }
+        impl<'a> VerificationKeyRef<'a> {
+            pub fn verify(
+                &self,
+                payload: &[u8],
+                signature: &[u8],
+                context: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                slice::$ty::verify(self.as_ref(), payload, signature, context)
+            }
+            pub fn verify_pre_hashed_shake128(
+                &self,
+                payload: &[u8],
+                signature: &[u8],
+                context: &[u8],
+            ) -> Result<(), slice::VerificationError> {
+                slice::$ty::verify_pre_hashed_shake128(self.as_ref(), payload, signature, context)
+            }
+        }
+
+        // key-centric API
+        impl SigningKey {
+            pub fn sign(
+                &self,
+                payload: &[u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<Signature, crate::SigningError> {
+                let mut signature = [0u8; SIGNATURE_LEN];
+                arrayref::$ty::sign(self.as_ref(), payload, &mut signature, context, randomness)
+                    .map(|_| Signature::from(signature))
+            }
+            pub fn sign_pre_hashed_shake128(
+                &self,
+                payload: &[u8],
+                context: &[u8],
+                randomness: [U8; 32],
+            ) -> Result<Signature, crate::SigningError> {
+                let mut signature = [0u8; SIGNATURE_LEN];
+                arrayref::$ty::sign_pre_hashed_shake128(
+                    self.as_ref(),
+                    payload,
+                    &mut signature,
+                    context,
+                    randomness,
+                )
+                .map(|_| Signature::from(signature))
+            }
+        }
+        impl VerificationKey {
+            pub fn verify(
+                &self,
+                payload: &[u8],
+                signature: &Signature,
+                context: &[u8],
+            ) -> Result<(), crate::VerificationError> {
+                arrayref::$ty::verify(self.as_ref(), payload, signature.as_ref(), context)
+            }
+            pub fn verify_pre_hashed_shake128(
+                &self,
+                payload: &[u8],
+                signature: &Signature,
+                context: &[u8],
+            ) -> Result<(), crate::VerificationError> {
+                arrayref::$ty::verify_pre_hashed_shake128(
+                    self.as_ref(),
+                    payload,
+                    signature.as_ref(),
+                    context,
+                )
+            }
+        }
+    };
+}
+
+#[cfg(feature = "mldsa44")]
+pub mod ml_dsa_44 {
+
+    impl_mod!(MlDsa44, ml_dsa_44);
+}
+
+#[cfg(feature = "mldsa65")]
+pub mod ml_dsa_65 {
+
+    impl_mod!(MlDsa65, ml_dsa_65);
+}
+
+#[cfg(feature = "mldsa87")]
+pub mod ml_dsa_87 {
+
+    impl_mod!(MlDsa87, ml_dsa_87);
+}
+
+#[test]
+#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
+fn key_centric_owned() {
+    use rand::TryRngCore;
+    let mut rng = rand::rngs::OsRng;
+    let mut rng = rng.unwrap_mut();
+    use libcrux_traits::signature::SignConsts;
+
+    use ml_dsa_44::{KeyPair, MlDsa44, SigningKey, VerificationKey};
+
+    let context = b"context";
+
+    // keys can be created from arrays
+    let _signing_key = SigningKey::from([0u8; MlDsa44::SIGNING_KEY_LEN]);
+    let _verification_key = VerificationKey::from([0u8; MlDsa44::VERIFICATION_KEY_LEN]);
+
+    // key-centric API
+    let KeyPair {
+        signing_key,
+        verification_key,
+    } = MlDsa44::generate_key_pair(&mut rng);
+
+    let signature = signing_key.sign(b"payload", context, [0u8; 32]).unwrap();
+    verification_key
+        .verify(b"payload", &signature, context)
+        .unwrap();
+
+    let pre_hashed = b"pre-hashed";
+
+    let signature_from_pre_hashed = signing_key
+        .sign_pre_hashed_shake128(pre_hashed, context, [0u8; 32])
+        .unwrap();
+    verification_key
+        .verify_pre_hashed_shake128(pre_hashed, &signature_from_pre_hashed, context)
+        .unwrap();
+}
+
+#[test]
+#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
+fn key_centric_refs() {
+    use libcrux_traits::signature::SignConsts;
+    use ml_dsa_44::*;
+
+    let context = b"context";
+
+    let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+
+    // create references from slice
+    let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+    let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+
+    let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+    signing_key
+        .sign(b"payload", &mut signature, context, [0u8; 32])
+        .unwrap();
+    verification_key
+        .verify(b"payload", &signature, context)
+        .unwrap();
+
+    signing_key
+        .sign_pre_hashed_shake128(b"pre-hashed", &mut signature, context, [0u8; 32])
+        .unwrap();
+    verification_key
+        .verify_pre_hashed_shake128(b"pre-hashed", &signature, context)
+        .unwrap();
+}
+
+#[test]
+#[cfg(not(feature = "expose-secret-independence"))]
+fn arrayref_apis() {
+    use libcrux_traits::signature::SignConsts;
+    use ml_dsa_44::MlDsa44;
+
+    let context = b"context";
+
+    let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+
+    // arrayref API
+    let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+    MlDsa44::sign(&signing_key, b"payload", &mut signature, context, [0u8; 32]).unwrap();
+    MlDsa44::verify(&verification_key, b"payload", &signature, context).unwrap();
+
+    // pre-hashed
+    MlDsa44::sign_pre_hashed_shake128(
+        &signing_key,
+        b"pre-hashed",
+        &mut signature,
+        context,
+        [0u8; 32],
+    )
+    .unwrap();
+    MlDsa44::verify_pre_hashed_shake128(&verification_key, b"pre-hashed", &signature, context)
+        .unwrap();
+}
+#[test]
+#[cfg(not(feature = "expose-secret-independence"))]
+fn slice_apis() {
+    use libcrux_traits::signature::SignConsts;
+    use ml_dsa_44::slice::MlDsa44;
+
+    let context = b"context";
+
+    let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+    let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+
+    // slice API
+    let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+    MlDsa44::sign(&signing_key, b"payload", &mut signature, context, [0u8; 32]).unwrap();
+    MlDsa44::verify(&verification_key, b"payload", &signature, context).unwrap();
+
+    MlDsa44::sign_pre_hashed_shake128(
+        signing_key.as_ref(),
+        b"pre-hashed",
+        &mut signature,
+        context,
+        [0u8; 32],
+    )
+    .unwrap();
+    MlDsa44::verify_pre_hashed_shake128(
+        verification_key.as_ref(),
+        b"pre-hashed",
+        &signature,
+        context,
+    )
+    .unwrap();
+}

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -44,7 +44,7 @@ macro_rules! impl_mod {
             //! Usage example:
             //! ```rust
             //! use libcrux_traits::signature::SignConsts;
-            //! use ml_dsa_44::slice::MlDsa44;
+            //! use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::slice::MlDsa44;
             //!
             //! let context = b"context";
             //!
@@ -539,7 +539,11 @@ pub mod ml_dsa_87 {
 }
 
 #[test]
-#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
+#[cfg(all(
+    feature = "mldsa44",
+    feature = "rand",
+    not(feature = "expose-secret-independence")
+))]
 fn key_centric_owned() {
     use rand::TryRngCore;
     let mut rng = rand::rngs::OsRng;
@@ -576,7 +580,11 @@ fn key_centric_owned() {
 }
 
 #[test]
-#[cfg(all(feature = "rand", not(feature = "expose-secret-independence")))]
+#[cfg(all(
+    feature = "mldsa44",
+    feature = "rand",
+    not(feature = "expose-secret-independence")
+))]
 fn key_centric_refs() {
     use libcrux_traits::signature::SignConsts;
     use ml_dsa_44::*;
@@ -608,7 +616,7 @@ fn key_centric_refs() {
 }
 
 #[test]
-#[cfg(not(feature = "expose-secret-independence"))]
+#[cfg(all(feature = "mldsa44", not(feature = "expose-secret-independence")))]
 fn arrayref_apis() {
     use libcrux_traits::signature::SignConsts;
     use ml_dsa_44::MlDsa44;

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,4 +1,6 @@
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
+use libcrux_traits::signature::{
+    impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
+};
 
 macro_rules! impl_mod {
     ($ty:ident, $module:ident) => {
@@ -16,11 +18,6 @@ macro_rules! impl_mod {
         pub use arrayref::*;
         #[doc(inline)]
         pub use slice::$ty;
-
-        // TODO: different error type?
-        #[derive(Debug)]
-        /// An incorrect length when converting from slice.
-        pub struct WrongLengthError;
 
         pub(crate) mod arrayref {
             #[derive(Debug, PartialEq)]

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -15,7 +15,7 @@ macro_rules! impl_mod {
         pub(super) const RAND_KEYGEN_LEN: usize = 32;
 
         use super::*;
-        // arrayref API
+
         #[doc(inline)]
         pub use arrayref::*;
 

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -142,6 +142,7 @@ macro_rules! impl_mod {
 
         impl KeyPair {
             #[cfg(feature = "rand")]
+            /// Generate an ML-DSA key pair
             pub fn generate(rng: &mut impl rand::CryptoRng) -> KeyPair {
                 use libcrux_secrets::Classify;
 

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,3 +1,72 @@
+//! This module includes key-centric and slice-based APIs for ML-DSA.
+//!
+//! ### Key-centric APIs
+//! This module provides key-centric APIs for ML-DSA.
+//!
+//! #### Key-centric (owned)
+//! ```rust
+//! use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::{SigningKey, KeyPair, VerificationKey};
+//!
+//! // generate key pair
+//! let KeyPair { signing_key, verification_key } = KeyPair::generate_derand([0u8; 32]);
+//!
+//! // sign and verify
+//! let signature = signing_key.sign(b"payload", b"context", [2; 32]).unwrap();
+//! verification_key.verify(b"payload", &signature, b"context").unwrap();
+//! ```
+//!
+//! #### Key-centric (reference)
+//! ```rust
+//! # use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::{
+//! #     MlDsa44, SigningKeyRef, VerificationKeyRef,
+//! # };
+//! # use libcrux_traits::signature::SignConsts;
+//! #
+//! # // key generation
+//! # let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+//! # let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+//! # MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+//! #
+//! // create key structs from references
+//! let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
+//! let verification_key = VerificationKeyRef::from_slice(&verification_key).unwrap();
+//!
+//! // signature buffer
+//! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+//!
+//! // sign and verify
+//! signing_key
+//!     .sign(b"payload", &mut signature, b"context", [0u8; 32])
+//!     .unwrap();
+//! verification_key
+//!     .verify(b"payload", &signature, b"context")
+//!     .unwrap();
+//! ```
+//!
+//! ### Slice-based APIs
+//! This module also provides slice-based APIs via the structs [`MlDsa44`], [`MlDsa65`] and
+//! [`MlDsa87`].
+//!
+//! ```rust
+//! use libcrux_ml_dsa::key_centric_apis::ml_dsa_44::MlDsa44;
+//! use libcrux_traits::signature::SignConsts;
+//!
+//! // keygen
+//! let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+//! let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+//! MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+//!
+//! // signature buffer
+//! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+//!
+//! // sign and verify
+//! MlDsa44::sign(&signing_key, b"payload", &mut signature, b"context", [0u8; 32]).unwrap();
+//! MlDsa44::verify(&verification_key, b"payload", &signature, b"context").unwrap();
+//! ```
+
+#[cfg(doc)]
+use self::{ml_dsa_44::MlDsa44, ml_dsa_65::MlDsa65, ml_dsa_87::MlDsa87};
+
 use libcrux_traits::signature::{
     impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
 };

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -155,12 +155,16 @@ macro_rules! impl_mod {
                 RAND_KEYGEN_LEN
             );
 
-            // error type including wrong length
+            /// An error when signing.
             #[derive(Debug)]
             pub enum SigningError {
+                // TODO: add doc comment.
                 RejectionSamplingError,
+                /// The provided context is too long.
                 ContextTooLongError,
+                /// The length of the provided signing key is incorrect.
                 WrongSigningKeyLength,
+                /// The length of the provided signature buffer is incorrect.
                 WrongSignatureLength,
             }
 
@@ -177,14 +181,20 @@ macro_rules! impl_mod {
                 }
             }
 
-            // error type including wrong length
+            /// An error when verifying a signature.
             #[derive(Debug)]
             pub enum VerificationError {
+                // TODO: add doc comment.
                 MalformedHintError,
+                // TODO: add doc comment.
                 SignerResponseExceedsBoundError,
+                // TODO: add doc comment.
                 CommitmentHashesDontMatchError,
+                /// The verification context is too long.
                 VerificationContextTooLongError,
+                /// The provided verification key too long.
                 WrongVerificationKeyLength,
+                /// The length of the provided signature is incorrect.
                 WrongSignatureLength,
             }
 

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -522,19 +522,16 @@ macro_rules! impl_mod {
 
 #[cfg(feature = "mldsa44")]
 pub mod ml_dsa_44 {
-
     impl_mod!(MlDsa44, ml_dsa_44);
 }
 
 #[cfg(feature = "mldsa65")]
 pub mod ml_dsa_65 {
-
     impl_mod!(MlDsa65, ml_dsa_65);
 }
 
 #[cfg(feature = "mldsa87")]
 pub mod ml_dsa_87 {
-
     impl_mod!(MlDsa87, ml_dsa_87);
 }
 

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -241,7 +241,7 @@ macro_rules! impl_mod {
             pub fn generate_derand(bytes: [U8; RAND_KEYGEN_LEN]) -> KeyPair {
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
-                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify());
+                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes);
 
                 KeyPair {
                     signing_key: SigningKey::from(signing_key),

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -50,7 +50,7 @@ macro_rules! impl_mod {
             //!
             //! let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
             //! let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
-            //! MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+            //! MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
             //!
             //! // slice API
             //! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
@@ -153,11 +153,7 @@ macro_rules! impl_mod {
                 rng.fill_bytes(&mut bytes);
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
-                arrayref::$ty::keygen_derand(
-                    &mut signing_key,
-                    &mut verification_key,
-                    bytes.classify(),
-                );
+                arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify());
 
                 KeyPair {
                     signing_key: SigningKey::from(signing_key),
@@ -252,7 +248,7 @@ macro_rules! impl_mod {
                 )
             }
             /// Generate an ML-DSA Key Pair
-            pub fn keygen_derand(
+            pub fn keygen(
                 signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
                 verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -359,7 +355,7 @@ macro_rules! impl_mod {
 
             /// Generate an ML-DSA Key Pair
             #[cfg(not(eurydice))]
-            pub fn keygen_derand(
+            pub fn keygen(
                 signing_key: &mut [U8],
                 verification_key: &mut [u8],
                 randomness: [U8; Self::RAND_KEYGEN_LEN],
@@ -371,7 +367,7 @@ macro_rules! impl_mod {
                     .try_into()
                     .map_err(|_| slice::KeygenError::WrongVerificationKeyLength)?;
 
-                arrayref::$ty::keygen_derand(signing_key, verification_key, randomness);
+                arrayref::$ty::keygen(signing_key, verification_key, randomness);
 
                 Ok(())
             }
@@ -590,7 +586,7 @@ fn key_centric_refs() {
 
     let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
-    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]);
 
     // create references from slice
     let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
@@ -622,7 +618,7 @@ fn arrayref_apis() {
 
     let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
-    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]);
+    MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]);
 
     // arrayref API
     let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -139,6 +139,11 @@ macro_rules! impl_mod {
             //! ```
 
             /// Slice-based APIs for ML-DSA.
+            ///
+            /// This struct provides slice-based APIs for ML-DSA, as well as an implementation
+            /// of the [`SignConsts`] trait, which can be used to retrieve constants defining
+            /// the verification key length, signing key length, signature length, and the
+            /// length of the randomness required for key generation for the signature scheme.
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -217,9 +217,12 @@ macro_rules! impl_mod {
                 }
             }
 
+            /// An error when generating a signature key pair.
             #[derive(Debug)]
             pub enum KeygenError {
+                /// The length of the provided signing key buffer is incorrect.
                 WrongSigningKeyLength,
+                /// The length of the provided verification key buffer is incorrecct.
                 WrongVerificationKeyLength,
             }
         }

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,3 +1,4 @@
+use libcrux_secrets::Classify;
 use libcrux_traits::signature::{
     impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
 };
@@ -144,10 +145,14 @@ macro_rules! impl_mod {
             #[cfg(feature = "rand")]
             /// Generate an ML-DSA key pair
             pub fn generate(rng: &mut impl rand::CryptoRng) -> KeyPair {
-                use libcrux_secrets::Classify;
-
                 let mut bytes = [0u8; arrayref::$ty::RAND_KEYGEN_LEN];
                 rng.fill_bytes(&mut bytes);
+
+                Self::generate_derand(bytes.classify())
+            }
+
+            /// Generate an ML-DSA key pair (derand)
+            pub fn generate_derand(bytes: [U8; RAND_KEYGEN_LEN]) -> KeyPair {
                 let mut signing_key = [0u8; arrayref::$ty::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; arrayref::$ty::VERIFICATION_KEY_LEN];
                 arrayref::$ty::keygen(&mut signing_key, &mut verification_key, bytes.classify());

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,9 +1,5 @@
 use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
 
-// placeholder error implementation
-// TODO: more specific error
-#[derive(Debug)]
-pub struct Error;
 macro_rules! impl_mod {
     ($ty:ident, $module:ident) => {
         use libcrux_secrets::{Declassify, DeclassifyRef, DeclassifyRefMut, U8};

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -118,7 +118,11 @@ macro_rules! impl_mod {
                 rng.fill_bytes(&mut bytes);
                 let mut signing_key = [0u8; Self::SIGNING_KEY_LEN].classify();
                 let mut verification_key = [0u8; Self::VERIFICATION_KEY_LEN];
-                arrayref::$ty::keygen_derand(&mut signing_key, &mut verification_key, bytes.classify());
+                arrayref::$ty::keygen_derand(
+                    &mut signing_key,
+                    &mut verification_key,
+                    bytes.classify(),
+                );
 
                 KeyPair {
                     signing_key: SigningKey::from(signing_key),
@@ -127,6 +131,11 @@ macro_rules! impl_mod {
             }
         }
         impl arrayref::$ty {
+            /// Generate an ML-DSA signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign(
                 key: &[U8; Self::SIGNING_KEY_LEN],
                 payload: &[u8],
@@ -143,6 +152,11 @@ macro_rules! impl_mod {
                     signature,
                 )
             }
+            /// Generate a HashML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign_pre_hashed_shake128(
                 key: &[U8; Self::SIGNING_KEY_LEN],
                 payload: &[u8],
@@ -166,6 +180,11 @@ macro_rules! impl_mod {
                 Ok(())
             }
 
+            /// Verify an ML-DSA Signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify(
                 key: &[u8; Self::VERIFICATION_KEY_LEN],
                 payload: &[u8],
@@ -176,6 +195,12 @@ macro_rules! impl_mod {
                     key, payload, context, signature,
                 )
             }
+
+            /// Verify an ML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify_pre_hashed_shake128(
                 key: &[u8; Self::VERIFICATION_KEY_LEN],
                 payload: &[u8],
@@ -204,6 +229,11 @@ macro_rules! impl_mod {
             }
         }
         impl slice::$ty {
+            /// Generate an ML-DSA signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign(
                 key: &[U8],
                 payload: &[u8],
@@ -221,6 +251,12 @@ macro_rules! impl_mod {
                 arrayref::$ty::sign(&key, payload, signature, context, randomness)
                     .map_err(slice::SigningError::from)
             }
+
+            /// Generate a HashML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign_pre_hashed_shake128(
                 key: &[U8],
                 payload: &[u8],
@@ -240,6 +276,12 @@ macro_rules! impl_mod {
                 )
                 .map_err(slice::SigningError::from)
             }
+
+            /// Verify an ML-DSA Signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify(
                 key: &[u8],
                 payload: &[u8],
@@ -256,6 +298,12 @@ macro_rules! impl_mod {
                 arrayref::$ty::verify(key, payload, signature, context)
                     .map_err(slice::VerificationError::from)
             }
+
+            /// Verify an ML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify_pre_hashed_shake128(
                 key: &[u8],
                 payload: &[u8],
@@ -272,6 +320,9 @@ macro_rules! impl_mod {
                 arrayref::$ty::verify_pre_hashed_shake128(key, payload, signature, context)
                     .map_err(slice::VerificationError::from)
             }
+
+            /// Generate an ML-DSA Key Pair
+            #[cfg(not(eurydice))]
             pub fn keygen_derand(
                 signing_key: &mut [U8],
                 verification_key: &mut [u8],
@@ -290,6 +341,11 @@ macro_rules! impl_mod {
             }
         }
         impl<'a> SigningKeyRef<'a> {
+            /// Generate an ML-DSA signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign(
                 &self,
                 payload: &[u8],
@@ -299,6 +355,12 @@ macro_rules! impl_mod {
             ) -> Result<(), slice::SigningError> {
                 slice::$ty::sign(self.as_ref(), payload, signature, context, randomness)
             }
+
+            /// Generate a HashML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign_pre_hashed_shake128(
                 &self,
                 payload: &[u8],
@@ -316,6 +378,11 @@ macro_rules! impl_mod {
             }
         }
         impl<'a> VerificationKeyRef<'a> {
+            /// Verify an ML-DSA Signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify(
                 &self,
                 payload: &[u8],
@@ -324,6 +391,12 @@ macro_rules! impl_mod {
             ) -> Result<(), slice::VerificationError> {
                 slice::$ty::verify(self.as_ref(), payload, signature, context)
             }
+
+            /// Verify an ML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify_pre_hashed_shake128(
                 &self,
                 payload: &[u8],
@@ -336,6 +409,11 @@ macro_rules! impl_mod {
 
         // key-centric API
         impl SigningKey {
+            /// Generate an ML-DSA signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign(
                 &self,
                 payload: &[u8],
@@ -346,6 +424,12 @@ macro_rules! impl_mod {
                 arrayref::$ty::sign(self.as_ref(), payload, &mut signature, context, randomness)
                     .map(|_| Signature::from(signature))
             }
+
+            /// Generate a HashML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn sign_pre_hashed_shake128(
                 &self,
                 payload: &[u8],
@@ -364,6 +448,11 @@ macro_rules! impl_mod {
             }
         }
         impl VerificationKey {
+            /// Verify an ML-DSA Signature
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify(
                 &self,
                 payload: &[u8],
@@ -372,6 +461,12 @@ macro_rules! impl_mod {
             ) -> Result<(), crate::VerificationError> {
                 arrayref::$ty::verify(self.as_ref(), payload, signature.as_ref(), context)
             }
+
+            /// Verify an ML-DSA Signature, with a SHAKE128 pre-hashing
+            ///
+            /// The parameter `context` is used for domain separation
+            /// and is a byte string of length at most 255 bytes. It
+            /// may also be empty.
             pub fn verify_pre_hashed_shake128(
                 &self,
                 payload: &[u8],

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,4 +1,4 @@
-use libcrux_traits::signature::{impl_key_centric_types, impl_sign_traits, SignConsts};
+use libcrux_traits::signature::{impl_key_centric_types, impl_sign_consts, SignConsts};
 
 macro_rules! impl_mod {
     ($ty:ident, $module:ident) => {
@@ -73,7 +73,7 @@ macro_rules! impl_mod {
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;
-            impl_sign_traits!(
+            impl_sign_consts!(
                 $ty,
                 SIGNING_KEY_LEN,
                 VERIFICATION_KEY_LEN,

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -24,7 +24,7 @@ macro_rules! impl_mod {
         /// An incorrect length when converting from slice.
         pub struct WrongLengthError;
 
-        pub mod arrayref {
+        pub(crate) mod arrayref {
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;
@@ -39,6 +39,41 @@ macro_rules! impl_mod {
             );
         }
         pub mod slice {
+            //! Slice-based APIs for ML-DSA.
+            //!
+            //! Usage example:
+            //! ```rust
+            //! use libcrux_traits::signature::SignConsts;
+            //! use ml_dsa_44::slice::MlDsa44;
+            //!
+            //! let context = b"context";
+            //!
+            //! let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
+            //! let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
+            //! MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
+            //!
+            //! // slice API
+            //! let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
+            //! MlDsa44::sign(&signing_key, b"payload", &mut signature, context, [0u8; 32]).unwrap();
+            //! MlDsa44::verify(&verification_key, b"payload", &signature, context).unwrap();
+            //!
+            //! MlDsa44::sign_pre_hashed_shake128(
+            //!     signing_key.as_ref(),
+            //!     b"payload",
+            //!     &mut signature,
+            //!     context,
+            //!     [0u8; 32],
+            //! )
+            //! .unwrap();
+            //! MlDsa44::verify_pre_hashed_shake128(
+            //!     verification_key.as_ref(),
+            //!     b"payload",
+            //!     &signature,
+            //!     context,
+            //! )
+            //! .unwrap();
+            //! ```
+
             #[derive(Debug, PartialEq)]
             pub struct $ty;
             use super::*;
@@ -216,6 +251,7 @@ macro_rules! impl_mod {
                     signature,
                 )
             }
+            /// Generate an ML-DSA Key Pair
             pub fn keygen_derand(
                 signing_key: &mut [U8; Self::SIGNING_KEY_LEN],
                 verification_key: &mut [u8; Self::VERIFICATION_KEY_LEN],
@@ -564,10 +600,10 @@ fn key_centric_refs() {
         .unwrap();
 
     signing_key
-        .sign_pre_hashed_shake128(b"pre-hashed", &mut signature, context, [0u8; 32])
+        .sign_pre_hashed_shake128(b"payload", &mut signature, context, [0u8; 32])
         .unwrap();
     verification_key
-        .verify_pre_hashed_shake128(b"pre-hashed", &signature, context)
+        .verify_pre_hashed_shake128(b"payload", &signature, context)
         .unwrap();
 }
 
@@ -589,47 +625,8 @@ fn arrayref_apis() {
     MlDsa44::verify(&verification_key, b"payload", &signature, context).unwrap();
 
     // pre-hashed
-    MlDsa44::sign_pre_hashed_shake128(
-        &signing_key,
-        b"pre-hashed",
-        &mut signature,
-        context,
-        [0u8; 32],
-    )
-    .unwrap();
-    MlDsa44::verify_pre_hashed_shake128(&verification_key, b"pre-hashed", &signature, context)
+    MlDsa44::sign_pre_hashed_shake128(&signing_key, b"payload", &mut signature, context, [0u8; 32])
         .unwrap();
-}
-#[test]
-#[cfg(not(feature = "expose-secret-independence"))]
-fn slice_apis() {
-    use libcrux_traits::signature::SignConsts;
-    use ml_dsa_44::slice::MlDsa44;
-
-    let context = b"context";
-
-    let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
-    let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
-    MlDsa44::keygen_derand(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
-
-    // slice API
-    let mut signature = [0u8; MlDsa44::SIGNATURE_LEN];
-    MlDsa44::sign(&signing_key, b"payload", &mut signature, context, [0u8; 32]).unwrap();
-    MlDsa44::verify(&verification_key, b"payload", &signature, context).unwrap();
-
-    MlDsa44::sign_pre_hashed_shake128(
-        signing_key.as_ref(),
-        b"pre-hashed",
-        &mut signature,
-        context,
-        [0u8; 32],
-    )
-    .unwrap();
-    MlDsa44::verify_pre_hashed_shake128(
-        verification_key.as_ref(),
-        b"pre-hashed",
-        &signature,
-        context,
-    )
-    .unwrap();
+    MlDsa44::verify_pre_hashed_shake128(&verification_key, b"payload", &signature, context)
+        .unwrap();
 }

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -1,11 +1,10 @@
-use libcrux_secrets::Classify;
 use libcrux_traits::signature::{
     impl_key_centric_types, impl_sign_consts, SignConsts, WrongLengthError,
 };
 
 macro_rules! impl_mod {
     ($ty:ident, $module:ident) => {
-        use libcrux_secrets::{Declassify, DeclassifyRef, DeclassifyRefMut, U8};
+        use libcrux_secrets::{Classify, Declassify, DeclassifyRef, DeclassifyRefMut, U8};
 
         pub(super) const VERIFICATION_KEY_LEN: usize =
             crate::ml_dsa_generic::$module::VERIFICATION_KEY_SIZE;
@@ -588,7 +587,7 @@ fn key_centric_refs() {
 
     let mut signing_key = [0u8; MlDsa44::SIGNING_KEY_LEN];
     let mut verification_key = [0u8; MlDsa44::VERIFICATION_KEY_LEN];
-    MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]);
+    MlDsa44::keygen(&mut signing_key, &mut verification_key, [0; 32]).unwrap();
 
     // create references from slice
     let signing_key = SigningKeyRef::from_slice(&signing_key).unwrap();
@@ -614,7 +613,7 @@ fn key_centric_refs() {
 #[cfg(all(feature = "mldsa44", not(feature = "expose-secret-independence")))]
 fn arrayref_apis() {
     use libcrux_traits::signature::SignConsts;
-    use ml_dsa_44::MlDsa44;
+    use ml_dsa_44::arrayref::MlDsa44;
 
     let context = b"context";
 

--- a/libcrux-ml-dsa/src/key_centric_apis.rs
+++ b/libcrux-ml-dsa/src/key_centric_apis.rs
@@ -200,7 +200,7 @@ macro_rules! impl_mod {
                 randomness: [U8; 32],
             ) -> Result<(), crate::SigningError> {
                 // TODO: use mut version
-                let mut pre_hash_buffer = [0; 256];
+                let mut pre_hash_buffer = [0; 32];
                 let signature_out =
                     crate::ml_dsa_generic::multiplexing::$module::sign_pre_hashed_shake128(
                         key.declassify_ref().try_into().unwrap(),
@@ -242,7 +242,7 @@ macro_rules! impl_mod {
                 signature: &[u8; Self::SIGNATURE_LEN],
                 context: &[u8],
             ) -> Result<(), crate::VerificationError> {
-                let mut pre_hash_buffer = [0; 256];
+                let mut pre_hash_buffer = [0; 32];
                 crate::ml_dsa_generic::multiplexing::$module::verify_pre_hashed_shake128(
                     key,
                     payload,

--- a/libcrux-ml-dsa/src/lib.rs
+++ b/libcrux-ml-dsa/src/lib.rs
@@ -41,4 +41,4 @@ pub mod ml_dsa_65;
 pub mod ml_dsa_87;
 
 #[cfg(not(hax))]
-pub mod key_centric_apis;
+pub(crate) mod key_centric_apis;

--- a/libcrux-ml-dsa/src/lib.rs
+++ b/libcrux-ml-dsa/src/lib.rs
@@ -39,3 +39,6 @@ pub mod ml_dsa_65;
 
 #[cfg(feature = "mldsa87")]
 pub mod ml_dsa_87;
+
+#[cfg(not(hax))]
+pub mod key_centric_apis;

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- [#1241](https://github.com/cryspen/libcrux/pull/1241): Add helper traits and macros for signatures
+
 ## [0.0.4] (2025-11-05)
 
 - [#1190](https://github.com/cryspen/libcrux/pull/1190): Use secret types in kem traits

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -23,3 +23,7 @@ alloc = []
 [dependencies]
 rand = { version = "0.9", default-features = false }
 libcrux-secrets = { version = "=0.0.4", path = "../crates/utils/secrets" }
+
+[dev-dependencies]
+# used for rustdocs
+libcrux-signature = { path = "../crates/primitives/signature" }

--- a/traits/Cargo.toml
+++ b/traits/Cargo.toml
@@ -27,3 +27,4 @@ libcrux-secrets = { version = "=0.0.4", path = "../crates/utils/secrets" }
 [dev-dependencies]
 # used for rustdocs
 libcrux-signature = { path = "../crates/primitives/signature" }
+rand = { version = "0.9", features = ["os_rng"] }

--- a/traits/src/lib.rs
+++ b/traits/src/lib.rs
@@ -26,5 +26,7 @@ pub mod aead;
 pub mod digest;
 pub mod ecdh;
 pub mod kem;
+pub mod signature;
 
 pub use libcrux_secrets;
+pub use rand;

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -47,9 +47,7 @@
 //! payload, followed by a `signature: &[u8]` representing the signature.
 //!
 //!  ```rust
-//! use libcrux_signature::ed25519::{
-//!     Ed25519, KeyPair, SigningKey, VerificationKey, SigningKeyRef, VerificationKeyRef,
-//! };
+//! use libcrux_signature::ed25519::{Ed25519, KeyPair, SigningKey, VerificationKey};
 //! use libcrux_traits::signature::SignConsts;
 //!
 //! // generate a new signature keypair

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -64,6 +64,7 @@ macro_rules! impl_key_centric_types {
             $rand_keygen_len
         );
 
+        /// A signing key. The bytes are borrowed.
         pub struct SigningKeyRef<'a> {
             key: &'a [U8],
         }
@@ -77,27 +78,36 @@ macro_rules! impl_key_centric_types {
                 self.key.as_ref()
             }
         }
+
+        /// A verification key. The bytes are borrowed.
         pub struct VerificationKeyRef<'a> {
             key: &'a [u8],
         }
 
+        /// A signing key. The bytes are owned.
         pub struct SigningKey {
             key: SigningKeyArray,
         }
+
+        /// A verification key. The bytes are owned.
         pub struct VerificationKey {
             key: VerificationKeyArray,
         }
+
+        /// A signature.
         #[derive(Debug, PartialEq)]
         pub struct Signature {
             signature: SignatureArray,
         }
 
+        /// A key pair, containing a [`SigningKey`] and a [`VerificationKey`].
         pub struct KeyPair {
             pub signing_key: SigningKey,
             pub verification_key: VerificationKey,
         }
 
         impl<'a> SigningKeyRef<'a> {
+            /// Create a signing key from a byte slice.
             pub fn from_slice(key: &'a [U8]) -> Result<Self, $from_slice_error> {
                 if key.len() != $signing_key_len {
                     return Err($from_slice_error_variant);
@@ -123,7 +133,9 @@ macro_rules! impl_key_centric_types {
                 &self.key
             }
         }
+
         impl<'a> VerificationKeyRef<'a> {
+            /// Create a verification key from a byte slice.
             pub fn from_slice(key: &'a [u8]) -> Result<Self, $from_slice_error> {
                 if key.len() != $verification_key_len {
                     return Err($from_slice_error_variant);

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -59,7 +59,6 @@ pub use impl_sign_consts;
 #[macro_export]
 macro_rules! impl_key_centric_types {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr, $from_slice_error:ty, $from_slice_error_variant:expr) => {
-        use $crate::libcrux_secrets::U8;
         $crate::signature::impl_sign_consts!(
             $algorithm,
             $signing_key_len,
@@ -69,16 +68,16 @@ macro_rules! impl_key_centric_types {
         );
 
         // internal types
-        type SigningKeyArray = [U8; $signing_key_len];
+        type SigningKeyArray = [$crate::libcrux_secrets::U8; $signing_key_len];
         type VerificationKeyArray = [u8; $verification_key_len];
         type SignatureArray = [u8; $signature_len];
 
         /// A signing key. The bytes are borrowed.
         pub struct SigningKeyRef<'a> {
-            key: &'a [U8],
+            key: &'a [$crate::libcrux_secrets::U8],
         }
-        impl<'a> AsRef<[U8]> for SigningKeyRef<'a> {
-            fn as_ref(&self) -> &[U8] {
+        impl<'a> AsRef<[$crate::libcrux_secrets::U8]> for SigningKeyRef<'a> {
+            fn as_ref(&self) -> &[$crate::libcrux_secrets::U8] {
                 self.key.as_ref()
             }
         }
@@ -117,7 +116,9 @@ macro_rules! impl_key_centric_types {
 
         impl<'a> SigningKeyRef<'a> {
             /// Create a signing key from a byte slice.
-            pub fn from_slice(key: &'a [U8]) -> Result<Self, $from_slice_error> {
+            pub fn from_slice(
+                key: &'a [$crate::libcrux_secrets::U8],
+            ) -> Result<Self, $from_slice_error> {
                 if key.len() != $signing_key_len {
                     return Err($from_slice_error_variant);
                 } else {
@@ -132,8 +133,8 @@ macro_rules! impl_key_centric_types {
             }
         }
 
-        impl AsRef<[U8]> for SigningKey {
-            fn as_ref(&self) -> &[U8] {
+        impl AsRef<[$crate::libcrux_secrets::U8]> for SigningKey {
+            fn as_ref(&self) -> &[$crate::libcrux_secrets::U8] {
                 self.key.as_ref()
             }
         }

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -60,6 +60,10 @@
 //! verification_key.verify(b"payload", &signature).unwrap();
 //!  ```
 
+#[derive(Debug)]
+/// An incorrect length when converting from slice.
+pub struct WrongLengthError;
+
 /// Constants defining the sizes of cryptographic elements for a signature algorithm.
 pub trait SignConsts {
     /// Length of verification (public) keys in bytes.

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -92,6 +92,33 @@ macro_rules! impl_sign_consts {
 pub use impl_sign_consts;
 
 /// Helper macro for implementing types for key-centric APIs
+///
+/// The [`impl_key_centric_types!()`] macro can be used to conveniently define types
+/// used by key-centric signature APIs.
+/// - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys.
+/// - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys.
+/// - `Signature`: an owned signature.
+/// - `KeyPair`: an owned signature keypair (contains a `SigningKey` and a `VerificationKey`)
+///
+/// It also implements some traits and methods on the structs:
+/// - SigningKey:
+///   - `AsRef<[libcrux_secrets::U8]>`
+///   - `AsRef<[libcrux_secrets::U8; $signing_key_len]>`
+///   - `From<[libcrux_secrets::U8; $signing_key_len]`
+/// - SigningKeyRef:
+///   - `AsRef<[libcrux_secrets::U8]>`
+///   - `from_slice(&[libcrux_secrets::U8])`
+/// - VerificationKey:
+///   - `AsRef<[u8]>`
+///   - `AsRef<[u8; $verification_key_len]>`
+///   - `From<[u8; $verification_key_len]`
+/// - VerificationKeyRef:
+///   - `AsRef<[u8]>`
+///   - `from_slice(&[u8])`
+/// - Signature:
+///   - `AsRef<[u8]>`
+///   - `AsRef<[u8; $signature_len]>`
+///   - `From<[u8; $signature_len]`
 #[macro_export]
 macro_rules! impl_key_centric_types {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr, $from_slice_error:ty, $from_slice_error_variant:expr) => {

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -1,0 +1,168 @@
+//! This module provides common interface traits for signature scheme implementations.
+
+/// Constants defining the sizes of cryptographic elements for a signature algorithm.
+pub trait SignConsts {
+    /// Length of verification (public) keys in bytes.
+    const VERIFICATION_KEY_LEN: usize;
+    /// Length of signing (private) keys in bytes.
+    const SIGNING_KEY_LEN: usize;
+    /// Length of signatures in bytes.
+    const SIGNATURE_LEN: usize;
+    /// Length of randomness required for key generation in bytes.
+    const RAND_KEYGEN_LEN: usize;
+}
+
+/// Associated types for signature algorithm components.
+///
+/// This trait defines the concrete types used by a signature algorithm for keys,
+/// signatures, randomness, and auxiliary signing data.
+pub trait SignTypes {
+    /// The type representing signing (private) keys.
+    type SigningKey;
+    /// The type representing verification (public) keys.
+    type VerificationKey;
+    /// The type representing signatures.
+    type Signature;
+}
+
+/// Helper macro for implementing signing-related traits
+#[macro_export]
+macro_rules! impl_sign_traits {
+    ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr) => {
+        use $crate::libcrux_secrets::U8;
+        impl $crate::signature::SignConsts for $algorithm {
+            const SIGNING_KEY_LEN: usize = $signing_key_len;
+            const VERIFICATION_KEY_LEN: usize = $verification_key_len;
+            const SIGNATURE_LEN: usize = $signature_len;
+            const RAND_KEYGEN_LEN: usize = $rand_keygen_len;
+        }
+
+        // internal types
+        type SigningKeyArray = [U8; $signing_key_len];
+        type VerificationKeyArray = [u8; $verification_key_len];
+        type SignatureArray = [u8; $signature_len];
+
+        impl $crate::signature::SignTypes for $algorithm {
+            type SigningKey = SigningKeyArray;
+            type VerificationKey = VerificationKeyArray;
+            type Signature = SignatureArray;
+        }
+    };
+}
+
+pub use impl_sign_traits;
+
+/// Helper macro for implementing types for key-centric APIs
+#[macro_export]
+macro_rules! impl_key_centric_types {
+    ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr, $from_slice_error:ty, $from_slice_error_variant:expr) => {
+        impl_sign_traits!(
+            $algorithm,
+            $signing_key_len,
+            $verification_key_len,
+            $signature_len,
+            $rand_keygen_len
+        );
+
+        pub struct SigningKeyRef<'a> {
+            key: &'a [U8],
+        }
+        impl<'a> AsRef<[U8]> for SigningKeyRef<'a> {
+            fn as_ref(&self) -> &[U8] {
+                self.key.as_ref()
+            }
+        }
+        impl<'a> AsRef<[u8]> for VerificationKeyRef<'a> {
+            fn as_ref(&self) -> &[u8] {
+                self.key.as_ref()
+            }
+        }
+        pub struct VerificationKeyRef<'a> {
+            key: &'a [u8],
+        }
+
+        pub struct SigningKey {
+            key: SigningKeyArray,
+        }
+        pub struct VerificationKey {
+            key: VerificationKeyArray,
+        }
+        #[derive(Debug, PartialEq)]
+        pub struct Signature {
+            signature: SignatureArray,
+        }
+
+        pub struct KeyPair {
+            pub signing_key: SigningKey,
+            pub verification_key: VerificationKey,
+        }
+
+        impl<'a> SigningKeyRef<'a> {
+            pub fn from_slice(key: &'a [U8]) -> Result<Self, $from_slice_error> {
+                if key.len() != $signing_key_len {
+                    return Err($from_slice_error_variant);
+                } else {
+                    return Ok(Self { key });
+                }
+            }
+        }
+
+        impl From<SigningKeyArray> for SigningKey {
+            fn from(key: SigningKeyArray) -> Self {
+                Self { key }
+            }
+        }
+
+        impl AsRef<[U8]> for SigningKey {
+            fn as_ref(&self) -> &[U8] {
+                self.key.as_ref()
+            }
+        }
+        impl AsRef<SigningKeyArray> for SigningKey {
+            fn as_ref(&self) -> &SigningKeyArray {
+                &self.key
+            }
+        }
+        impl<'a> VerificationKeyRef<'a> {
+            pub fn from_slice(key: &'a [u8]) -> Result<Self, $from_slice_error> {
+                if key.len() != $verification_key_len {
+                    return Err($from_slice_error_variant);
+                } else {
+                    return Ok(Self { key });
+                }
+            }
+        }
+        impl From<VerificationKeyArray> for VerificationKey {
+            fn from(key: VerificationKeyArray) -> Self {
+                Self { key }
+            }
+        }
+        impl AsRef<[u8]> for VerificationKey {
+            fn as_ref(&self) -> &[u8] {
+                self.key.as_ref()
+            }
+        }
+        impl AsRef<VerificationKeyArray> for VerificationKey {
+            fn as_ref(&self) -> &VerificationKeyArray {
+                &self.key
+            }
+        }
+        impl AsRef<[u8]> for Signature {
+            fn as_ref(&self) -> &[u8] {
+                self.signature.as_ref()
+            }
+        }
+        impl AsRef<SignatureArray> for Signature {
+            fn as_ref(&self) -> &SignatureArray {
+                &self.signature
+            }
+        }
+        impl From<SignatureArray> for Signature {
+            fn from(signature: SignatureArray) -> Self {
+                Self { signature }
+            }
+        }
+    };
+}
+
+pub use impl_key_centric_types;

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -27,6 +27,40 @@
 //! assert_eq!(MlDsa44::RAND_KEYGEN_LEN, 32);
 //! ```
 //!
+//! ### Implementing key-centric APIs
+//!
+//! The [`impl_key_centric_types!()`] macro can be used to conveniently define types
+//! used by key-centric signature APIs.
+//! - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys.
+//! - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys.
+//! - `Signature`: an owned signature.
+//! - `KeyPair`: an owned signature keypair (contains a `SigningKey` and a `VerificationKey`)
+//!
+//! Key-centric APIs can be defined on the above structs.
+//! - `SigningKey::sign()`: The first argument should be the `payload`, followed by other
+//! arguments. This API should return an owned `Signature`.
+//! - `SigningKeyRef::sign()`: The first argument should be the `payload`, followed by a
+//! `signature: &mut [u8]` representing the signature buffer to write into.
+//! - `VerificationKey::verify()`: The first argument should be a slice representing the payload,
+//! followed by a reference to a `Signature`.
+//! - `VerificationKeyRef::verify()`: The first argument should be a slice representing the
+//! payload, followed by a `signature: &[u8]` representing the signature.
+//!
+//!  ```rust
+//! use libcrux_signature::ed25519::{
+//!     Ed25519, KeyPair, SigningKey, VerificationKey, SigningKeyRef, VerificationKeyRef,
+//! };
+//! use libcrux_traits::signature::SignConsts;
+//!
+//! // generate a new signature keypair
+//! use rand::TryRngCore;
+//! let mut rng = rand::rngs::OsRng;
+//! let KeyPair { signing_key, verification_key } = KeyPair::generate(&mut rng.unwrap_mut());
+//!
+//! // sign and verify
+//! let signature = signing_key.sign(b"payload").unwrap();
+//! verification_key.verify(b"payload", &signature).unwrap();
+//!  ```
 
 /// Constants defining the sizes of cryptographic elements for a signature algorithm.
 pub trait SignConsts {

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -31,8 +31,8 @@
 //!
 //! The [`impl_key_centric_types!()`] macro can be used to conveniently define types
 //! used by key-centric signature APIs.
-//! - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys.
-//! - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys.
+//! - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys, respectively.
+//! - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys, respectively.
 //! - `Signature`: an owned signature.
 //! - `KeyPair`: an owned signature keypair (contains a `SigningKey` and a `VerificationKey`)
 //!
@@ -95,8 +95,8 @@ pub use impl_sign_consts;
 ///
 /// The [`impl_key_centric_types!()`] macro can be used to conveniently define types
 /// used by key-centric signature APIs.
-/// - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys.
-/// - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys.
+/// - `SigningKey`, `SigningKeyRef`: owned and borrowed signing keys, respectively.
+/// - `VerificationKey`, `VerificationKeyRef`: owned and borrowed verification keys, respectively.
 /// - `Signature`: an owned signature.
 /// - `KeyPair`: an owned signature keypair (contains a `SigningKey` and a `VerificationKey`)
 ///

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -44,7 +44,6 @@ pub trait SignConsts {
 #[macro_export]
 macro_rules! impl_sign_consts {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr) => {
-        use $crate::libcrux_secrets::U8;
         impl $crate::signature::SignConsts for $algorithm {
             const SIGNING_KEY_LEN: usize = $signing_key_len;
             const VERIFICATION_KEY_LEN: usize = $verification_key_len;
@@ -60,6 +59,7 @@ pub use impl_sign_consts;
 #[macro_export]
 macro_rules! impl_key_centric_types {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr, $from_slice_error:ty, $from_slice_error_variant:expr) => {
+        use $crate::libcrux_secrets::U8;
         $crate::signature::impl_sign_consts!(
             $algorithm,
             $signing_key_len,

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -1,6 +1,6 @@
-//! This module provides common interface traits and helper macros for signature scheme implementations.
+//! This module provides a common [`SignConsts`] trait and helper macros for signature scheme implementations.
 //!
-//! Instead of a fully trait-based API for signature operations, this crate provides traits and
+//! Instead of a fully trait-based API for signature operations, this crate provides a trait and
 //! macros that can be used to implement signature APIs with a given shape.
 //!
 //! ### Defining useful constants with the [`SignConsts`] trait

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -27,9 +27,6 @@
 //! assert_eq!(MlDsa44::RAND_KEYGEN_LEN, 32);
 //! ```
 //!
-//! ### Defining associated types with the [`SignTypes`] trait
-//!
-//! The [`SignTypes`] trait can be used to define associated types for signature algorithms.
 
 /// Constants defining the sizes of cryptographic elements for a signature algorithm.
 pub trait SignConsts {
@@ -43,22 +40,9 @@ pub trait SignConsts {
     const RAND_KEYGEN_LEN: usize;
 }
 
-/// Associated types for signature algorithm components.
-///
-/// This trait defines the concrete types used by a signature algorithm for keys,
-/// signatures, randomness, and auxiliary signing data.
-pub trait SignTypes {
-    /// The type representing signing (private) keys.
-    type SigningKey;
-    /// The type representing verification (public) keys.
-    type VerificationKey;
-    /// The type representing signatures.
-    type Signature;
-}
-
-/// Helper macro for implementing signing-related traits
+/// Helper macro for implementing the [`SignConsts`] trait.
 #[macro_export]
-macro_rules! impl_sign_traits {
+macro_rules! impl_sign_consts {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr) => {
         use $crate::libcrux_secrets::U8;
         impl $crate::signature::SignConsts for $algorithm {
@@ -67,33 +51,27 @@ macro_rules! impl_sign_traits {
             const SIGNATURE_LEN: usize = $signature_len;
             const RAND_KEYGEN_LEN: usize = $rand_keygen_len;
         }
-
-        // internal types
-        type SigningKeyArray = [U8; $signing_key_len];
-        type VerificationKeyArray = [u8; $verification_key_len];
-        type SignatureArray = [u8; $signature_len];
-
-        impl $crate::signature::SignTypes for $algorithm {
-            type SigningKey = SigningKeyArray;
-            type VerificationKey = VerificationKeyArray;
-            type Signature = SignatureArray;
-        }
     };
 }
 
-pub use impl_sign_traits;
+pub use impl_sign_consts;
 
 /// Helper macro for implementing types for key-centric APIs
 #[macro_export]
 macro_rules! impl_key_centric_types {
     ($algorithm:ty, $signing_key_len:expr, $verification_key_len:expr, $signature_len:expr, $rand_keygen_len:expr, $from_slice_error:ty, $from_slice_error_variant:expr) => {
-        impl_sign_traits!(
+        $crate::signature::impl_sign_consts!(
             $algorithm,
             $signing_key_len,
             $verification_key_len,
             $signature_len,
             $rand_keygen_len
         );
+
+        // internal types
+        type SigningKeyArray = [U8; $signing_key_len];
+        type VerificationKeyArray = [u8; $verification_key_len];
+        type SignatureArray = [u8; $signature_len];
 
         /// A signing key. The bytes are borrowed.
         pub struct SigningKeyRef<'a> {

--- a/traits/src/signature.rs
+++ b/traits/src/signature.rs
@@ -1,4 +1,35 @@
-//! This module provides common interface traits for signature scheme implementations.
+//! This module provides common interface traits and helper macros for signature scheme implementations.
+//!
+//! Instead of a fully trait-based API for signature operations, this crate provides traits and
+//! macros that can be used to implement signature APIs with a given shape.
+//!
+//! ### Defining useful constants with the [`SignConsts`] trait
+//!
+//! Structs that implement the [`SignConsts`] trait allow retrieving useful constants for that
+//! signature algorithm. These can be used as the lengths of new buffers representing the
+//! signing key, verification key, signature, or the randomness input to keygen functions.
+//!
+//! Example:
+//! ```rust
+//! use libcrux_traits::signature::SignConsts;
+//! use libcrux_signature::mldsa::ml_dsa_44::MlDsa44;
+//!
+//! // the length of the signing key in bytes.
+//! assert_eq!(MlDsa44::SIGNING_KEY_LEN, 2560);
+//!
+//! // the length of the verification key in bytes.
+//! assert_eq!(MlDsa44::VERIFICATION_KEY_LEN, 1312);
+//!
+//! // the length of the signature in bytes.
+//! assert_eq!(MlDsa44::SIGNATURE_LEN, 2420);
+//!
+//! // the length of the rand_keygen buffer in bytes.
+//! assert_eq!(MlDsa44::RAND_KEYGEN_LEN, 32);
+//! ```
+//!
+//! ### Defining associated types with the [`SignTypes`] trait
+//!
+//! The [`SignTypes`] trait can be used to define associated types for signature algorithms.
 
 /// Constants defining the sizes of cryptographic elements for a signature algorithm.
 pub trait SignConsts {


### PR DESCRIPTION
- [x] Implement key-centric and slice-based signature public APIs for `libcrux-ml-dsa`, `libcrux-ed25519`, and `libcrux-ecdsa`
- [x] Include macros in `libcrux-traits` crate that reduce boilerplate in signature API implementations in crates
- [x] Add `libcrux-signature` crate
- [x] Implement internal `sign_mut()` in `libcrux-ml-dsa` (moved from the change in #1080 )
- [x] Update changelogs
- [ ] Additional documentation as needed

Resolves #1034 