### PR TITLE
feat(ml-kem): add zeroize support and tests

### DIFF
--- a/crates/utils/intrinsics/src/arm64.rs
+++ b/crates/utils/intrinsics/src/arm64.rs
@@ -492,3 +492,8 @@ pub fn _vdupq_n_u8(value: u8) -> uint8x16_t {
 pub fn _vdupq_laneq_u32<const N: i32>(a: uint32x4_t) -> uint32x4_t {
     unsafe { vdupq_laneq_u32(a, N) }
 }
+
+#[inline(always)]
+pub fn _vmaxvq_u8(v: uint8x16_t) -> u8 {
+    unsafe { vmaxvq_u8(v) }
+}

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -32,6 +32,7 @@ hax-lib.workspace = true
 tls_codec = { version = "0.4.2", features = [
     "derive",
 ], default-features = false, optional = true }
+zeroize = { version = "1.8", optional = true, default-features = false}
 
 [features]
 # By default all variants and std are enabled.
@@ -64,6 +65,9 @@ alloc = []
 
 # Incremental encapsulation API
 incremental = []
+
+# Feature for zeroize
+zeroize = ["dep:zeroize"]
 
 # Checking secret independence
 check-secret-independence = [

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -48,6 +48,11 @@ mod utils;
 mod variant;
 mod vector;
 
+
+#[cfg(all(feature = "zeroize", not(hax)))]
+#[cfg_attr(docsrs, doc(cfg(feature = "zeroize")))]
+pub mod zeroize;
+
 #[cfg(feature = "pqcp")]
 pub(crate) mod pqcp;
 

--- a/libcrux-ml-kem/src/vector/avx2.rs
+++ b/libcrux-ml-kem/src/vector/avx2.rs
@@ -11,7 +11,7 @@ mod serialize;
 #[hax_lib::fstar::before(interface, "noeq")]
 #[hax_lib::fstar::after(interface,"let repr (x:t_SIMD256Vector) : t_Array i16 (sz 16) = Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 x.f_elements")]
 pub struct SIMD256Vector {
-    elements: Vec256,
+    pub(crate) elements: Vec256,
 }
 
 #[inline(always)]

--- a/libcrux-ml-kem/src/zeroize.rs
+++ b/libcrux-ml-kem/src/zeroize.rs
@@ -1,0 +1,337 @@
+use crate::{
+    ind_cca::unpacked::{MlKemKeyPairUnpacked, MlKemPrivateKeyUnpacked},
+    ind_cpa::unpacked::IndCpaPrivateKeyUnpacked,
+    polynomial::PolynomialRingElement,
+    vector::{portable::PortableVector, Operations},
+    MlKemKeyPair, MlKemPrivateKey,
+};
+
+#[cfg(feature = "simd256")]
+use crate::vector::SIMD256Vector;
+
+#[cfg(feature = "simd128")]
+use crate::vector::SIMD128Vector;
+
+impl<const SIZE: usize> zeroize::Zeroize for MlKemPrivateKey<SIZE> {
+    fn zeroize(&mut self) {
+        self.value.zeroize();
+    }
+}
+impl<const SIZE: usize> zeroize::ZeroizeOnDrop for MlKemPrivateKey<SIZE> {}
+
+impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize> zeroize::Zeroize
+    for MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE>
+{
+    fn zeroize(&mut self) {
+        self.sk.zeroize();
+    }
+}
+impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize> zeroize::ZeroizeOnDrop
+    for MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE>
+{
+}
+
+impl<Vector: Operations + zeroize::Zeroize> zeroize::Zeroize for PolynomialRingElement<Vector> {
+    fn zeroize(&mut self) {
+        self.coefficients.zeroize();
+    }
+}
+impl<Vector: Operations + zeroize::Zeroize> zeroize::ZeroizeOnDrop for PolynomialRingElement<Vector> {}
+
+
+impl<const SIZE: usize, Vector: Operations + zeroize::Zeroize> zeroize::Zeroize
+    for MlKemPrivateKeyUnpacked<SIZE, Vector>
+{
+    fn zeroize(&mut self) {
+        self.implicit_rejection_value.zeroize();
+        self.ind_cpa_private_key.zeroize();
+    }
+}
+impl<const SIZE: usize, Vector: Operations + zeroize::Zeroize> zeroize::ZeroizeOnDrop
+    for MlKemPrivateKeyUnpacked<SIZE, Vector>
+{
+}
+
+impl<const SIZE: usize, Vector: Operations + zeroize::Zeroize> zeroize::Zeroize
+    for IndCpaPrivateKeyUnpacked<SIZE, Vector>
+{
+    fn zeroize(&mut self) {
+        self.secret_as_ntt.zeroize();
+    }
+}
+impl<const SIZE: usize, Vector: Operations + zeroize::Zeroize> zeroize::ZeroizeOnDrop
+    for IndCpaPrivateKeyUnpacked<SIZE, Vector>
+{
+}
+
+impl<const K: usize, Vector: Operations + zeroize::Zeroize> zeroize::Zeroize
+    for MlKemKeyPairUnpacked<K, Vector>
+{
+    fn zeroize(&mut self) {
+        self.private_key.zeroize();
+    }
+}
+impl<const K: usize, Vector: Operations + zeroize::Zeroize> zeroize::ZeroizeOnDrop
+    for MlKemKeyPairUnpacked<K, Vector>
+{
+}
+
+// Don't implement ZeroizeOnDrop for vector types for performance reasons
+impl zeroize::Zeroize for PortableVector {
+    fn zeroize(&mut self) {
+        self.elements.zeroize();
+    }
+}
+
+#[cfg(feature = "simd128")]
+impl zeroize::Zeroize for SIMD128Vector {
+    fn zeroize(&mut self) {
+        // Overwrite the SIMD registers (or memory backing them) with zeros.
+        let zero = SIMD128Vector::ZERO();
+        self.low = zero.low;
+        self.high = zero.high;
+
+        // Prevent Dead Store Elimination (DSE).
+        // black_box forces the compiler to treat the memory as used, ensuring
+        // the zeroing instructions aren't optimized away.
+        //
+        // Checking the assembly output on a Macbook M1 shows that this successfully
+        // pushes the compiler to preserve the needed instructions in Debug and Release.
+        core::hint::black_box(self);
+    }
+}
+
+#[cfg(feature = "simd256")]
+impl zeroize::Zeroize for SIMD256Vector {
+    fn zeroize(&mut self) {
+        // AVX2 registers implemented natively by zeroize crate
+        self.elements.zeroize();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        hash_functions::portable::PortableHash,
+        mlkem768::{MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey},
+        variant::MlKem,
+    };
+    use zeroize::Zeroize;
+
+    // Using black_box forces the CPU to perform an actual memory
+    // fetch and comparison, ensuring the test validates the physical state
+    // of the memory rather than a compiler-level assumption.
+    trait CheckZero {
+        fn is_zero(slice: &[Self]) -> bool
+        where
+            Self: Sized;
+    }
+
+    impl CheckZero for u8 {
+        #[inline(never)]
+        fn is_zero(slice: &[u8]) -> bool {
+            slice.iter().all(|&byte| core::hint::black_box(byte) == 0)
+        }
+    }
+
+    impl CheckZero for i16 {
+        #[inline(never)]
+        fn is_zero(slice: &[i16]) -> bool {
+            // We still check the i16 value, but black_box the whole 16-bit word
+            slice.iter().all(|&val| core::hint::black_box(val) == 0)
+        }
+    }
+
+    #[test]
+    fn test_is_zero_sanity_check() {
+        {
+            let mut canary = [0xFFu8; 32];
+
+            // Wrap in black_box so the compiler doesn't "pre-calculate" the result.
+            let is_it_zero = u8::is_zero(core::hint::black_box(&canary));
+
+            assert!(!is_it_zero, "is_zero should have detected the 0xFF bytes");
+            canary.zeroize();
+            let is_it_zero_now = u8::is_zero(core::hint::black_box(&canary));
+
+            assert!(
+                is_it_zero_now,
+                "is_zero should return true after manual zeroing"
+            );
+        }
+
+        {
+            let mut canary = [0x4444i16; 16];
+
+            // Wrap in black_box so the compiler doesn't "pre-calculate" the result.
+            let is_it_zero = i16::is_zero(core::hint::black_box(&canary));
+
+            assert!(!is_it_zero, "is_zero should have detected the 0xFF bytes");
+            canary.zeroize();
+            let is_it_zero_now = i16::is_zero(core::hint::black_box(&canary));
+
+            assert!(
+                is_it_zero_now,
+                "is_zero should return true after manual zeroing"
+            );
+        }
+    }
+
+    #[test]
+    fn mlkem_private_key() {
+        // Create a dummy private key with non-zero data
+        let sk_bytes = [0xFFu8; 2400]; // Size for Kyber768 roughly
+        let mut sk = MlKem768PrivateKey::from(sk_bytes);
+
+        // Verify it's not zero initially
+        assert!(!u8::is_zero(&sk.as_ref()), "Key should start non-zero");
+        sk.zeroize();
+
+        // Verify it is now zero
+        assert!(
+            u8::is_zero(&sk.as_ref()),
+            "Key should be zeroed after zeroize()"
+        );
+    }
+
+    #[test]
+    fn mlkem_keypair() {
+        // Setup dummy keys
+        let sk_bytes = [0xAAu8; 2400];
+        let pk_bytes = [0xBBu8; 1184];
+        let sk = MlKem768PrivateKey::from(sk_bytes);
+        let pk = MlKem768PublicKey::from(pk_bytes);
+
+        let mut keypair = MlKem768KeyPair::from(sk, pk);
+
+        // Check internal private key is not zero
+        assert!(!u8::is_zero(&keypair.sk().as_ref()));
+
+        // Zeroize the pair
+        keypair.zeroize();
+
+        // Check private key is zeroed
+        assert!(
+            u8::is_zero(&keypair.sk().as_ref()),
+            "Private key inside pair should be zeroed"
+        );
+    }
+
+    #[test]
+    fn portable_vector() {
+        let mut vec = PortableVector::from_bytes(&[0xFF; 32]);
+
+        vec.zeroize();
+
+        assert!(
+            i16::is_zero(vec.elements.as_ref()),
+            "Element was not zeroed"
+        );
+    }
+
+    #[test]
+    #[cfg(feature = "simd128")]
+    fn simd128_vector() {
+        if !std::arch::is_aarch64_feature_detected!("neon") {
+            return;
+        }
+
+        let mut vec = SIMD128Vector::from_bytes(&[0xFF; 32]);
+
+        vec.zeroize();
+
+        // Security Verification:
+        // Manual inspection of the assembly for this test on AArch64 (Apple M1)
+        // confirms that the compiler does NOT optimize this check away.
+        //
+        // The resulting binary uses `stp` (Store Pair) to write zeros to the
+        // stack/memory and `umaxv.16b` (Unsigned Maximum Across Vector) to
+        // perform the horizontal reduction for the zero check. The use of
+        // `black_box` prevents Dead Store Elimination, forcing the CPU to
+        // physically verify the state of the registers/memory.
+        let opaque_vec = core::hint::black_box(vec);
+
+        let low_bytes = libcrux_intrinsics::arm64::_vreinterpretq_u8_s16(opaque_vec.low);
+        let high_bytes = libcrux_intrinsics::arm64::_vreinterpretq_u8_s16(opaque_vec.high);
+
+        let low_max = libcrux_intrinsics::arm64::_vmaxvq_u8(low_bytes);
+        let high_max = libcrux_intrinsics::arm64::_vmaxvq_u8(high_bytes);
+
+        assert_eq!(low_max, 0, "Low 128 bits were not zeroed");
+        assert_eq!(high_max, 0, "High 128 bits were not zeroed");
+    }
+
+    #[test]
+    #[cfg(feature = "simd256")]
+    fn simd256_vector() {
+        if !std::is_x86_feature_detected!("avx2") {
+            return;
+        }
+
+        let mut vec = SIMD256Vector::from_bytes(&[0xFF; 32]);
+
+        vec.zeroize();
+
+        // Security Verification:
+        // Manual inspection of the assembly for this test (via RUSTFLAGS="--emit asm")
+        // confirms that the compiler does NOT optimize this check away.
+        //
+        // The resulting binary uses `vmovdqa` to load the memory and `vptest`
+        // to verify the bits. The presence of the #APP/#NO_APP (black_box)
+        // markers ensures that Dead Store Elimination is bypassed, forcing
+        // the CPU to physically confirm the RAM is zeroed.
+        let opaque_vec = core::hint::black_box(vec);
+        assert!(
+            libcrux_intrinsics::avx2::mm256_testz_si256(opaque_vec.elements, opaque_vec.elements)
+                != 0,
+            "Element was not zeroed"
+        );
+    }
+
+    #[test]
+    fn unpacked_keypair_cascade() {
+        let randomness = [0x42u8; 64]; // Deterministic seed
+        let mut unpacked = MlKemKeyPairUnpacked::<3, PortableVector>::new(); // Rank 3 = Kyber768
+
+        crate::ind_cca::unpacked::generate_keypair::<
+            3,               // Rank 3 = Kyber768
+            1152,            // CPA_PRIVATE_KEY_SIZE (3 * 384)
+            2400,            // PRIVATE_KEY_SIZE
+            1184,            // PUBLIC_KEY_SIZE
+            2,               // ETA1
+            128,             // ETA1_RANDOMNESS_SIZE (64 * ETA1)
+            PortableVector,  // Vector Type
+            PortableHash<3>, // Hasher Type
+            MlKem,           // Variant Scheme
+        >(randomness, &mut unpacked);
+
+        // Sanity check: ensure Implicit Rejection Value is set
+        let irv_before = unpacked.private_key.implicit_rejection_value;
+        assert!(
+            !u8::is_zero(&irv_before),
+            "Implicit rejection value should be set"
+        );
+
+        // Zeroize the top-level Unpacked KeyPair
+        unpacked.zeroize();
+
+        // Verify Implicit Rejection Value is gone
+        let irv_after = unpacked.private_key.implicit_rejection_value;
+        assert!(
+            u8::is_zero(&irv_after),
+            "Implicit rejection value should be zeroed"
+        );
+
+        // Verify the IndCpaPrivateKey (Polynomials) are zeroed
+        // We have to iterate over the polynomials in the secret vector
+        for poly in &unpacked.private_key.ind_cpa_private_key.secret_as_ntt {
+            for coeff in &poly.coefficients {
+                assert!(
+                    i16::is_zero(coeff.elements.as_ref()),
+                    "Coefficient was not zeroed"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description:
This PR introduces memory hardening for ML-KEM secret keys by implementing the Zeroize and ZeroizeOnDrop traits. The goal is to ensure sensitive key material is securely wiped from memory when it goes out of scope. This facilitates FIPS 140-3 compliance (AS05.10) regarding the zeroization of plaintext secret keys.

## Scope:
This implementation focuses on the secret-holding structs and their underlying vector types. It does not modify the underlying core logic or seed inputs (which very likely needs more work to fully implement zeroize). I believe this covers all primary secret-holding structs in a non-intrusive way required for memory hardening.

This is implemented as an optional feature that requires being enabled.

## Changes:
I have implemented Zeroize for the following types:
- High-Level Keys: MlKemPrivateKey, MlKemKeyPair
- Internal Components: PolynomialRingElement
- Unpacked Variants: MlKemPrivateKeyUnpacked, IndCpaPrivateKeyUnpacked, MlKemKeyPairUnpacked
- Vector Backends: PortableVector, SIMD128Vector, SIMD256Vector

I have implemented ZeroizeOnDrop for the following types:
- MlKemPrivateKey, MlKemKeyPair
- PolynomialRingElement
- MlKemPrivateKeyUnpacked, IndCpaPrivateKeyUnpacked, MlKemKeyPairUnpacked

> Note: Vector types do not implement ZeroizeOnDrop to avoid performance penalties in non-secret contexts; they are zeroed explicitly by their parent structs.

## Technical Verification:
To ensure the security features are not optimized away by the compiler, I performed the following checks:
- Hax Compatibility: All zeroize logic is gated behind #[cfg(not(hax))] to prevent interference with the formal verification pipeline.
- Dead Store Elimination (DSE): Used core::hint::black_box in SIMD implementations and testing to force the compiler to treat the memory as "used," preventing it from deleting the zeroing instructions.

Assembly Audit:
- SIMD128Vector test: Verified that stp (Store Pair) instructions are generated for clearing, and vmaxvq is used for zero-verification in tests.
- SIMD256Vector test: Verified that vmovdqa is generated for clearing, and vptest is used for zero-verification.

## Performance:
Benchmarks show a negligible performance impact (performed on a Ryzen 5 7430u):

Operation | Key Size | Platform | API | Ratio | Zeroize-Enabled | Original
-- | -- | -- | -- | -- | -- | --
Decapsulation | 1024 | AVX2 | Standard | 1.00 | 18.8±0.18µs | 18.8±0.17µs
Decapsulation | 1024 | AVX2 | Unpacked | 1.01 | 11.7±0.09µs | 11.6±0.11µs
Decapsulation | 1024 | Portable | Standard | 1.02 | 55.7±0.65µs | 54.5±0.63µs
Decapsulation | 1024 | Portable | Unpacked | 1.00 | 35.0±0.31µs | 35.2±0.39µs
Encapsulation | 1024 | AVX2 | Ext. Random | 1.03 | 17.4±0.30µs | 16.9±0.17µs
Encapsulation | 1024 | AVX2 | Unp. (Ext. Rand) | 1.00 | 6.3±0.17µs | 6.3±0.20µs
Encapsulation | 1024 | Portable | Ext. Random | 1.00 | 47.9±0.68µs | 47.9±0.63µs
Encapsulation | 1024 | Portable | Unp. (Ext. Rand) | 1.00 | 24.5±0.30µs | 24.9±0.22µs
Key Generation | 1024 | AVX2 | Ext. Random | 1.00 | 15.1±0.20µs | 15.0±0.19µs
Key Generation | 1024 | AVX2 | Unp. (Ext. Rand) | 1.02 | 15.0±0.28µs | 14.7±0.22µs
Key Generation | 1024 | Portable | Ext. Random | 1.02 | 42.0±0.52µs | 41.3±0.69µs
Key Generation | 1024 | Portable | Unp. (Ext. Rand) | 1.01 | 41.9±0.60µs | 41.6±0.71µs
PK Validation | 1024 | AVX2 | Standard | 1.00 | 539.1±8.32ns | 543.7±9.46ns
PK Validation | 1024 | Portable | Standard | 1.00 | 1240.0±13.17ns | 1263.6±22.09ns
--- | --- | --- | --- | --- | --- | ---
Decapsulation | 512 | AVX2 | Standard | 1.00 | 9.2±0.15µs | 9.3±0.08µs
Decapsulation | 512 | AVX2 | Unpacked | 1.01 | 6.4±0.05µs | 6.3±0.05µs
Decapsulation | 512 | Portable | Standard | 1.00 | 22.6±0.21µs | 22.6±0.25µs
Decapsulation | 512 | Portable | Unpacked | 1.00 | 17.1±0.28µs | 17.1±0.28µs
Encapsulation | 512 | AVX2 | Ext. Random | 1.10 | 9.3±0.16µs | 8.5±0.11µs
Encapsulation | 512 | AVX2 | Unp. (Ext. Rand) | 1.02 | 3.9±0.06µs | 3.8±0.04µs
Encapsulation | 512 | Portable | Ext. Random | 1.04 | 19.0±0.14µs | 18.4±0.24µs
Encapsulation | 512 | Portable | Unp. (Ext. Rand) | 1.02 | 11.9±0.09µs | 11.7±0.16µs
Key Generation | 512 | AVX2 | Ext. Random | 1.02 | 8.2±0.23µs | 8.0±0.09µs
Key Generation | 512 | AVX2 | Unp. (Ext. Rand) | 1.02 | 7.9±0.28µs | 7.8±0.11µs
Key Generation | 512 | Portable | Ext. Random | 1.00 | 15.6±0.22µs | 15.8±0.18µs
Key Generation | 512 | Portable | Unp. (Ext. Rand) | 1.00 | 15.4±0.19µs | 15.6±0.16µs
PK Validation | 512 | AVX2 | Standard | 1.00 | 265.8±4.79ns | 273.2±16.21ns
PK Validation | 512 | Portable | Standard | 1.00 | 622.3±14.28ns | 632.7±13.59ns
--- | --- | --- | --- | --- | --- | ---
Decapsulation | 768 | AVX2 | Standard | 1.02 | 13.2±0.16µs | 12.9±0.13µs
Decapsulation | 768 | AVX2 | Unpacked | 1.01 | 8.2±0.07µs | 8.1±0.06µs
Decapsulation | 768 | Portable | Standard | 1.01 | 37.2±0.36µs | 36.8±0.51µs
Decapsulation | 768 | Portable | Unpacked | 1.00 | 24.9±0.21µs | 25.0±0.18µs
Encapsulation | 768 | AVX2 | Ext. Random | 1.01 | 12.1±0.21µs | 12.0±0.13µs
Encapsulation | 768 | AVX2 | Unp. (Ext. Rand) | 1.00 | 4.5±0.04µs | 4.6±0.05µs
Encapsulation | 768 | Portable | Ext. Random | 1.01 | 31.8±0.38µs | 31.3±0.30µs
Encapsulation | 768 | Portable | Unp. (Ext. Rand) | 1.04 | 18.2±1.81µs | 17.5±0.13µs
Key Generation | 768 | AVX2 | Ext. Random | 1.01 | 11.0±0.17µs | 11.0±0.13µs
Key Generation | 768 | AVX2 | Unp. (Ext. Rand) | 1.01 | 10.9±0.14µs | 10.8±0.09µs
Key Generation | 768 | Portable | Ext. Random | 1.03 | 27.0±0.28µs | 26.3±0.33µs
Key Generation | 768 | Portable | Unp. (Ext. Rand) | 1.01 | 26.5±0.33µs | 26.2±0.31µs
PK Validation | 768 | AVX2 | Standard | 1.01 | 411.0±28.60ns | 405.2±6.72ns
PK Validation | 768 | Portable | Standard | 1.01 | 977.1±14.22ns | 970.5±6.81ns

---
## Closing Notes:
Note: I am not a security programmer or researcher. I have tried to implement this to the best of my abilities, verifying the assembly output to ensure the compiler respects the zeroing instructions. I really like libcrux and wanted to use it for a project, but also need zeroize functionality, so I worked to try to implement it. I have tried to do my due diligence in checking and design. I would very much appreciate someone double checking my work, especially as this is my first contribution to a project. But I believe that this works.

I would greatly appreciate feedback and comments on anything that needs to be changed.