### PR TITLE
Fix cloop and warnings

### DIFF
--- a/libcrux-ml-dsa/CHANGELOG.md
+++ b/libcrux-ml-dsa/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- [#1504](https://github.com/cryspen/libcrux/issues/1504): Fix incorrect `cloop!` macro `step_by` variant logic
+
 ### Added
 
 - [#1457](https://github.com/cryspen/libcrux/pull/1457): Add dependency on libcrux-secrets for optional valgrind integration

--- a/libcrux-ml-dsa/src/helper.rs
+++ b/libcrux-ml-dsa/src/helper.rs
@@ -58,9 +58,9 @@ macro_rules! cloop {
         }
     };
     (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {
-        for $i in ($start..($end / $step + 1)) {
-            let $i = $i * $step;
-            if $i >= $end { break; }
+        for _cloop_i in 0..(($end) / $step + 1) {
+            let $i = $start + _cloop_i * $step;
+            if $i >= ($end) { break; }
             $body
         }
     };

--- a/libcrux-ml-kem/CHANGELOG.md
+++ b/libcrux-ml-kem/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+- [#1504](https://github.com/cryspen/libcrux/issues/1504): Fix incorrect `cloop!` macro `step_by` variant logic
+
 ## [0.0.9] (2026-05-13)
 
 ### Changed

--- a/libcrux-ml-kem/src/helper.rs
+++ b/libcrux-ml-kem/src/helper.rs
@@ -28,8 +28,9 @@ macro_rules! cloop {
         }
     };
     (for $i:ident in ($start:literal..$end:expr).step_by($step:literal) $body:block) => {
-        for $i in $start..$end / $step {
-            let $i = $i * $step;
+        for _cloop_i in 0..(($end) / $step + 1) {
+            let $i = $start + _cloop_i * $step;
+            if $i >= ($end) { break; }
             $body
         }
     };


### PR DESCRIPTION
This PR implements a fix for the `cloop!` macro's `step_by` variant as discussed in issue #1504.

## Changes
- The `step_by` variant of the `cloop!` macro in both `ml-kem` and `ml-dsa` was mathematically incorrect for cases where `$start != 0` or `$end % $step != 0`. This replaces the flawed implementation with a rigorously bounded `for` loop `0..(($end) / $step + 1)` that computes the offset internally. This maintains Eurydice's ability to extract cleanly to C (unlike `loop { ... }` approaches) while preventing loop bound overshoots and `$start` scaling bugs.