### PR TITLE
fix(aes): re-export aead module from libcrux_traits

### DIFF
--- a/crates/algorithms/aes/src/lib.rs
+++ b/crates/algorithms/aes/src/lib.rs
@@ -1533,4 +1533,5 @@ pub use aes_gcm_256::Nonce as AesGcm256Nonce;
 #[doc(inline)]
 pub use aes_gcm_256::Tag as AesGcm256Tag;
 pub use implementations::{AesCcm128, AesCcm256, AesGcm128, AesGcm256};
+pub use libcrux_traits::aead;
 pub use libcrux_traits::aead::{consts::AeadConsts, typed_refs::Aead};


### PR DESCRIPTION
## Export `aead` module from `libcrux_aes` #1533

### Changes
* Added `pub use libcrux_traits::aead;` to `crates/algorithms/aes/src/lib.rs`.
