### PR TITLE
libcrux-psq: ProVerif extraction + symbolic verification

### DIFF
--- a/.github/workflows/psq-proverif.yml
+++ b/.github/workflows/psq-proverif.yml
@@ -1,0 +1,77 @@
+name: PSQ - ProVerif
+
+# Nightly ProVerif analysis of the libcrux-psq PSQ handshake.
+#
+# This is EXTRACTION-ONLY: unlike the other flagship ProVerif models, PSQ
+# gitignores its extraction snapshot (proofs/proverif/extraction/lib.pvl — see
+# proofs/proverif/.gitignore), so there is NO committed .pvl to diff against and
+# therefore no cheap per-push "verify the committed snapshot" job is possible.
+# The only thing we can do is RE-EXTRACT the handshake via the hax ProVerif
+# backend and then run the full analysis, which requires building the OCaml
+# hax-engine + Rust cargo-hax. That is heavy (~60 min wall clock), so it runs on
+# a nightly schedule (and on manual dispatch) rather than per push/PR.
+#
+# check-pv.sh re-extracts via `cargo hax ... into proverif`, composes lib.pvl
+# with the symbolic crypto model (psq_crypto.pvl), and runs the full ProVerif
+# suite: query mode (14/14), registration msg1 (DH/sig), post-quantum
+# forward-secrecy + authenticity, the DH session (~58 min, backgrounded) and the
+# sig session (~40 min, backgrounded). It prints `CHECK PASSED` (exit 0) on
+# success or `CHECK FAILED` (exit 1).
+
+on:
+  schedule:
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  proverif-psq:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Checkout hax ProVerif backend
+        uses: actions/checkout@v4
+        with:
+          repository: cryspen/hax
+          ref: proverif-rust-backend
+          path: hax-engine
+
+      - name: System deps (opam, jq, node, proverif)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y opam jq nodejs libgtk2.0-dev
+          opam init -y --disable-sandboxing --bare
+          opam install -y proverif
+
+      - name: Rust toolchain (pinned by hax)
+        run: |
+          rustup toolchain install "$(grep -oE 'nightly-[0-9-]+' hax-engine/rust-toolchain.toml | head -1)" \
+            --component rustc-dev --component rust-src --component llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: hax-engine
+
+      - name: Cache opam
+        uses: actions/cache@v4
+        with:
+          path: ~/.opam
+          key: opam-hax-proverif-${{ runner.os }}-${{ hashFiles('hax-engine/engine/**/dune-project') }}
+
+      - name: Build + install the hax engine into a switch
+        run: |
+          opam switch list --short | grep -qx hax-proverif || opam switch create hax-proverif 5.3.0
+          HAX_OPAM_SWITCH=hax-proverif ./hax-engine/setup-local.sh
+
+      - name: Re-extract + run the full ProVerif analysis
+        env:
+          HAX_PROVERIF_DIR: ${{ github.workspace }}/hax-engine
+        run: bash libcrux-psq/proofs/proverif/check-pv.sh

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -42,6 +42,12 @@ tls_codec = { version = "0.4.2", features = ["derive"] }
 libcrux-ml-dsa = { workspace = true, features = ["codec"] }
 libcrux-aes.workspace = true
 
+# ProVerif extraction via the hax proverif-rust-backend. The pv_extern /
+# replace_body / opaque macros used for the symbolic-crypto boundary are not in
+# the workspace-pinned crates.io hax-lib 0.3.6, so pin the git rev directly.
+# Optional + gated behind `hax-pv` so normal builds are unaffected.
+hax-lib = { git = "https://github.com/cryspen/hax.git", rev = "1a99a1948d5931026fd0be4e322fbd1b7149927b", optional = true }
+
 [dev-dependencies]
 rand_core = { version = "0.10" }
 clap = { version = "4.5.30", features = ["derive"] }
@@ -52,6 +58,8 @@ pretty_env_logger = "0.5.0"
 [features]
 v1 = []
 classic-mceliece = ["dep:classic-mceliece-rust", "rand_old"]
+# Enables the hax ProVerif-backend symbolic-crypto annotations.
+hax-pv = ["dep:hax-lib"]
 
 # Allows external control over the AEAD nonces of transport channels.
 # ⚠️ CAUTION! Enabling this makes it the responsibility of the application to avoid nonce re-use.

--- a/libcrux-psq/Cargo.toml
+++ b/libcrux-psq/Cargo.toml
@@ -46,7 +46,7 @@ libcrux-aes.workspace = true
 # replace_body / opaque macros used for the symbolic-crypto boundary are not in
 # the workspace-pinned crates.io hax-lib 0.3.6, so pin the git rev directly.
 # Optional + gated behind `hax-pv` so normal builds are unaffected.
-hax-lib = { git = "https://github.com/cryspen/hax.git", rev = "1a99a1948d5931026fd0be4e322fbd1b7149927b", optional = true }
+hax-lib = { git = "https://github.com/cryspen/hax.git", rev = "5cdb74443a1eeebd34f7bae057ead44bc8a25107", optional = true }
 
 [dev-dependencies]
 rand_core = { version = "0.10" }

--- a/libcrux-psq/proofs/proverif/.gitignore
+++ b/libcrux-psq/proofs/proverif/.gitignore
@@ -1,0 +1,3 @@
+# hax ProVerif extraction output (regenerated; snapshot committed at Phase 4)
+extraction/lib.pvl
+extraction/missingdecl*.pvl

--- a/libcrux-psq/proofs/proverif/.gitignore
+++ b/libcrux-psq/proofs/proverif/.gitignore
@@ -1,3 +1,6 @@
-# hax ProVerif extraction output (regenerated; snapshot committed at Phase 4)
+# hax ProVerif extraction output + check-script intermediates (regenerated;
+# the lib.pvl snapshot is committed at Phase 4).
 extraction/lib.pvl
+extraction/lib.clean.pvl
 extraction/missingdecl*.pvl
+extraction/loadcheck.pv

--- a/libcrux-psq/proofs/proverif/.gitignore
+++ b/libcrux-psq/proofs/proverif/.gitignore
@@ -4,3 +4,4 @@ extraction/lib.pvl
 extraction/lib.clean.pvl
 extraction/missingdecl*.pvl
 extraction/loadcheck.pv
+extraction/*.pvl.map

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -198,6 +198,14 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
   proverif "${LIBS_REG[@]}" "$EX/sanity_reg_passive.pv"    > "$LOG_SAN"  2>&1
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_msg1.pv"  > "$LOG_RDH"  2>&1
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_sig_msg1.pv" > "$LOG_RSIG" 2>&1
+  # Post-quantum forward secrecy + authenticity: the quantum apocalypse (all
+  # classical DH/sig keys derivable) hits in phase 1, STRICTLY AFTER the phase-0
+  # session. A session accepted before the apocalypse keeps both secrecy (ML-KEM
+  # anchor) and authenticity (timestamp form: only a compromise PRECEDING the
+  # acceptance can forge — contrast R2a, false, where the break is during the run).
+  LOG_PQ=$(mktemp)
+  [ -f "$EX/analysis_reg_dh_pq.pv" ] && \
+    proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_pq.pv" > "$LOG_PQ" 2>&1
   # Session passive sanity: the FULL two-message handshake + into_session honest run
   # must reach InitSessDH AND RespSessDH on its own (response/session non-vacuity).
   [ -f "$EX/sanity_session_passive.pv" ] && \
@@ -222,6 +230,14 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
     echo "                         exp: $EXP_SSAN"
     [ "$GOT_SSAN" = "$EXP_SSAN" ] || REG_OK=0
   fi
+  if [ -f "$EX/analysis_reg_dh_pq.pv" ]; then
+    if [ "$(grep -c '^Error:' "$LOG_PQ")" -ne 0 ]; then echo "PQ LOAD FAILED:"; grep '^Error:' "$LOG_PQ" | head; REG_OK=0; fi
+    EXP_PQ="true true true true false "   # FA1, FA2(timestamp), FS1, FS2, NV
+    GOT_PQ=$(verdicts "$LOG_PQ")
+    echo "  pq fwd-sec/auth (FA1 FA2 FS1 FS2 NV) got: $GOT_PQ"
+    echo "                                       exp: $EXP_PQ"
+    [ "$GOT_PQ" = "$EXP_PQ" ] || REG_OK=0
+  fi
   # Collect the backgrounded DH session secrecy (R5 InitSessDH, R5 RespSessDH, R7, R8).
   if [ -n "${DHSESS_PID:-}" ]; then
     echo "  (waiting on DH session secrecy R5/R7/R8 ...)"
@@ -238,7 +254,7 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
 fi
 
 if [ "$QUERY_OK" = 1 ] && [ "$REG_OK" = 1 ]; then
-  echo "CHECK PASSED (query 14/14 + registration msg1 R1/R2a/R2b/R2c/R4/R6/R9 + session R1/R5/R7/R8: DH R2a false / sig R2a true; session key-secret + forward-secret)"
+  echo "CHECK PASSED (query 14/14 + reg msg1 R1/R2a/R2b/R2c/R4/R6/R9 + PQ fwd-sec/auth + session R1/R5/R7/R8: DH R2a false / sig R2a true; post-quantum fwd-secret + fwd-authentic)"
 else
   echo "CHECK FAILED"; exit 1
 fi

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Re-extract the libcrux-psq PSQ handshake to ProVerif via the hax
+# proverif-rust backend, compose it with the symbolic crypto model
+# (psq_crypto.pvl) and the de-duplicated `missingdecl`, and run ProVerif.
+#
+# Phase 2 status: this validates that the QUERY-MODE model (initiator + responder)
+# LOADS and type-checks (no parse/type error). Security queries (Phase 3) are
+# added in proofs/proverif/extraction/analysis.pv once present.
+#
+#   HAX_PROVERIF_DIR : a hax checkout @ proverif-rust-backend with target/release
+#                      built (or the hax-proverif opam switch installed).
+set -uo pipefail
+# script lives at libcrux-psq/proofs/proverif/check-pv.sh; run from workspace root
+cd "$(dirname "$0")/../../.."
+ENG="${HAX_PROVERIF_DIR:?set HAX_PROVERIF_DIR to a hax checkout}"
+PRIM="$ENG/hax-lib/proof-libs/proverif/primitives.pvl"
+PVD=libcrux-psq/proofs/proverif
+EX="$PVD/extraction"
+eval "$(opam env --switch=hax-proverif 2>/dev/null)" 2>/dev/null || true
+if ! command -v cargo-hax >/dev/null 2>&1; then export PATH="$ENG/target/release:$PATH"; fi
+export HAX_RUST_ENGINE_BINARY="${HAX_RUST_ENGINE_BINARY:-$ENG/target/release/hax-rust-engine}"
+
+# Query-mode entry points: the query initiator + the (unified) responder,
+# transitively. The crypto boundary is annotated in src/** with
+# `#[hax_lib::proverif::replace_body(...)]` (DH / KDF / AEAD) and modeled in
+# psq_crypto.pvl; serialization is bypassed there.
+INC='-** +~libcrux_psq::handshake::initiator::query::** +~libcrux_psq::handshake::responder::**'
+cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || exit 1
+
+# (a) Neutralize + hoist self-recursive serialization stubs. hax renders
+#     unresolvable tls_codec trait methods as `f(..) = f(..)`; the engine
+#     converts the bare form to an opaque `fun`, this pass catches the
+#     let-wrapped form too and hoists ALL opaque stub funs to the top (they are
+#     dependency-free; this fixes the mutual-recursion forward references).
+python3 - "$EX/lib.pvl" > "$EX/lib.clean.pvl" <<'PY'
+import re,sys
+stmts=re.split(r'(?<=\.)\n', open(sys.argv[1]).read())
+hoist=[]; body=[]
+for s in stmts:
+    m=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\((.*?)\)\s*=', s, re.S)
+    if m and re.search(r'\b'+re.escape(m.group(1))+r'\b', s[m.end():]):
+        ar=m.group(2).count(':') if m.group(2).strip() else 0
+        hoist.append(f'fun {m.group(1)}({", ".join(["bitstring"]*ar)}): bitstring.'); continue
+    m2=re.search(r'(?m)^fun\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)\s*:\s*bitstring\.\s*$', s)
+    if m2 and '[data]' not in s and s.strip().startswith(('fun','(* self-recursive')):
+        hoist.append(f'fun {m2.group(1)}({m2.group(2)}): bitstring.'); continue
+    body.append(s)
+seen=set(); H=[]
+for h in hoist:
+    n=re.match(r'fun\s+([A-Za-z0-9_]+)',h).group(1)
+    if n not in seen: seen.add(n); H.append(h)
+sys.stdout.write('(* hoisted opaque serialization stubs *)\n'+'\n'.join(H)+'\n\n'+'\n'.join(body))
+PY
+
+# (b) De-dup the auto-declared `missingdecl` against the real defs
+#     (primitives + psq_crypto + the cleaned lib) and mark survivors `[data]`.
+python3 - "$PRIM" "$PVD/psq_crypto.pvl" "$EX/lib.clean.pvl" "$EX/missingdecl.pvl" > "$EX/missingdecl.dedup.pvl" <<'PY'
+import re,sys
+defs=set()
+for f in sys.argv[1:4]:
+    try: t=open(f).read()
+    except: continue
+    for m in re.finditer(r'^(?:fun|letfun|const)\s+([A-Za-z0-9_]+)', t, re.M): defs.add(m.group(1))
+    for m in re.finditer(r';\s*([A-Za-z0-9_]+)\s*\(', t.replace('\n',' ')): defs.add(m.group(1))
+out=[]
+for l in open(sys.argv[4]):
+    m=re.match(r'^(fun|const)\s+([A-Za-z0-9_]+)', l)
+    if m and m.group(2) in defs: continue
+    if l.startswith('fun ') and l.rstrip().endswith(': bitstring.'): l=l.rstrip()[:-1]+' [data].\n'
+    out.append(l)
+sys.stdout.write(''.join(out))
+PY
+
+# Use analysis.pv (the security queries) if present; else a bare load-check.
+ANALYSIS="$EX/analysis.pv"
+[ -f "$ANALYSIS" ] || { printf 'process\n  0\n' > "$EX/loadcheck.pv"; ANALYSIS="$EX/loadcheck.pv"; }
+LOG=$(mktemp)
+proverif -lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl" \
+         -lib "$EX/lib.clean.pvl" "$ANALYSIS" > "$LOG" 2>&1
+NERR=$(grep -c '^Error:' "$LOG")
+if [ "$NERR" -ne 0 ]; then echo "LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG" | head; exit 1; fi
+echo "MODEL LOADS OK (0 errors)."
+grep -E '^RESULT' "$LOG" || echo "(no queries yet — Phase 3)"

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -24,7 +24,7 @@ export HAX_RUST_ENGINE_BINARY="${HAX_RUST_ENGINE_BINARY:-$ENG/target/release/hax
 # transitively. The crypto boundary is annotated in src/** with
 # `#[hax_lib::proverif::replace_body(...)]` (DH / KDF / AEAD) and modeled in
 # psq_crypto.pvl; serialization is bypassed there.
-INC='-** +~libcrux_psq::handshake::initiator::query::** +~libcrux_psq::handshake::responder::**'
+INC='-** +~libcrux_psq::handshake::initiator::** +~libcrux_psq::handshake::responder::**'
 cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || exit 1
 
 # (a) Neutralize + hoist self-recursive serialization stubs. hax renders
@@ -34,17 +34,52 @@ cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || exi
 #     dependency-free; this fixes the mutual-recursion forward references).
 python3 - "$EX/lib.pvl" > "$EX/lib.clean.pvl" <<'PY'
 import re,sys
-# Constructors re-declared in psq_crypto.pvl (so the pv_deserialize bridge can
-# reference them before lib.pvl loads); strip their `fun … [data].` decls here
-# to avoid a duplicate definition. Their projector reducs + use sites stay and
-# resolve against the psq_crypto declaration (loaded earlier).
+# Constructors re-declared in psq_crypto.pvl (so the pv_deserialize bridge and
+# the signature model can reference them before lib.pvl loads); strip their
+# `fun … [data].` decls here to avoid a duplicate definition. Their projector
+# reducs + use sites stay and resolve against the psq_crypto declaration (loaded
+# earlier).
 STRIP={'libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query',
-       'libcrux_psq__handshake__responder__InitiatorOuterPayload__Query'}
+       'libcrux_psq__handshake__responder__InitiatorOuterPayload__Query',
+       'libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration',
+       'libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration',
+       'libcrux_psq__handshake__InnerMessageOut__InnerMessageOut',
+       'libcrux_psq__handshake__InnerMessage__InnerMessage',
+       'libcrux_psq__handshake__AuthMessageOut__Dh',
+       'libcrux_psq__handshake__AuthMessageOut__Sig',
+       'libcrux_psq__handshake__AuthMessage__Dh',
+       'libcrux_psq__handshake__AuthMessage__Sig',
+       'libcrux_psq__handshake__initiator__InitiatorInnerPayloadOut__InitiatorInnerPayloadOut',
+       'libcrux_psq__handshake__initiator__InitiatorInnerPayload__InitiatorInnerPayload',
+       'libcrux_psq__handshake__responder__ResponderRegistrationPayloadOut__ResponderRegistrationPayloadOut',
+       'libcrux_psq__handshake__responder__ResponderRegistrationPayload__ResponderRegistrationPayload',
+       'tls_codec__quic_vec__VLByteSlice__VLByteSlice',
+       'libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519',
+       'libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65',
+       'libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519',
+       'libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65',
+       'libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519',
+       'libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65',
+       'libcrux_psq__handshake__ciphersuite__initiator__Auth__DH',
+       'libcrux_psq__handshake__ciphersuite__initiator__Auth__Sig',
+       'libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair',
+       'libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh',
+       'libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig',
+       'libcrux_psq__handshake__ciphersuite__initiator__PqKemPublicKey__MlKem',
+       'libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem',
+       'libcrux_psq__handshake__ciphersuite__initiator__InitiatorCiphersuite__InitiatorCiphersuite',
+       'libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite'}
+# Letfuns re-defined in psq_crypto.pvl (overriding a mis-resolved extraction);
+# strip the extracted definition here so the psq_crypto one is the sole def.
+STRIP_LETFUN={'libcrux_psq__handshake__ciphersuite__types__Impl_2__from',
+              'libcrux_psq__aead__Impl_1__handshake_encrypt'}
 stmts=re.split(r'(?<=\.)\n', open(sys.argv[1]).read())
 hoist=[]; body=[]
 for s in stmts:
-    ms=re.match(r'\s*fun\s+([A-Za-z0-9_]+)\s*\(\s*bitstring\s*\)\s*:\s*bitstring\s*\[data\]\.\s*$', s, re.S)
+    ms=re.match(r'\s*fun\s+([A-Za-z0-9_]+)\s*\(.*?\)\s*:\s*bitstring\s*\[data\]\.\s*$', s, re.S)
     if ms and ms.group(1) in STRIP: continue
+    ml=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\(', s)
+    if ml and ml.group(1) in STRIP_LETFUN: continue
     m=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\((.*?)\)\s*=', s, re.S)
     if m and re.search(r'\b'+re.escape(m.group(1))+r'\b', s[m.end():]):
         ar=m.group(2).count(':') if m.group(2).strip() else 0
@@ -91,7 +126,10 @@ PY
 # security-equivalent auth core (cf. mandrake's *_core files).
 LIBS=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl"
       -lib "$EX/lib.clean.pvl" -lib "$EX/psq_query_lib.pvl")
-verdicts () { grep '^RESULT' "$1" | grep -oE 'is (true|false)' | awk '{print $2}' | tr '\n' ' '; }
+# Primary verdict per query. Skip ProVerif's secondary `RESULT (but event(...)
+# is true.)` annotation that follows a FALSE injective-correspondence query
+# (e.g. R2c replay): it is not a separate query verdict.
+verdicts () { grep '^RESULT' "$1" | grep -v '(but' | grep -oE 'is (true|false)' | awk '{print $2}' | tr '\n' ' '; }
 
 # If the queries aren't present yet, fall back to a bare load-check.
 if [ ! -f "$EX/analysis.pv" ]; then
@@ -119,8 +157,54 @@ echo "  P1,P4..P11  got: $GOT_MAIN"
 echo "              exp: $EXP_MAIN"
 echo "  P2,P3       got: $GOT_AUTH"
 echo "              exp: $EXP_AUTH"
-if [ "$GOT_MAIN" = "$EXP_MAIN" ] && [ "$GOT_AUTH" = "$EXP_AUTH" ]; then
-  echo "CHECK PASSED (14/14 query-mode verdicts match psq_query.pv)"
+QUERY_OK=0
+[ "$GOT_MAIN" = "$EXP_MAIN" ] && [ "$GOT_AUTH" = "$EXP_AUTH" ] && QUERY_OK=1
+
+# ---------------------------------------------------------------------------
+# Registration mode — MESSAGE-1 analyses (shared lib psq_reg_lib.pvl). Drives the
+# real extracted registration initiator/responder (auth core), on a SOUND honest
+# run (sanity_reg_passive.pv: InitReg*+RespReg* reachable under a PASSIVE attacker
+# with K_1 agreement — the non-vacuity foundation). Reproduces psq-design/models/
+# psq_registration_{dh,sig}_msg1.pv EXACTLY, including R2c (replay) and R9 (NOT
+# forward-secret), which now resolve correctly (the sound honest run + the wire
+# leak fixes — CiphersuiteBase::name field-projection and the AuthMessageOut::Sig
+# .into() canon in psq_crypto.pvl — let ProVerif reconstruct the honest K_1, so
+# R2c/R9 come out FALSE rather than over-approximating to true):
+#   DH  : R1 reachable, R2a FALSE (DH initiator-auth NOT post-quantum sound),
+#         R2b true, R2c false, R4 true, R6 true, R9 false, nonvac false
+#                                              -> false false true false true true false false
+#   sig : R1 reachable, R2a TRUE (signature-based auth IS PQ-sound),
+#         R2c false, R4 true, R6 true, R9 false, nonvac false
+#                                              -> false true false true true false false
+# R9-false reconstructs reg_secret under endpoint compromise (no ephemeral break),
+# doubling as the leak / non-vacuity control for the secrecy queries R4/R6.
+LIBS_REG=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl"
+          -lib "$EX/lib.clean.pvl" -lib "$EX/psq_reg_lib.pvl")
+REG_OK=1
+if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
+  LOG_SAN=$(mktemp); LOG_RDH=$(mktemp); LOG_RSIG=$(mktemp)
+  # Passive-first sanity: the honest registration round-trip must complete on its
+  # own (no attacker help). Without this the active-attacker verdicts are unsound.
+  proverif "${LIBS_REG[@]}" "$EX/sanity_reg_passive.pv"    > "$LOG_SAN"  2>&1
+  proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_msg1.pv"  > "$LOG_RDH"  2>&1
+  proverif "${LIBS_REG[@]}" "$EX/analysis_reg_sig_msg1.pv" > "$LOG_RSIG" 2>&1
+  NERR=$(( $(grep -c '^Error:' "$LOG_SAN") + $(grep -c '^Error:' "$LOG_RDH") + $(grep -c '^Error:' "$LOG_RSIG") ))
+  if [ "$NERR" -ne 0 ]; then echo "REG LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG_SAN" "$LOG_RDH" "$LOG_RSIG" | head; REG_OK=0; fi
+  EXP_SAN="false false false false true true "   # InitReg*/RespReg* reachable + K_1 agreement
+  EXP_RDH="false false true false true true false false "
+  EXP_RSIG="false true false true true false false "
+  GOT_SAN=$(verdicts "$LOG_SAN"); GOT_RDH=$(verdicts "$LOG_RDH"); GOT_RSIG=$(verdicts "$LOG_RSIG")
+  echo "  reg passive sanity got: $GOT_SAN"
+  echo "                     exp: $EXP_SAN"
+  echo "  reg dh msg1 got: $GOT_RDH"
+  echo "              exp: $EXP_RDH"
+  echo "  reg sig msg1 got: $GOT_RSIG"
+  echo "              exp: $EXP_RSIG"
+  [ "$GOT_SAN" = "$EXP_SAN" ] && [ "$GOT_RDH" = "$EXP_RDH" ] && [ "$GOT_RSIG" = "$EXP_RSIG" ] || REG_OK=0
+fi
+
+if [ "$QUERY_OK" = 1 ] && [ "$REG_OK" = 1 ]; then
+  echo "CHECK PASSED (query 14/14 + registration msg1 R1/R2a/R2b/R2c/R4/R6/R9: DH R2a false / sig R2a true, replay+fwd-sec both false)"
 else
   echo "CHECK FAILED"; exit 1
 fi

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -76,16 +76,20 @@ STRIP_LETFUN={'libcrux_psq__handshake__ciphersuite__types__Impl_2__from',
 stmts=re.split(r'(?<=\.)\n', open(sys.argv[1]).read())
 hoist=[]; body=[]
 for s in stmts:
-    ms=re.match(r'\s*fun\s+([A-Za-z0-9_]+)\s*\(.*?\)\s*:\s*bitstring\s*\[data\]\.\s*$', s, re.S)
+    # The engine now prepends Rust doc comments `(* ... *)` before items. Strip
+    # any leading comment block when CLASSIFYING the statement (fun/letfun/const)
+    # so the statement-start regexes still match; keep `s` intact for output.
+    sc=re.sub(r'^\s*(?:\(\*.*?\*\)\s*)+', '', s, flags=re.S)
+    ms=re.match(r'\s*fun\s+([A-Za-z0-9_]+)\s*\(.*?\)\s*:\s*bitstring\s*\[data\]\.\s*$', sc, re.S)
     if ms and ms.group(1) in STRIP: continue
-    ml=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\(', s)
+    ml=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\(', sc)
     if ml and ml.group(1) in STRIP_LETFUN: continue
-    m=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\((.*?)\)\s*=', s, re.S)
-    if m and re.search(r'\b'+re.escape(m.group(1))+r'\b', s[m.end():]):
+    m=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\((.*?)\)\s*=', sc, re.S)
+    if m and re.search(r'\b'+re.escape(m.group(1))+r'\b', sc[m.end():]):
         ar=m.group(2).count(':') if m.group(2).strip() else 0
         hoist.append(f'fun {m.group(1)}({", ".join(["bitstring"]*ar)}): bitstring.'); continue
-    m2=re.search(r'(?m)^fun\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)\s*:\s*bitstring\.\s*$', s)
-    if m2 and '[data]' not in s and s.strip().startswith(('fun','(* self-recursive')):
+    m2=re.search(r'(?m)^fun\s+([A-Za-z0-9_]+)\s*\(([^)]*)\)\s*:\s*bitstring\.\s*$', sc)
+    if m2 and '[data]' not in sc and sc.strip().startswith('fun'):
         hoist.append(f'fun {m2.group(1)}({m2.group(2)}): bitstring.'); continue
     body.append(s)
 seen=set(); H=[]

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -182,17 +182,22 @@ LIBS_REG=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pv
           -lib "$EX/lib.clean.pvl" -lib "$EX/psq_reg_lib.pvl")
 REG_OK=1
 if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
-  # The DH session secrecy (R5/R7/R8) drives the FULL handshake + into_session and
-  # is the heaviest run (DH commutativity x the response's two DH shared secrets,
-  # ~20-25 min even with the nounif resolution control). Launch it in the BACKGROUND
-  # now so it overlaps the (faster) msg1 analyses below; collected after them.
-  LOG_DHSESS=$(mktemp)
+  # The session analyses drive the FULL handshake + into_session and are the
+  # heaviest runs (DH commutativity; the DH session ~58 min, the sig session ~40
+  # min — its responder-auth correspondences R3/R3i are the long poles). Launch
+  # BOTH in the BACKGROUND now so they overlap each other AND the (faster) msg1
+  # analyses below; collected at the end.
+  LOG_DHSESS=$(mktemp); LOG_SIGSESS=$(mktemp)
   if [ -f "$EX/analysis_reg_dh_session.pv" ]; then
     proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_session.pv" > "$LOG_DHSESS" 2>&1 &
     DHSESS_PID=$!
   fi
+  if [ -f "$EX/analysis_reg_sig_session.pv" ]; then
+    proverif "${LIBS_REG[@]}" "$EX/analysis_reg_sig_session.pv" > "$LOG_SIGSESS" 2>&1 &
+    SIGSESS_PID=$!
+  fi
   LOG_SAN=$(mktemp); LOG_RDH=$(mktemp); LOG_RSIG=$(mktemp)
-  LOG_SSAN=$(mktemp)
+  LOG_SSAN=$(mktemp); LOG_SSSAN=$(mktemp)
   # Passive-first sanity: the honest registration round-trip must complete on its
   # own (no attacker help). Without this the active-attacker verdicts are unsound.
   proverif "${LIBS_REG[@]}" "$EX/sanity_reg_passive.pv"    > "$LOG_SAN"  2>&1
@@ -210,6 +215,8 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
   # must reach InitSessDH AND RespSessDH on its own (response/session non-vacuity).
   [ -f "$EX/sanity_session_passive.pv" ] && \
     proverif "${LIBS_REG[@]}" "$EX/sanity_session_passive.pv" > "$LOG_SSAN" 2>&1
+  [ -f "$EX/sanity_session_sig_passive.pv" ] && \
+    proverif "${LIBS_REG[@]}" "$EX/sanity_session_sig_passive.pv" > "$LOG_SSSAN" 2>&1
   NERR=$(( $(grep -c '^Error:' "$LOG_SAN") + $(grep -c '^Error:' "$LOG_RDH") + $(grep -c '^Error:' "$LOG_RSIG") ))
   if [ "$NERR" -ne 0 ]; then echo "REG LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG_SAN" "$LOG_RDH" "$LOG_RSIG" | head; REG_OK=0; fi
   EXP_SAN="false false false false true true "   # InitReg*/RespReg* reachable + K_1 agreement
@@ -229,6 +236,12 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
     echo "  session passive sanity got: $GOT_SSAN"
     echo "                         exp: $EXP_SSAN"
     [ "$GOT_SSAN" = "$EXP_SSAN" ] || REG_OK=0
+  fi
+  if [ -f "$EX/sanity_session_sig_passive.pv" ]; then
+    GOT_SSSAN=$(verdicts "$LOG_SSSAN")
+    echo "  session sig passive sanity got: $GOT_SSSAN"
+    echo "                             exp: $EXP_SSAN"   # InitSessSig + RespSessSig reachable
+    [ "$GOT_SSSAN" = "$EXP_SSAN" ] || REG_OK=0
   fi
   if [ -f "$EX/analysis_reg_dh_pq.pv" ]; then
     if [ "$(grep -c '^Error:' "$LOG_PQ")" -ne 0 ]; then echo "PQ LOAD FAILED:"; grep '^Error:' "$LOG_PQ" | head; REG_OK=0; fi
@@ -251,10 +264,23 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
     echo "                      exp: $EXP_DHSESS"
     [ "$GOT_DHSESS" = "$EXP_DHSESS" ] || REG_OK=0
   fi
+  # Collect the backgrounded sig session (R3 + R3i responder auth, R5x2, R7, R8).
+  if [ -n "${SIGSESS_PID:-}" ]; then
+    echo "  (waiting on sig session R3/R3i/R5/R7/R8 ...)"
+    wait "$SIGSESS_PID"
+    if [ "$(grep -c '^Error:' "$LOG_SIGSESS")" -ne 0 ]; then
+      echo "  SIG SESSION LOAD FAILED:"; grep '^Error:' "$LOG_SIGSESS" | head; REG_OK=0
+    fi
+    EXP_SIGSESS="true true true true true true "   # R3, R3i, R5(Init), R5(Resp), R7, R8
+    GOT_SIGSESS=$(verdicts "$LOG_SIGSESS")
+    echo "  sig session R3/R3i/R5/R7/R8 got: $GOT_SIGSESS"
+    echo "                              exp: $EXP_SIGSESS"
+    [ "$GOT_SIGSESS" = "$EXP_SIGSESS" ] || REG_OK=0
+  fi
 fi
 
 if [ "$QUERY_OK" = 1 ] && [ "$REG_OK" = 1 ]; then
-  echo "CHECK PASSED (query 14/14 + reg msg1 R1/R2a/R2b/R2c/R4/R6/R9 + PQ fwd-sec/auth + session R1/R5/R7/R8: DH R2a false / sig R2a true; post-quantum fwd-secret + fwd-authentic)"
+  echo "CHECK PASSED (query 14/14 + reg msg1 R1/R2a/R2b/R2c/R4/R6/R9 + PQ fwd-sec/auth + DH session R1/R5/R7/R8 + sig session R1/R3/R3i/R5/R7/R8: DH R2a false / sig R2a true; sig responder-auth + post-quantum fwd-secret/authentic)"
 else
   echo "CHECK FAILED"; exit 1
 fi

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -182,17 +182,32 @@ LIBS_REG=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pv
           -lib "$EX/lib.clean.pvl" -lib "$EX/psq_reg_lib.pvl")
 REG_OK=1
 if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
+  # The DH session secrecy (R5/R7/R8) drives the FULL handshake + into_session and
+  # is the heaviest run (DH commutativity x the response's two DH shared secrets,
+  # ~20-25 min even with the nounif resolution control). Launch it in the BACKGROUND
+  # now so it overlaps the (faster) msg1 analyses below; collected after them.
+  LOG_DHSESS=$(mktemp)
+  if [ -f "$EX/analysis_reg_dh_session.pv" ]; then
+    proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_session.pv" > "$LOG_DHSESS" 2>&1 &
+    DHSESS_PID=$!
+  fi
   LOG_SAN=$(mktemp); LOG_RDH=$(mktemp); LOG_RSIG=$(mktemp)
+  LOG_SSAN=$(mktemp)
   # Passive-first sanity: the honest registration round-trip must complete on its
   # own (no attacker help). Without this the active-attacker verdicts are unsound.
   proverif "${LIBS_REG[@]}" "$EX/sanity_reg_passive.pv"    > "$LOG_SAN"  2>&1
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_msg1.pv"  > "$LOG_RDH"  2>&1
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_sig_msg1.pv" > "$LOG_RSIG" 2>&1
+  # Session passive sanity: the FULL two-message handshake + into_session honest run
+  # must reach InitSessDH AND RespSessDH on its own (response/session non-vacuity).
+  [ -f "$EX/sanity_session_passive.pv" ] && \
+    proverif "${LIBS_REG[@]}" "$EX/sanity_session_passive.pv" > "$LOG_SSAN" 2>&1
   NERR=$(( $(grep -c '^Error:' "$LOG_SAN") + $(grep -c '^Error:' "$LOG_RDH") + $(grep -c '^Error:' "$LOG_RSIG") ))
   if [ "$NERR" -ne 0 ]; then echo "REG LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG_SAN" "$LOG_RDH" "$LOG_RSIG" | head; REG_OK=0; fi
   EXP_SAN="false false false false true true "   # InitReg*/RespReg* reachable + K_1 agreement
   EXP_RDH="false false true false true true false false "
   EXP_RSIG="false true false true true false false "
+  EXP_SSAN="false false "                        # InitSessDH + RespSessDH reachable
   GOT_SAN=$(verdicts "$LOG_SAN"); GOT_RDH=$(verdicts "$LOG_RDH"); GOT_RSIG=$(verdicts "$LOG_RSIG")
   echo "  reg passive sanity got: $GOT_SAN"
   echo "                     exp: $EXP_SAN"
@@ -201,10 +216,29 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
   echo "  reg sig msg1 got: $GOT_RSIG"
   echo "              exp: $EXP_RSIG"
   [ "$GOT_SAN" = "$EXP_SAN" ] && [ "$GOT_RDH" = "$EXP_RDH" ] && [ "$GOT_RSIG" = "$EXP_RSIG" ] || REG_OK=0
+  if [ -f "$EX/sanity_session_passive.pv" ]; then
+    GOT_SSAN=$(verdicts "$LOG_SSAN")
+    echo "  session passive sanity got: $GOT_SSAN"
+    echo "                         exp: $EXP_SSAN"
+    [ "$GOT_SSAN" = "$EXP_SSAN" ] || REG_OK=0
+  fi
+  # Collect the backgrounded DH session secrecy (R5 InitSessDH, R5 RespSessDH, R7, R8).
+  if [ -n "${DHSESS_PID:-}" ]; then
+    echo "  (waiting on DH session secrecy R5/R7/R8 ...)"
+    wait "$DHSESS_PID"
+    if [ "$(grep -c '^Error:' "$LOG_DHSESS")" -ne 0 ]; then
+      echo "  DH SESSION LOAD FAILED:"; grep '^Error:' "$LOG_DHSESS" | head; REG_OK=0
+    fi
+    EXP_DHSESS="true true true true "   # R5(Init), R5(Resp), R7, R8
+    GOT_DHSESS=$(verdicts "$LOG_DHSESS")
+    echo "  dh session R5/R7/R8 got: $GOT_DHSESS"
+    echo "                      exp: $EXP_DHSESS"
+    [ "$GOT_DHSESS" = "$EXP_DHSESS" ] || REG_OK=0
+  fi
 fi
 
 if [ "$QUERY_OK" = 1 ] && [ "$REG_OK" = 1 ]; then
-  echo "CHECK PASSED (query 14/14 + registration msg1 R1/R2a/R2b/R2c/R4/R6/R9: DH R2a false / sig R2a true, replay+fwd-sec both false)"
+  echo "CHECK PASSED (query 14/14 + registration msg1 R1/R2a/R2b/R2c/R4/R6/R9 + session R1/R5/R7/R8: DH R2a false / sig R2a true; session key-secret + forward-secret)"
 else
   echo "CHECK FAILED"; exit 1
 fi

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -34,9 +34,17 @@ cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || exi
 #     dependency-free; this fixes the mutual-recursion forward references).
 python3 - "$EX/lib.pvl" > "$EX/lib.clean.pvl" <<'PY'
 import re,sys
+# Constructors re-declared in psq_crypto.pvl (so the pv_deserialize bridge can
+# reference them before lib.pvl loads); strip their `fun … [data].` decls here
+# to avoid a duplicate definition. Their projector reducs + use sites stay and
+# resolve against the psq_crypto declaration (loaded earlier).
+STRIP={'libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query',
+       'libcrux_psq__handshake__responder__InitiatorOuterPayload__Query'}
 stmts=re.split(r'(?<=\.)\n', open(sys.argv[1]).read())
 hoist=[]; body=[]
 for s in stmts:
+    ms=re.match(r'\s*fun\s+([A-Za-z0-9_]+)\s*\(\s*bitstring\s*\)\s*:\s*bitstring\s*\[data\]\.\s*$', s, re.S)
+    if ms and ms.group(1) in STRIP: continue
     m=re.match(r'\s*letfun\s+([A-Za-z0-9_]+)\s*\((.*?)\)\s*=', s, re.S)
     if m and re.search(r'\b'+re.escape(m.group(1))+r'\b', s[m.end():]):
         ar=m.group(2).count(':') if m.group(2).strip() else 0
@@ -71,13 +79,48 @@ for l in open(sys.argv[4]):
 sys.stdout.write(''.join(out))
 PY
 
-# Use analysis.pv (the security queries) if present; else a bare load-check.
-ANALYSIS="$EX/analysis.pv"
-[ -f "$ANALYSIS" ] || { printf 'process\n  0\n' > "$EX/loadcheck.pv"; ANALYSIS="$EX/loadcheck.pv"; }
-LOG=$(mktemp)
-proverif -lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl" \
-         -lib "$EX/lib.clean.pvl" "$ANALYSIS" > "$LOG" 2>&1
-NERR=$(grep -c '^Error:' "$LOG")
-if [ "$NERR" -ne 0 ]; then echo "LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG" | head; exit 1; fi
+# ---------------------------------------------------------------------------
+# Run the two query-mode analyses against the composed model and assert the
+# P1–P11 verdicts from psq-design/models/psq_query.pv. The shared setup/roles/
+# aliases/nounif live in psq_query_lib.pvl; the queries split into:
+#   analysis.pv      full responder (drives read_message_contents): P1, P4–P11
+#   analysis_auth.pv auth-core responder (drives decrypt_outer_message): P2, P3
+# P2/P3 are responder-authentication correspondences; the DH-commutativity model
+# does not terminate through the full read_message_contents bookkeeping (rate
+# limiter / ciphersuite coercion / state machine), so they run against the
+# security-equivalent auth core (cf. mandrake's *_core files).
+LIBS=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl"
+      -lib "$EX/lib.clean.pvl" -lib "$EX/psq_query_lib.pvl")
+verdicts () { grep '^RESULT' "$1" | grep -oE 'is (true|false)' | awk '{print $2}' | tr '\n' ' '; }
+
+# If the queries aren't present yet, fall back to a bare load-check.
+if [ ! -f "$EX/analysis.pv" ]; then
+  printf 'process\n  0\n' > "$EX/loadcheck.pv"
+  LOG=$(mktemp); proverif "${LIBS[@]}" "$EX/loadcheck.pv" > "$LOG" 2>&1
+  NERR=$(grep -c '^Error:' "$LOG")
+  [ "$NERR" -eq 0 ] && echo "MODEL LOADS OK (0 errors)." || { echo "LOAD FAILED"; grep '^Error:' "$LOG"|head; exit 1; }
+  echo "(no queries yet)"; exit 0
+fi
+
+LOG_MAIN=$(mktemp); LOG_AUTH=$(mktemp)
+proverif "${LIBS[@]}" "$EX/analysis.pv"      > "$LOG_MAIN" 2>&1
+proverif "${LIBS[@]}" "$EX/analysis_auth.pv" > "$LOG_AUTH" 2>&1
+NERR=$(( $(grep -c '^Error:' "$LOG_MAIN") + $(grep -c '^Error:' "$LOG_AUTH") ))
+if [ "$NERR" -ne 0 ]; then echo "LOAD FAILED ($NERR errors):"; grep '^Error:' "$LOG_MAIN" "$LOG_AUTH" | head; exit 1; fi
+
+# Expected verdicts (psq_query.pv "Expected:" tags).
+#   analysis.pv      P1×4 reachable(false), P4 false, P5–P9 true, P10 false, P11 false
+#   analysis_auth.pv P2 true, P3 true
+EXP_MAIN="false false false false false true true true true true false false "
+EXP_AUTH="true true "
+GOT_MAIN=$(verdicts "$LOG_MAIN"); GOT_AUTH=$(verdicts "$LOG_AUTH")
 echo "MODEL LOADS OK (0 errors)."
-grep -E '^RESULT' "$LOG" || echo "(no queries yet — Phase 3)"
+echo "  P1,P4..P11  got: $GOT_MAIN"
+echo "              exp: $EXP_MAIN"
+echo "  P2,P3       got: $GOT_AUTH"
+echo "              exp: $EXP_AUTH"
+if [ "$GOT_MAIN" = "$EXP_MAIN" ] && [ "$GOT_AUTH" = "$EXP_AUTH" ]; then
+  echo "CHECK PASSED (14/14 query-mode verdicts match psq_query.pv)"
+else
+  echo "CHECK FAILED"; exit 1
+fi

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -25,7 +25,11 @@ export HAX_RUST_ENGINE_BINARY="${HAX_RUST_ENGINE_BINARY:-$ENG/target/release/hax
 # `#[hax_lib::proverif::replace_body(...)]` (DH / KDF / AEAD) and modeled in
 # psq_crypto.pvl; serialization is bypassed there.
 INC='-** +~libcrux_psq::handshake::initiator::** +~libcrux_psq::handshake::responder::**'
-cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || exit 1
+# cargo hax exits non-zero on HAX diagnostics (e.g. a tls_codec serialization
+# method in a call-graph cycle is opacified to an uninterpreted fun) but still
+# writes lib.pvl; tolerate the exit and let the load-check below catch a
+# genuinely broken model.
+cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || true
 
 # (a) Neutralize + hoist self-recursive serialization stubs. hax renders
 #     unresolvable tls_codec trait methods as `f(..) = f(..)`; the engine

--- a/libcrux-psq/proofs/proverif/check-pv.sh
+++ b/libcrux-psq/proofs/proverif/check-pv.sh
@@ -3,10 +3,6 @@
 # proverif-rust backend, compose it with the symbolic crypto model
 # (psq_crypto.pvl) and the de-duplicated `missingdecl`, and run ProVerif.
 #
-# Phase 2 status: this validates that the QUERY-MODE model (initiator + responder)
-# LOADS and type-checks (no parse/type error). Security queries (Phase 3) are
-# added in proofs/proverif/extraction/analysis.pv once present.
-#
 #   HAX_PROVERIF_DIR : a hax checkout @ proverif-rust-backend with target/release
 #                      built (or the hax-proverif opam switch installed).
 set -uo pipefail
@@ -34,7 +30,7 @@ cargo hax -C -p libcrux-psq --features hax-pv ';' into -i "$INC" proverif || tru
 # (a) Neutralize + hoist self-recursive serialization stubs. hax renders
 #     unresolvable tls_codec trait methods as `f(..) = f(..)`; the engine
 #     converts the bare form to an opaque `fun`, this pass catches the
-#     let-wrapped form too and hoists ALL opaque stub funs to the top (they are
+#     let-wrapped form too and hoists all opaque stub funs to the top (they are
 #     dependency-free; this fixes the mutual-recursion forward references).
 python3 - "$EX/lib.pvl" > "$EX/lib.clean.pvl" <<'PY'
 import re,sys
@@ -80,7 +76,7 @@ STRIP_LETFUN={'libcrux_psq__handshake__ciphersuite__types__Impl_2__from',
 stmts=re.split(r'(?<=\.)\n', open(sys.argv[1]).read())
 hoist=[]; body=[]
 for s in stmts:
-    # The engine now prepends Rust doc comments `(* ... *)` before items. Strip
+    # The engine prepends Rust doc comments `(* ... *)` before items. Strip
     # any leading comment block when CLASSIFYING the statement (fun/letfun/const)
     # so the statement-start regexes still match; keep `s` intact for output.
     sc=re.sub(r'^\s*(?:\(\*.*?\*\)\s*)+', '', s, flags=re.S)
@@ -131,11 +127,11 @@ PY
 # P2/P3 are responder-authentication correspondences; the DH-commutativity model
 # does not terminate through the full read_message_contents bookkeeping (rate
 # limiter / ciphersuite coercion / state machine), so they run against the
-# security-equivalent auth core (cf. mandrake's *_core files).
+# security-equivalent auth core.
 LIBS=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pvl"
       -lib "$EX/lib.clean.pvl" -lib "$EX/psq_query_lib.pvl")
 # Primary verdict per query. Skip ProVerif's secondary `RESULT (but event(...)
-# is true.)` annotation that follows a FALSE injective-correspondence query
+# is true.)` annotation that follows a false injective-correspondence query
 # (e.g. R2c replay): it is not a separate query verdict.
 verdicts () { grep '^RESULT' "$1" | grep -v '(but' | grep -oE 'is (true|false)' | awk '{print $2}' | tr '\n' ' '; }
 
@@ -173,15 +169,12 @@ QUERY_OK=0
 # real extracted registration initiator/responder (auth core), on a SOUND honest
 # run (sanity_reg_passive.pv: InitReg*+RespReg* reachable under a PASSIVE attacker
 # with K_1 agreement — the non-vacuity foundation). Reproduces psq-design/models/
-# psq_registration_{dh,sig}_msg1.pv EXACTLY, including R2c (replay) and R9 (NOT
-# forward-secret), which now resolve correctly (the sound honest run + the wire
-# leak fixes — CiphersuiteBase::name field-projection and the AuthMessageOut::Sig
-# .into() canon in psq_crypto.pvl — let ProVerif reconstruct the honest K_1, so
-# R2c/R9 come out FALSE rather than over-approximating to true):
-#   DH  : R1 reachable, R2a FALSE (DH initiator-auth NOT post-quantum sound),
+# psq_registration_{dh,sig}_msg1.pv exactly, including R2c (replay) and R9 (not
+# forward-secret):
+#   DH  : R1 reachable, R2a false (DH initiator-auth not post-quantum sound),
 #         R2b true, R2c false, R4 true, R6 true, R9 false, nonvac false
 #                                              -> false false true false true true false false
-#   sig : R1 reachable, R2a TRUE (signature-based auth IS PQ-sound),
+#   sig : R1 reachable, R2a true (signature-based auth is PQ-sound),
 #         R2c false, R4 true, R6 true, R9 false, nonvac false
 #                                              -> false true false true true false false
 # R9-false reconstructs reg_secret under endpoint compromise (no ephemeral break),
@@ -190,10 +183,10 @@ LIBS_REG=(-lib "$PRIM" -lib "$PVD/psq_crypto.pvl" -lib "$EX/missingdecl.dedup.pv
           -lib "$EX/lib.clean.pvl" -lib "$EX/psq_reg_lib.pvl")
 REG_OK=1
 if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
-  # The session analyses drive the FULL handshake + into_session and are the
+  # The session analyses drive the full handshake + into_session and are the
   # heaviest runs (DH commutativity; the DH session ~58 min, the sig session ~40
   # min — its responder-auth correspondences R3/R3i are the long poles). Launch
-  # BOTH in the BACKGROUND now so they overlap each other AND the (faster) msg1
+  # both in the background now so they overlap each other and the (faster) msg1
   # analyses below; collected at the end.
   LOG_DHSESS=$(mktemp); LOG_SIGSESS=$(mktemp)
   if [ -f "$EX/analysis_reg_dh_session.pv" ]; then
@@ -212,15 +205,15 @@ if [ -f "$EX/analysis_reg_dh_msg1.pv" ]; then
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_msg1.pv"  > "$LOG_RDH"  2>&1
   proverif "${LIBS_REG[@]}" "$EX/analysis_reg_sig_msg1.pv" > "$LOG_RSIG" 2>&1
   # Post-quantum forward secrecy + authenticity: the quantum apocalypse (all
-  # classical DH/sig keys derivable) hits in phase 1, STRICTLY AFTER the phase-0
+  # classical DH/sig keys derivable) hits in phase 1, strictly after the phase-0
   # session. A session accepted before the apocalypse keeps both secrecy (ML-KEM
-  # anchor) and authenticity (timestamp form: only a compromise PRECEDING the
+  # anchor) and authenticity (timestamp form: only a compromise preceding the
   # acceptance can forge — contrast R2a, false, where the break is during the run).
   LOG_PQ=$(mktemp)
   [ -f "$EX/analysis_reg_dh_pq.pv" ] && \
     proverif "${LIBS_REG[@]}" "$EX/analysis_reg_dh_pq.pv" > "$LOG_PQ" 2>&1
-  # Session passive sanity: the FULL two-message handshake + into_session honest run
-  # must reach InitSessDH AND RespSessDH on its own (response/session non-vacuity).
+  # Session passive sanity: the full two-message handshake + into_session honest run
+  # must reach InitSessDH and RespSessDH on its own (response/session non-vacuity).
   [ -f "$EX/sanity_session_passive.pv" ] && \
     proverif "${LIBS_REG[@]}" "$EX/sanity_session_passive.pv" > "$LOG_SSAN" 2>&1
   [ -f "$EX/sanity_session_sig_passive.pv" ] && \

--- a/libcrux-psq/proofs/proverif/extraction/analysis.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis.pv
@@ -1,0 +1,51 @@
+(* PSQ query mode - full-responder analysis: reachability (P1), no-initiator-auth
+   (P4/P11), key/payload secrecy + forward secrecy (P5-P10). Drives the real
+   Responder::read_message_contents. The responder-authentication correspondences
+   P2/P3 live in analysis_auth.pv (auth core), which the DH-commutativity model
+   makes intractable through the full read_message_contents bookkeeping.
+   Shared setup/roles/aliases/nounif: -lib psq_query_lib.pvl. *)
+
+(* =========================================================================
+   Security queries (Pn) - Expected verdicts from psq-design/models/psq_query.pv
+   ========================================================================= *)
+
+(* P1  Sanity / reachability: the honest run completes.        Expected: false *)
+query p: Principal, ctx: bitstring, k: bitstring; event(QInitSend(p, ctx, k)).
+query p: Principal, ctx: bitstring, k: bitstring; event(QRespRecv(p, ctx, k)).
+query p: Principal, ctx: bitstring, er: bitstring, k: bitstring; event(QRespSend(p, ctx, er, k)).
+query p: Principal, ctx: bitstring, er: bitstring, k: bitstring; event(QInitRecv(p, ctx, er, k)).
+
+(* P4  NO initiator authentication (deliberate non-goal).      Expected: false *)
+query p: Principal, ctx: bitstring, k0: bitstring;
+      event(QRespRecv(p, ctx, k0)) ==> event(QInitSend(p, ctx, k0)).
+
+(* P5  Key secrecy K_0 ==> endpoint compromise.                 Expected: true *)
+query p: Principal, ctx: bitstring, k0: bitstring;
+      event(QInitSend(p, ctx, k0)) && attacker(k0) ==> event(CompromiseEndpoint(p)).
+
+(* P6  Key secrecy K_2 (honest initiator view) ==> compromise.  Expected: true *)
+query p: Principal, ctx: bitstring, er: bitstring, k2: bitstring;
+      event(QInitRecv(p, ctx, er, k2)) && attacker(k2) ==> event(CompromiseEndpoint(p)).
+
+(* P7  Query-payload confidentiality ==> compromise.            Expected: true *)
+query attacker(query_secret) ==> event(CompromiseEndpoint(Bob)).
+
+(* P8  Response-payload confidentiality ==> compromise.         Expected: true *)
+query attacker(response_secret) ==> event(CompromiseEndpoint(Bob)).
+
+(* P9  Forward secrecy of the RESPONSE (deletion schedule).     Expected: true *)
+query attacker(response_secret).
+
+(* P10 NO forward secrecy of the QUERY.                        Expected: false *)
+query attacker(query_secret).
+
+(* P11 No initiator auth at the key level (responder K_2 not uniformly secret).
+                                                               Expected: false *)
+query p: Principal, ctx: bitstring, er: bitstring, k2: bitstring;
+      event(QRespSend(p, ctx, er, k2)) && attacker(k2) ==> event(CompromiseEndpoint(p)).
+
+process
+    ( setup_responder(Bob)
+    | ( !query_initiator(Bob) )
+    | ( !query_responder(Bob) )
+    | ( phase 1; !compromise_endpoint(Bob) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis.pv
@@ -1,5 +1,5 @@
 (* PSQ query mode - full-responder analysis: reachability (P1), no-initiator-auth
-   (P4/P11), key/payload secrecy + forward secrecy (P5-P10). Drives the real
+   (P4/P11), key/payload secrecy + forward secrecy (P5-P10). Drives the
    Responder::read_message_contents. The responder-authentication correspondences
    P2/P3 live in analysis_auth.pv (auth core), which the DH-commutativity model
    makes intractable through the full read_message_contents bookkeeping.
@@ -9,13 +9,13 @@
    Security queries (Pn) - Expected verdicts from psq-design/models/psq_query.pv
    ========================================================================= *)
 
-(* P1  Sanity / reachability: the honest run completes.        Expected: false *)
+(* P1  Sanity / reachability: the run completes.        Expected: false *)
 query p: Principal, ctx: bitstring, k: bitstring; event(QInitSend(p, ctx, k)).
 query p: Principal, ctx: bitstring, k: bitstring; event(QRespRecv(p, ctx, k)).
 query p: Principal, ctx: bitstring, er: bitstring, k: bitstring; event(QRespSend(p, ctx, er, k)).
 query p: Principal, ctx: bitstring, er: bitstring, k: bitstring; event(QInitRecv(p, ctx, er, k)).
 
-(* P4  NO initiator authentication (deliberate non-goal).      Expected: false *)
+(* P4  no initiator authentication (deliberate non-goal).      Expected: false *)
 query p: Principal, ctx: bitstring, k0: bitstring;
       event(QRespRecv(p, ctx, k0)) ==> event(QInitSend(p, ctx, k0)).
 
@@ -23,7 +23,7 @@ query p: Principal, ctx: bitstring, k0: bitstring;
 query p: Principal, ctx: bitstring, k0: bitstring;
       event(QInitSend(p, ctx, k0)) && attacker(k0) ==> event(CompromiseEndpoint(p)).
 
-(* P6  Key secrecy K_2 (honest initiator view) ==> compromise.  Expected: true *)
+(* P6  Key secrecy K_2 (initiator view) ==> compromise.  Expected: true *)
 query p: Principal, ctx: bitstring, er: bitstring, k2: bitstring;
       event(QInitRecv(p, ctx, er, k2)) && attacker(k2) ==> event(CompromiseEndpoint(p)).
 
@@ -33,10 +33,10 @@ query attacker(query_secret) ==> event(CompromiseEndpoint(Bob)).
 (* P8  Response-payload confidentiality ==> compromise.         Expected: true *)
 query attacker(response_secret) ==> event(CompromiseEndpoint(Bob)).
 
-(* P9  Forward secrecy of the RESPONSE (deletion schedule).     Expected: true *)
+(* P9  Forward secrecy of the response (deletion schedule).     Expected: true *)
 query attacker(response_secret).
 
-(* P10 NO forward secrecy of the QUERY.                        Expected: false *)
+(* P10 no forward secrecy of the query.                        Expected: false *)
 query attacker(query_secret).
 
 (* P11 No initiator auth at the key level (responder K_2 not uniformly secret).

--- a/libcrux-psq/proofs/proverif/extraction/analysis_auth.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_auth.pv
@@ -1,0 +1,61 @@
+(* PSQ query mode - responder authentication (P2) + replay protection (P3),
+   driven against the auth-core responder. Shared setup/roles/aliases/nounif:
+   -lib psq_query_lib.pvl. *)
+
+(* Auth-core responder: drives decrypt_outer_message directly, skipping the
+   rate-limiter / ciphersuite-coercion / state-machine bookkeeping of
+   read_message_contents (none security-relevant to query-mode authentication).
+   This keeps the responder-authentication correspondence tractable under the
+   DH-commutativity equation (full read_message_contents does not terminate). *)
+let query_responder_core(p: Principal) =
+    get resp_sk(=p, sk_R) in
+    get resp_cs(=p, cs_R) in
+    new rng_R0: bitstring;
+    let resp0 = resp_new(cs_R, context, resp_aad, rk_bound, rng_R0) in
+    in(c, msg: bitstring);
+    let dec = resp_decrypt_outer(resp0, msg) in
+    let initiator_payload = t3_0(dec) in
+    let tx0_r  = t3_1(dec) in
+    let k0_r   = t3_2(dec) in
+    let libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(qp) = initiator_payload in
+    let epubI_r = hm_pk(msg) in
+    event QRespRecv(p, context, k0_r);
+    new rng_R1: bitstring;
+    let eph_R = t2_1(dh_new(rng_R1)) in
+    let epub_R  = dh_pk(eph_R) in
+    let epriv_R = dh_sk(eph_R) in
+    let tx2_r = tx2c(tx0_r, epub_R) in
+    let k2_r = resp_derive_k2(k0_r, epubI_r, epriv_R, sk_R, tx2_r, aead_chacha()) in
+    event QRespSend(p, context, epub_R, k2_r);
+    if qp = mk_vlbytes(query_secret) then (
+        let enc = hs_encrypt(k2_r, mk_respout(mk_vlbytes(response_secret)), resp_aad) in
+        out(c, mk_hsmsg(epub_R, t2_0(t2_1(enc)), t2_1(t2_1(enc)), resp_aad, query_cs()))
+    ) else (
+        let enc = hs_encrypt(k2_r, mk_respout(mk_vlbytes(public_response)), resp_aad) in
+        out(c, mk_hsmsg(epub_R, t2_0(t2_1(enc)), t2_1(t2_1(enc)), resp_aad, query_cs()))
+    ).
+
+(* =========================================================================
+   Responder-authentication queries (P2, P3)
+   ========================================================================= *)
+
+(* P2  Responder authentication, on the per-run id epub_R (= er): every response
+   an honest initiator accepts was produced by the genuine responder for the same
+   run. The accepting initiator only fires QInitRecv AFTER read_response decrypts
+   the responder ciphertext under its own K_2, so by AEAD integrity that K_2
+   equals the responder's - i.e. K_2 agreement is enforced by the AEAD and need
+   not be unified in the query (which would force the non-terminating reasoning
+   through the DH-commutativity equation). Hence the K_2 fields are free vars.
+                                                                 Expected: true *)
+query p: Principal, ctx: bitstring, er: bitstring, k2a: bitstring, k2b: bitstring;
+      event(QInitRecv(p, ctx, er, k2a)) ==> event(QRespSend(p, ctx, er, k2b)).
+
+(* P3  Response authenticity / replay protection (injective).   Expected: true *)
+query p: Principal, ctx: bitstring, er: bitstring, k2a: bitstring, k2b: bitstring;
+      inj-event(QInitRecv(p, ctx, er, k2a)) ==> inj-event(QRespSend(p, ctx, er, k2b)).
+
+process
+    ( setup_responder(Bob)
+    | ( !query_initiator(Bob) )
+    | ( !query_responder_core(Bob) )
+    | ( phase 1; !compromise_endpoint(Bob) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis_auth.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_auth.pv
@@ -40,8 +40,8 @@ let query_responder_core(p: Principal) =
    ========================================================================= *)
 
 (* P2  Responder authentication, on the per-run id epub_R (= er): every response
-   an honest initiator accepts was produced by the genuine responder for the same
-   run. The accepting initiator only fires QInitRecv AFTER read_response decrypts
+   an initiator accepts was produced by the genuine responder for the same
+   run. The accepting initiator only fires QInitRecv after read_response decrypts
    the responder ciphertext under its own K_2, so by AEAD integrity that K_2
    equals the responder's - i.e. K_2 agreement is enforced by the AEAD and need
    not be unified in the query (which would force the non-terminating reasoning

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_msg1.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_msg1.pv
@@ -1,0 +1,79 @@
+(* PSQ registration mode (DH auth) — MESSAGE-1 analysis, against the EXTRACTED
+   libcrux-psq model. Mirrors psq-design/models/psq_registration_dh_msg1.pv.
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   THREAT MODEL: active DY attacker. The classical endpoint key priv_R and the
+   client key priv_I are exposed CONCURRENTLY (phase 0) — a quantum adversary
+   that breaks classical DH during the run is what exposes DH-auth's weakness.
+   The PQ-KEM key and the quantum recovery of recorded ephemerals are deferred to
+   phase 1 (harvest-now-decrypt-later).
+
+   SOUNDNESS: the verdicts below are established on a SOUND honest run — the
+   passive-attacker sanity (sanity_reg_passive.pv) confirms InitRegDH+RespRegDH
+   are reachable WITHOUT attacker help and the responder's K_1 agrees with the
+   honest initiator's. This is the non-vacuity foundation; do not read any verdict
+   here without it.
+
+   Reproduces psq_registration_dh_msg1.pv EXACTLY:
+     R1  reachable (false)         R2a false (DH init-auth NOT PQ-sound)
+     R2b true                      R2c false (replay)
+     R4  true                      R6  true        R9  false *)
+
+set reconstructTrace = true.
+
+(* --- R1. Reachability of RespRegDH.                       Expected: false *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k)).
+
+(* --- R2a. Initiator auth, escape only via the initiator's own credential.
+   A quantum break of priv_R forges without compromising the initiator, so
+   DH-based initiator authentication is NOT PQ-secure.       Expected: false *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k))
+          ==> event(InitRegDH(i, r, ctx, k)) || event(CompromiseClient(i)).
+
+(* --- R2b. Initiator auth, classically sound: with the responder's classical key
+   in the escape set, no forgery while both classical keys stay secret. Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k))
+          ==> event(InitRegDH(i, r, ctx, k)) || event(CompromiseClient(i))
+              || event(CompromiseEndpointClassical(r)).
+
+(* --- R2c. Injective initiator agreement.        Expected: false (replay). *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      inj-event(RespRegDH(i, r, ctx, k))
+          ==> inj-event(InitRegDH(i, r, ctx, k)) || event(CompromiseClient(i))
+              || event(CompromiseEndpointClassical(r)).
+
+(* --- R4. K_1 secrecy: requires the PQ-KEM secret.         Expected: true.
+   Non-vacuous: R9 below (false) reconstructs the honest K_1 / reg payload, so
+   `attacker(k)` is genuinely achievable (it requires CompromiseEndpointPQ). *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(InitRegDH(i, r, ctx, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+
+(* --- R6. HNDL of the registration payload.                Expected: true *)
+query attacker(reg_secret) ==> event(CompromiseEndpointPQ(Bob)).
+
+(* --- R9. The registration payload is NOT forward-secret — it falls to long-term
+   endpoint compromise alone, with NO ephemeral break.       Expected: false.
+   The R9 counterexample reconstructs reg_secret under CompromiseEndpointPQ +
+   CompromiseEndpointClassical (no LeakEphemeral) — this DOUBLES as the leak /
+   non-vacuity control for R4 and R6 (the secret is genuinely derivable, so those
+   `=> compromise` queries are not vacuously true). *)
+query attacker(reg_secret) ==> event(LeakEphemeral(Bob)).
+
+(* --- Non-vacuity / leak control. reg_secret IS derivable in this model (under
+   the modeled endpoint compromises) — so the secrecy queries above are not
+   vacuous (mandrake lesson).                                 Expected: false *)
+query attacker(reg_secret).
+
+process
+    ( setup_responder(Bob)
+    | create_dh_client(Alice)
+    | ( !m1_dh_initiator(Alice, Bob) )
+    | ( !m1_dh_responder(Bob) )
+    | ( !compromise_endpoint_classical(Bob) )
+    | ( !compromise_dh_client(Alice) )
+    | ( phase 1;
+        ( !compromise_endpoint_pq(Bob) | !leak_ephemeral(Bob) ) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_msg1.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_msg1.pv
@@ -1,21 +1,21 @@
-(* PSQ registration mode (DH auth) — MESSAGE-1 analysis, against the EXTRACTED
+(* PSQ registration mode (DH auth) — message-1 analysis, against the extracted
    libcrux-psq model. Mirrors psq-design/models/psq_registration_dh_msg1.pv.
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
 
-   THREAT MODEL: active DY attacker. The classical endpoint key priv_R and the
-   client key priv_I are exposed CONCURRENTLY (phase 0) — a quantum adversary
+   Threat model: active DY attacker. The classical endpoint key priv_R and the
+   client key priv_I are exposed concurrently (phase 0) — a quantum adversary
    that breaks classical DH during the run is what exposes DH-auth's weakness.
    The PQ-KEM key and the quantum recovery of recorded ephemerals are deferred to
    phase 1 (harvest-now-decrypt-later).
 
-   SOUNDNESS: the verdicts below are established on a SOUND honest run — the
+   Soundness: the verdicts below are established on a sound run — the
    passive-attacker sanity (sanity_reg_passive.pv) confirms InitRegDH+RespRegDH
-   are reachable WITHOUT attacker help and the responder's K_1 agrees with the
-   honest initiator's. This is the non-vacuity foundation; do not read any verdict
+   are reachable without attacker help and the responder's K_1 agrees with the
+   initiator's. This is the non-vacuity foundation; do not read any verdict
    here without it.
 
-   Reproduces psq_registration_dh_msg1.pv EXACTLY:
-     R1  reachable (false)         R2a false (DH init-auth NOT PQ-sound)
+   Reproduces psq_registration_dh_msg1.pv exactly:
+     R1  reachable (false)         R2a false (DH init-auth not PQ-sound)
      R2b true                      R2c false (replay)
      R4  true                      R6  true        R9  false *)
 
@@ -27,7 +27,7 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
 
 (* --- R2a. Initiator auth, escape only via the initiator's own credential.
    A quantum break of priv_R forges without compromising the initiator, so
-   DH-based initiator authentication is NOT PQ-secure.       Expected: false *)
+   DH-based initiator authentication is not PQ-secure.       Expected: false *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegDH(i, r, ctx, k))
           ==> event(InitRegDH(i, r, ctx, k)) || event(CompromiseClient(i)).
@@ -46,8 +46,8 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
               || event(CompromiseEndpointClassical(r)).
 
 (* --- R4. K_1 secrecy: requires the PQ-KEM secret.         Expected: true.
-   Non-vacuous: R9 below (false) reconstructs the honest K_1 / reg payload, so
-   `attacker(k)` is genuinely achievable (it requires CompromiseEndpointPQ). *)
+   Non-vacuous: R9 below (false) reconstructs the K_1 / reg payload, so
+   `attacker(k)` is achievable (it requires CompromiseEndpointPQ). *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(InitRegDH(i, r, ctx, k)) && attacker(k)
           ==> event(CompromiseEndpointPQ(r)).
@@ -55,17 +55,17 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
 (* --- R6. HNDL of the registration payload.                Expected: true *)
 query attacker(reg_secret) ==> event(CompromiseEndpointPQ(Bob)).
 
-(* --- R9. The registration payload is NOT forward-secret — it falls to long-term
-   endpoint compromise alone, with NO ephemeral break.       Expected: false.
+(* --- R9. The registration payload is not forward-secret — it falls to long-term
+   endpoint compromise alone, with no ephemeral break.       Expected: false.
    The R9 counterexample reconstructs reg_secret under CompromiseEndpointPQ +
-   CompromiseEndpointClassical (no LeakEphemeral) — this DOUBLES as the leak /
-   non-vacuity control for R4 and R6 (the secret is genuinely derivable, so those
+   CompromiseEndpointClassical (no LeakEphemeral) — this doubles as the leak /
+   non-vacuity control for R4 and R6 (the secret is derivable, so those
    `=> compromise` queries are not vacuously true). *)
 query attacker(reg_secret) ==> event(LeakEphemeral(Bob)).
 
-(* --- Non-vacuity / leak control. reg_secret IS derivable in this model (under
-   the modeled endpoint compromises) — so the secrecy queries above are not
-   vacuous (mandrake lesson).                                 Expected: false *)
+(* --- Non-vacuity / leak control. reg_secret is derivable in this model (under
+   the modeled endpoint compromises), so the secrecy queries above are not
+   vacuous. Expected: false *)
 query attacker(reg_secret).
 
 process

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_pq.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_pq.pv
@@ -1,0 +1,74 @@
+(* PSQ registration (DH auth) — POST-QUANTUM forward secrecy & authenticity:
+   a session that COMPLETES before the quantum apocalypse keeps BOTH its secrecy
+   and its authenticity. Against the EXTRACTED libcrux-psq model.
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   THE PROPERTY (the point of PSQ's hybrid X25519+ML-KEM construction)
+   ------------------------------------------------------------------
+   Model the quantum apocalypse with PHASES (= timestamps): phase 0 is the honest
+   session under a FULL active Dolev-Yao attacker; phase 1 is the apocalypse, where
+   the attacker derives EVERY classical private key from its public — the responder
+   long-term DH key sk_R, the client long-term DH key sk_I, the session ephemeral
+   epriv_I (and, in signature mode, the classical signing key). We model that by
+   revealing all classical secrets in phase 1, STRICTLY AFTER the phase-0 session.
+   The ML-KEM-768 decapsulation key is revealed in phase 1 too (the apocalypse does
+   NOT break ML-KEM — it is the post-quantum anchor; we expose it only to witness
+   non-vacuity / the leak boundary).
+
+   Claim: classical keys compromised AFTER an accepted session do not break that
+   session — its confidentiality rests on the ML-KEM shared secret folded into K_1,
+   and its authentication completed while the classical keys were still secret.
+
+   FA1  Forward authenticity (phase form): a phase-0 responder acceptance agrees
+        with an honest initiator — the phase-1 apocalypse cannot retroactively
+        forge it.                                              Expected: true
+   FA2  Forward authenticity (TIMESTAMP form): a responder acceptance at t1 agrees
+        with an honest initiator, UNLESS a classical key was compromised BEFORE t1
+        (t2 < t1). I.e. only a compromise that PRECEDES the acceptance can forge.
+        Contrast: the same correspondence WITHOUT the `t2 < t1` guard is R2a in
+        analysis_reg_dh_msg1.pv, which is FALSE (DH-auth is not PQ-secure when the
+        attacker breaks DH DURING the run).                    Expected: true
+   FS1  Forward secrecy of the registration payload: reg_secret stays secret though
+        ALL classical DH keys leak after the session, unless ML-KEM is also
+        compromised.                                           Expected: true
+   FS2  Forward secrecy of the message-1 key K_1.             Expected: true
+   NV   Non-vacuity / leak control: reg_secret IS derivable once the phase-1 ML-KEM
+        compromise fires (so FS1/FS2 are tight, and the honest session really ran). Expected: false *)
+
+set reconstructTrace = true.
+
+(* --- FA1. Forward authenticity, phase form.                 Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k)) ==> event(InitRegDH(i, r, ctx, k)).
+
+(* --- FA2. Forward authenticity, timestamp form: accept@t1 => honest, or a
+   classical key was compromised BEFORE t1.                    Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring, t1: time, t2: time;
+      event(RespRegDH(i, r, ctx, k))@t1
+        ==> event(InitRegDH(i, r, ctx, k))
+            || (event(CompromiseClient(i))@t2 && t2 < t1)
+            || (event(CompromiseEndpointClassical(r))@t2 && t2 < t1).
+
+(* --- FS1. Forward secrecy of reg_secret: ML-KEM is the sole dependency. Expected: true *)
+query attacker(reg_secret) ==> event(CompromiseEndpointPQ(Bob)).
+
+(* --- FS2. Forward secrecy of K_1.                            Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(InitRegDH(i, r, ctx, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+
+(* --- NV. Non-vacuity: reg_secret leaks once ML-KEM falls (phase 1).  Expected: false *)
+query attacker(reg_secret).
+
+process
+    ( setup_responder(Bob)
+    | create_dh_client(Alice)
+    | ( !m1_dh_initiator_leaky(Alice, Bob) )   (* phase-0 honest session       *)
+    | ( !m1_dh_responder(Bob) )                (* phase-0 honest session       *)
+    (* QUANTUM APOCALYPSE — strictly AFTER the phase-0 session: every classical
+       private key becomes derivable, plus (to witness the leak boundary) ML-KEM. *)
+    | ( phase 1;
+        ( !compromise_endpoint_classical(Bob)   (* sk_R                         *)
+        | !compromise_dh_client(Alice)           (* sk_I                         *)
+        | !leak_ephemeral(Bob)                   (* epriv_I                      *)
+        | !compromise_endpoint_pq(Bob) ) ) )     (* ML-KEM (non-vacuity witness) *)

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_pq.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_pq.pv
@@ -1,39 +1,39 @@
-(* PSQ registration (DH auth) — POST-QUANTUM forward secrecy & authenticity:
-   a session that COMPLETES before the quantum apocalypse keeps BOTH its secrecy
-   and its authenticity. Against the EXTRACTED libcrux-psq model.
+(* PSQ registration (DH auth) — post-quantum forward secrecy & authenticity:
+   a session that completes before the quantum apocalypse keeps both its secrecy
+   and its authenticity. Against the extracted libcrux-psq model.
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
 
-   THE PROPERTY (the point of PSQ's hybrid X25519+ML-KEM construction)
+   The property (the point of PSQ's hybrid X25519+ML-KEM construction)
    ------------------------------------------------------------------
-   Model the quantum apocalypse with PHASES (= timestamps): phase 0 is the honest
-   session under a FULL active Dolev-Yao attacker; phase 1 is the apocalypse, where
-   the attacker derives EVERY classical private key from its public — the responder
+   Model the quantum apocalypse with phases (= timestamps): phase 0 is the
+   session under a full active Dolev-Yao attacker; phase 1 is the apocalypse, where
+   the attacker derives every classical private key from its public — the responder
    long-term DH key sk_R, the client long-term DH key sk_I, the session ephemeral
    epriv_I (and, in signature mode, the classical signing key). We model that by
-   revealing all classical secrets in phase 1, STRICTLY AFTER the phase-0 session.
+   revealing all classical secrets in phase 1, strictly after the phase-0 session.
    The ML-KEM-768 decapsulation key is revealed in phase 1 too (the apocalypse does
-   NOT break ML-KEM — it is the post-quantum anchor; we expose it only to witness
+   not break ML-KEM — it is the post-quantum anchor; we expose it only to witness
    non-vacuity / the leak boundary).
 
-   Claim: classical keys compromised AFTER an accepted session do not break that
+   Claim: classical keys compromised after an accepted session do not break that
    session — its confidentiality rests on the ML-KEM shared secret folded into K_1,
    and its authentication completed while the classical keys were still secret.
 
    FA1  Forward authenticity (phase form): a phase-0 responder acceptance agrees
-        with an honest initiator — the phase-1 apocalypse cannot retroactively
+        with an initiator — the phase-1 apocalypse cannot retroactively
         forge it.                                              Expected: true
-   FA2  Forward authenticity (TIMESTAMP form): a responder acceptance at t1 agrees
-        with an honest initiator, UNLESS a classical key was compromised BEFORE t1
-        (t2 < t1). I.e. only a compromise that PRECEDES the acceptance can forge.
-        Contrast: the same correspondence WITHOUT the `t2 < t1` guard is R2a in
-        analysis_reg_dh_msg1.pv, which is FALSE (DH-auth is not PQ-secure when the
-        attacker breaks DH DURING the run).                    Expected: true
+   FA2  Forward authenticity (timestamp form): a responder acceptance at t1 agrees
+        with an initiator, unless a classical key was compromised before t1
+        (t2 < t1). I.e. only a compromise that precedes the acceptance can forge.
+        Contrast: the same correspondence without the `t2 < t1` guard is R2a in
+        analysis_reg_dh_msg1.pv, which is false (DH-auth is not PQ-secure when the
+        attacker breaks DH during the run).                    Expected: true
    FS1  Forward secrecy of the registration payload: reg_secret stays secret though
-        ALL classical DH keys leak after the session, unless ML-KEM is also
+        all classical DH keys leak after the session, unless ML-KEM is also
         compromised.                                           Expected: true
    FS2  Forward secrecy of the message-1 key K_1.             Expected: true
-   NV   Non-vacuity / leak control: reg_secret IS derivable once the phase-1 ML-KEM
-        compromise fires (so FS1/FS2 are tight, and the honest session really ran). Expected: false *)
+   NV   Non-vacuity / leak control: reg_secret is derivable once the phase-1 ML-KEM
+        compromise fires (so FS1/FS2 are tight, and the session really ran). Expected: false *)
 
 set reconstructTrace = true.
 
@@ -42,7 +42,7 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegDH(i, r, ctx, k)) ==> event(InitRegDH(i, r, ctx, k)).
 
 (* --- FA2. Forward authenticity, timestamp form: accept@t1 => honest, or a
-   classical key was compromised BEFORE t1.                    Expected: true *)
+   classical key was compromised before t1.                    Expected: true *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring, t1: time, t2: time;
       event(RespRegDH(i, r, ctx, k))@t1
         ==> event(InitRegDH(i, r, ctx, k))
@@ -63,9 +63,9 @@ query attacker(reg_secret).
 process
     ( setup_responder(Bob)
     | create_dh_client(Alice)
-    | ( !m1_dh_initiator_leaky(Alice, Bob) )   (* phase-0 honest session       *)
-    | ( !m1_dh_responder(Bob) )                (* phase-0 honest session       *)
-    (* QUANTUM APOCALYPSE — strictly AFTER the phase-0 session: every classical
+    | ( !m1_dh_initiator_leaky(Alice, Bob) )   (* phase-0 session       *)
+    | ( !m1_dh_responder(Bob) )                (* phase-0 session       *)
+    (* Quantum apocalypse — strictly after the phase-0 session: every classical
        private key becomes derivable, plus (to witness the leak boundary) ML-KEM. *)
     | ( phase 1;
         ( !compromise_endpoint_classical(Bob)   (* sk_R                         *)

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_session.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_session.pv
@@ -1,0 +1,69 @@
+(* PSQ registration mode (DH auth) — RESPONSE / SESSION analysis, against the
+   EXTRACTED libcrux-psq model. Mirrors psq-design/models/psq_registration_dh_session.pv.
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   Drives the FULL two-message handshake on the real extracted code: the initiator
+   writes msg1, reads the response and into_session (InitSessDH); the responder
+   reads msg1 via the FULL read_message_contents path (rate-limit + coerce +
+   decrypt_outer/inner + state bookkeeping — unblocked by the CiphersuiteBase::name
+   fix), prepares the response and into_session (RespSessDH). The honest run is
+   sound: sanity_session_passive.pv reaches both events under a passive attacker.
+
+   THREAT MODEL: active attacker; phase-1 compromise of the PQ-KEM key and quantum
+   recovery of a recorded session ephemeral (the classical-DH-key leaks belong to
+   the msg1 initiator-auth contrast and are omitted here for tractability).
+
+   PROPERTIES (mirror the spec):
+     R1   Reachability of InitSessDH / RespSessDH.            Expected: reachable (false)
+     R5   Key secrecy of K_S — requires the PQ-KEM secret.    Expected: true
+     R7   HNDL of the response/session payload.               Expected: true
+     R8   Forward secrecy of the session — leaks only if a session ephemeral
+          is broken.                                          Expected: true
+
+   R3/R3i (responder authentication) DO NOT TERMINATE for DH mode (the DH
+   commutativity equation x the response's two DH shared secrets blows up
+   saturation) — exactly as in the spec, which machine-verifies them in the
+   signature mode and argues DH identically (the responder authenticates via the
+   PQ-KEM-derived K_1 in both). Kept commented. *)
+
+set reconstructTrace = false.
+
+(* R1 (reachability of InitSessDH / RespSessDH) is established by the PASSIVE
+   sanity (sanity_session_passive.pv) — the honest run reaches both. Under the
+   ACTIVE attacker the reachability query only yields "cannot be proved" (trace
+   reconstruction is intractable through the full handshake + DH commutativity)
+   and adds ~13 min, so it is NOT re-asserted here; the secrecy queries below run
+   against the same sound run. *)
+
+(* --- R5. Key secrecy of K_S: requires the PQ-KEM secret.   Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessDH(i, r, ctx, e, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(RespSessDH(i, r, ctx, e, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+
+(* --- R7. HNDL of the response/session payload.             Expected: true *)
+query attacker(resp_secret) ==> event(CompromiseEndpointPQ(Bob)).
+
+(* --- R8. Forward secrecy of the session — the session ephemeral x ephemeral DH
+   in K_2 protects resp_secret even under PQ + long-term compromise, unless a
+   session ephemeral is itself broken.                       Expected: true *)
+query attacker(resp_secret) ==> event(LeakEphemeral(Bob)).
+
+(* R3 / R3i — responder authentication; non-terminating for DH mode (see header).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessDH(i, r, ctx, e, k))
+          ==> event(RespSessDH(i, r, ctx, e, k)) || event(CompromiseEndpointPQ(r)).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      inj-event(InitSessDH(i, r, ctx, e, k))
+          ==> inj-event(RespSessDH(i, r, ctx, e, k)) || event(CompromiseEndpointPQ(r)).
+*)
+
+process
+    ( setup_responder(Bob)
+    | create_dh_client(Alice)
+    | ( !sess_dh_initiator(Alice, Bob) )
+    | ( !sess_dh_responder(Bob) )
+    | ( phase 1;
+        ( !compromise_endpoint_pq(Bob) | !leak_ephemeral(Bob) ) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_session.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_dh_session.pv
@@ -1,26 +1,26 @@
-(* PSQ registration mode (DH auth) — RESPONSE / SESSION analysis, against the
-   EXTRACTED libcrux-psq model. Mirrors psq-design/models/psq_registration_dh_session.pv.
+(* PSQ registration mode (DH auth) — response / session analysis, against the
+   extracted libcrux-psq model. Mirrors psq-design/models/psq_registration_dh_session.pv.
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
 
-   Drives the FULL two-message handshake on the real extracted code: the initiator
+   Drives the two-message handshake on the extracted code: the initiator
    writes msg1, reads the response and into_session (InitSessDH); the responder
-   reads msg1 via the FULL read_message_contents path (rate-limit + coerce +
-   decrypt_outer/inner + state bookkeeping — unblocked by the CiphersuiteBase::name
-   fix), prepares the response and into_session (RespSessDH). The honest run is
-   sound: sanity_session_passive.pv reaches both events under a passive attacker.
+   reads msg1 via the read_message_contents path (rate-limit + coerce +
+   decrypt_outer/inner + state bookkeeping), prepares the response and
+   into_session (RespSessDH). sanity_session_passive.pv reaches both events
+   under a passive attacker.
 
-   THREAT MODEL: active attacker; phase-1 compromise of the PQ-KEM key and quantum
+   Threat model: active attacker; phase-1 compromise of the PQ-KEM key and quantum
    recovery of a recorded session ephemeral (the classical-DH-key leaks belong to
    the msg1 initiator-auth contrast and are omitted here for tractability).
 
-   PROPERTIES (mirror the spec):
+   Properties (mirror the spec):
      R1   Reachability of InitSessDH / RespSessDH.            Expected: reachable (false)
      R5   Key secrecy of K_S — requires the PQ-KEM secret.    Expected: true
      R7   HNDL of the response/session payload.               Expected: true
      R8   Forward secrecy of the session — leaks only if a session ephemeral
           is broken.                                          Expected: true
 
-   R3/R3i (responder authentication) DO NOT TERMINATE for DH mode (the DH
+   R3/R3i (responder authentication) do not terminate for DH mode (the DH
    commutativity equation x the response's two DH shared secrets blows up
    saturation) — exactly as in the spec, which machine-verifies them in the
    signature mode and argues DH identically (the responder authenticates via the
@@ -28,11 +28,11 @@
 
 set reconstructTrace = false.
 
-(* R1 (reachability of InitSessDH / RespSessDH) is established by the PASSIVE
-   sanity (sanity_session_passive.pv) — the honest run reaches both. Under the
-   ACTIVE attacker the reachability query only yields "cannot be proved" (trace
+(* R1 (reachability of InitSessDH / RespSessDH) is established by the passive
+   sanity (sanity_session_passive.pv) — the run reaches both. Under the
+   active attacker the reachability query only yields "cannot be proved" (trace
    reconstruction is intractable through the full handshake + DH commutativity)
-   and adds ~13 min, so it is NOT re-asserted here; the secrecy queries below run
+   and adds ~13 min, so it is not re-asserted here; the secrecy queries below run
    against the same sound run. *)
 
 (* --- R5. Key secrecy of K_S: requires the PQ-KEM secret.   Expected: true *)

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_msg1.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_msg1.pv
@@ -1,0 +1,58 @@
+(* PSQ registration mode (signature auth) — MESSAGE-1 analysis, against the
+   EXTRACTED libcrux-psq model. Mirrors psq-design/models/psq_registration_sig_msg1.pv.
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   HEADLINE CONTRAST: signature-based initiator authentication IS PQ-secure
+   (R2a true) — a quantum adversary breaks all classical DH but cannot forge a PQ
+   signature; the same query is FALSE in DH mode (analysis_reg_dh_msg1.pv).
+
+   SOUNDNESS: established on a SOUND honest run (see sanity_reg_passive.pv —
+   InitRegSig+RespRegSig reachable under a passive attacker, K_1 agrees).
+
+   Reproduces psq_registration_sig_msg1.pv EXACTLY:
+     R1 reachable (false)   R2a true   R2c false (replay)
+     R4 true                R6 true    R9 false *)
+
+set reconstructTrace = true.
+
+(* --- R1. Reachability of RespRegSig.                      Expected: false *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegSig(i, r, ctx, k)).
+
+(* --- R2a. Initiator auth, escape only via the initiator's own credential sk_I.
+   Signature-based auth IS PQ-secure.                       Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegSig(i, r, ctx, k))
+          ==> event(InitRegSig(i, r, ctx, k)) || event(CompromiseClient(i)).
+
+(* --- R2c. Injective initiator agreement.        Expected: false (replay). *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      inj-event(RespRegSig(i, r, ctx, k))
+          ==> inj-event(InitRegSig(i, r, ctx, k)) || event(CompromiseClient(i)).
+
+(* --- R4. K_1 secrecy: requires the PQ-KEM secret.         Expected: true.
+   Non-vacuous via R9 below (reconstructs the honest K_1 / reg payload). *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(InitRegSig(i, r, ctx, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+
+(* --- R6. HNDL of the registration payload.                Expected: true *)
+query attacker(reg_secret) ==> event(CompromiseEndpointPQ(Bob)).
+
+(* --- R9. Registration payload is NOT forward-secret.       Expected: false.
+   The counterexample reconstructs reg_secret under endpoint compromise with NO
+   ephemeral break — doubles as the leak / non-vacuity control for R4 and R6. *)
+query attacker(reg_secret) ==> event(LeakEphemeral(Bob)).
+
+(* --- Non-vacuity / leak control: reg_secret IS derivable (mandrake lesson). Expected: false *)
+query attacker(reg_secret).
+
+process
+    ( setup_responder(Bob)
+    | create_sig_client(Alice)
+    | ( !m1_sig_initiator(Alice, Bob) )
+    | ( !m1_sig_responder(Bob) )
+    | ( !compromise_endpoint_classical(Bob) )
+    | ( !compromise_sig_client(Alice) )
+    | ( phase 1;
+        ( !compromise_endpoint_pq(Bob) | !leak_ephemeral(Bob) ) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_msg1.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_msg1.pv
@@ -1,15 +1,15 @@
-(* PSQ registration mode (signature auth) — MESSAGE-1 analysis, against the
-   EXTRACTED libcrux-psq model. Mirrors psq-design/models/psq_registration_sig_msg1.pv.
+(* PSQ registration mode (signature auth) — message-1 analysis, against the
+   extracted libcrux-psq model. Mirrors psq-design/models/psq_registration_sig_msg1.pv.
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
 
-   HEADLINE CONTRAST: signature-based initiator authentication IS PQ-secure
+   Headline contrast: signature-based initiator authentication is PQ-secure
    (R2a true) — a quantum adversary breaks all classical DH but cannot forge a PQ
-   signature; the same query is FALSE in DH mode (analysis_reg_dh_msg1.pv).
+   signature; the same query is false in DH mode (analysis_reg_dh_msg1.pv).
 
-   SOUNDNESS: established on a SOUND honest run (see sanity_reg_passive.pv —
+   Soundness: established on a sound run (see sanity_reg_passive.pv —
    InitRegSig+RespRegSig reachable under a passive attacker, K_1 agrees).
 
-   Reproduces psq_registration_sig_msg1.pv EXACTLY:
+   Reproduces psq_registration_sig_msg1.pv exactly:
      R1 reachable (false)   R2a true   R2c false (replay)
      R4 true                R6 true    R9 false *)
 
@@ -20,7 +20,7 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegSig(i, r, ctx, k)).
 
 (* --- R2a. Initiator auth, escape only via the initiator's own credential sk_I.
-   Signature-based auth IS PQ-secure.                       Expected: true *)
+   Signature-based auth is PQ-secure.                       Expected: true *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegSig(i, r, ctx, k))
           ==> event(InitRegSig(i, r, ctx, k)) || event(CompromiseClient(i)).
@@ -31,7 +31,7 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
           ==> inj-event(InitRegSig(i, r, ctx, k)) || event(CompromiseClient(i)).
 
 (* --- R4. K_1 secrecy: requires the PQ-KEM secret.         Expected: true.
-   Non-vacuous via R9 below (reconstructs the honest K_1 / reg payload). *)
+   Non-vacuous via R9 below (reconstructs the K_1 / reg payload). *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(InitRegSig(i, r, ctx, k)) && attacker(k)
           ==> event(CompromiseEndpointPQ(r)).
@@ -39,12 +39,12 @@ query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
 (* --- R6. HNDL of the registration payload.                Expected: true *)
 query attacker(reg_secret) ==> event(CompromiseEndpointPQ(Bob)).
 
-(* --- R9. Registration payload is NOT forward-secret.       Expected: false.
-   The counterexample reconstructs reg_secret under endpoint compromise with NO
+(* --- R9. Registration payload is not forward-secret.       Expected: false.
+   The counterexample reconstructs reg_secret under endpoint compromise with no
    ephemeral break — doubles as the leak / non-vacuity control for R4 and R6. *)
 query attacker(reg_secret) ==> event(LeakEphemeral(Bob)).
 
-(* --- Non-vacuity / leak control: reg_secret IS derivable (mandrake lesson). Expected: false *)
+(* --- Non-vacuity / leak control: reg_secret is derivable. Expected: false *)
 query attacker(reg_secret).
 
 process

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_session.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_session.pv
@@ -1,0 +1,58 @@
+(* PSQ registration (sig auth) — RESPONSE / SESSION analysis, against the EXTRACTED
+   libcrux-psq model. Mirrors psq-design/models/psq_registration_sig_session.pv.
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   Drives the FULL two-message handshake + into_session on the real extracted code
+   in SIGNATURE-auth mode (sess_sig_{initiator,responder}). Unlike DH mode, the
+   response K_2 folds only ONE DH term (responder_eph x initiator_eph), so the
+   responder-authentication correspondences R3/R3i ARE machine-verifiable here.
+   Honest run is sound (sanity_session_sig_passive.pv reaches both events, passive).
+
+   THREAT MODEL: active attacker; phase-1 compromise of the PQ-KEM key + quantum
+   recovery of a recorded session ephemeral.
+
+   R1   Reachability of InitSessSig / RespSessSig.            Expected: reachable (false)
+   R3   Responder authentication, PQ-secure: an initiator's session view implies
+        the responder ran, unless the PQ-KEM key is compromised.  Expected: true
+   R3i  Injective responder agreement.                        Expected: true
+   R5   Key secrecy of K_S — requires the PQ-KEM secret.       Expected: true
+   R7   HNDL of the response/session payload.                  Expected: true
+   R8   Forward secrecy of the session.                        Expected: true *)
+
+set reconstructTrace = false.
+
+(* R1 is established by the PASSIVE sanity (sanity_session_sig_passive.pv). Under
+   the active attacker the reachability query only yields "cannot be proved", so
+   it is not re-asserted here; the queries below run against the same sound run. *)
+
+(* --- R3. Responder authentication, PQ-secure.               Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessSig(i, r, ctx, e, k))
+          ==> event(RespSessSig(i, r, ctx, e, k)) || event(CompromiseEndpointPQ(r)).
+
+(* --- R3i. Injective responder agreement.                    Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      inj-event(InitSessSig(i, r, ctx, e, k))
+          ==> inj-event(RespSessSig(i, r, ctx, e, k)) || event(CompromiseEndpointPQ(r)).
+
+(* --- R5. Key secrecy of K_S: requires the PQ-KEM secret.    Expected: true *)
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessSig(i, r, ctx, e, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(RespSessSig(i, r, ctx, e, k)) && attacker(k)
+          ==> event(CompromiseEndpointPQ(r)).
+
+(* --- R7. HNDL of the response/session payload.              Expected: true *)
+query attacker(resp_secret) ==> event(CompromiseEndpointPQ(Bob)).
+
+(* --- R8. Forward secrecy of the session.                    Expected: true *)
+query attacker(resp_secret) ==> event(LeakEphemeral(Bob)).
+
+process
+    ( setup_responder(Bob)
+    | create_sig_client(Alice)
+    | ( !sess_sig_initiator(Alice, Bob) )
+    | ( !sess_sig_responder(Bob) )
+    | ( phase 1;
+        ( !compromise_endpoint_pq(Bob) | !leak_ephemeral(Bob) ) ) )

--- a/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_session.pv
+++ b/libcrux-psq/proofs/proverif/extraction/analysis_reg_sig_session.pv
@@ -1,14 +1,14 @@
-(* PSQ registration (sig auth) — RESPONSE / SESSION analysis, against the EXTRACTED
+(* PSQ registration (sig auth) — response / session analysis, against the extracted
    libcrux-psq model. Mirrors psq-design/models/psq_registration_sig_session.pv.
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
 
-   Drives the FULL two-message handshake + into_session on the real extracted code
-   in SIGNATURE-auth mode (sess_sig_{initiator,responder}). Unlike DH mode, the
-   response K_2 folds only ONE DH term (responder_eph x initiator_eph), so the
-   responder-authentication correspondences R3/R3i ARE machine-verifiable here.
-   Honest run is sound (sanity_session_sig_passive.pv reaches both events, passive).
+   Drives the full two-message handshake + into_session on the extracted code
+   in signature-auth mode (sess_sig_{initiator,responder}). Unlike DH mode, the
+   response K_2 folds only one DH term (responder_eph x initiator_eph), so the
+   responder-authentication correspondences R3/R3i are machine-verifiable here.
+   Run is sound (sanity_session_sig_passive.pv reaches both events, passive).
 
-   THREAT MODEL: active attacker; phase-1 compromise of the PQ-KEM key + quantum
+   Threat model: active attacker; phase-1 compromise of the PQ-KEM key + quantum
    recovery of a recorded session ephemeral.
 
    R1   Reachability of InitSessSig / RespSessSig.            Expected: reachable (false)
@@ -21,7 +21,7 @@
 
 set reconstructTrace = false.
 
-(* R1 is established by the PASSIVE sanity (sanity_session_sig_passive.pv). Under
+(* R1 is established by the passive sanity (sanity_session_sig_passive.pv). Under
    the active attacker the reachability query only yields "cannot be proved", so
    it is not re-asserted here; the queries below run against the same sound run. *)
 

--- a/libcrux-psq/proofs/proverif/extraction/psq_query_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_query_lib.pvl
@@ -1,0 +1,238 @@
+(* PSQ query-mode shared model: setup, roles, crypto aliases, resolution
+   control. Loaded (via -lib) by analysis.pv (full responder, P1+P4..P11) and
+   analysis_auth.pv (auth-core responder, P2/P3). See those files for queries. *)
+
+(* ===========================================================================
+   PSQ — Query mode: security analysis against the EXTRACTED libcrux-psq model
+   ===========================================================================
+   This file adds a handwritten top-level process and the query-mode security
+   queries (P1–P11) on top of the extracted `lib.pvl` (driven via check-pv.sh,
+   which composes primitives.pvl + psq_crypto.pvl + missingdecl + lib.clean.pvl).
+
+   The process drives the real extracted letfuns:
+     initiator : QueryInitiator::new_kw, write_message_external_encoding,
+                 read_response  (+ derive_k2_query_initiator to expose K_2)
+     responder : Responder::new_kw, read_message_contents
+                 (+ derive_k2_query_responder / handshake_encrypt to produce the
+                  response — the responder's ephemeral is generated INSIDE
+                  prepare_message_contents and is therefore inaccessible from the
+                  process, so the response step is driven one level lower, which
+                  is exactly what prepare_message_contents/query_kw do internally,
+                  and lets the process observe the K_2 it derives.)
+
+   It mirrors psq-design/models/psq_handshake_lib.pvl's query_initiator /
+   query_responder, and reproduces psq_query.pv's P1–P11 verdicts. The threat
+   model is an active Dolev-Yao attacker (everything goes on `c`) plus a phase-1
+   compromise of the responder's long-term DH key (harvest-now-decrypt-later).
+   ProVerif phases are global barriers and the honest roles carry no `phase`
+   instruction, so every honest run completes in phase 0 before the compromise.
+   =========================================================================== *)
+
+type Principal.
+const Bob: Principal.   (* the (single) responder endpoint *)
+
+(* Public, attacker-known protocol parameters (the handshake context + AADs). *)
+const context:  bitstring.
+const init_aad: bitstring.
+const resp_aad: bitstring.
+const rk_bound: bitstring.   (* responder rate-limiter bound (symbolically opaque) *)
+
+(* Secrets. The honest initiator's query token doubles as the responder's
+   application gate (a confidential response is only as secret as the query that
+   requested it). public_response is what every other (incl. attacker) query gets. *)
+free query_secret:    bitstring [private].
+free response_secret: bitstring [private].
+free public_response: bitstring.
+
+(* ---- Responder key tables (authentic distribution of the public key) ---- *)
+table resp_sk(Principal, bitstring).   (* long-term DH scalar priv_R          *)
+table resp_pk(Principal, bitstring).   (* long-term DH public key pub_R        *)
+table resp_cs(Principal, bitstring).   (* the ResponderCiphersuite             *)
+
+(* ---- Events; mirror psq_handshake_lib.pvl ------------------------------- *)
+(* The K_0 events carry (r, context, K_0). The K_2 events additionally carry the
+   responder ephemeral public key epub_R: it is the per-run identifier the two
+   parties agree on (both derive K_2 deterministically from it + the shared k0 /
+   transcript), so the responder-authentication correspondence is stated on
+   epub_R. Keying it on the *derived* K_2 instead is logically equivalent — AEAD
+   integrity makes the accepted K_2 equal the responder's — but forces ProVerif
+   to unify K_2 across the DH-commutativity equation, which does not terminate.
+   K_2 is still carried (4th field) so the key-secrecy queries (P6/P11) keep it. *)
+event QInitSend(Principal, bitstring, bitstring).             (* p, ctx, K_0          *)
+event QRespRecv(Principal, bitstring, bitstring).             (* p, ctx, K_0          *)
+event QRespSend(Principal, bitstring, bitstring, bitstring).  (* p, ctx, epub_R, K_2  *)
+event QInitRecv(Principal, bitstring, bitstring, bitstring).  (* p, ctx, epub_R, K_2  *)
+event CompromiseEndpoint(Principal).
+
+(* =========================================================================
+   Aliases for the extracted names (purely cosmetic — keep the process readable)
+   ========================================================================= *)
+(* tuple projectors *)
+letfun t2_0(t: bitstring) = rust_primitives__hax__Tuple2__Tuple2__0(t).
+letfun t2_1(t: bitstring) = rust_primitives__hax__Tuple2__Tuple2__1(t).
+letfun t3_0(t: bitstring) = rust_primitives__hax__Tuple3__Tuple3__0(t).
+letfun t3_1(t: bitstring) = rust_primitives__hax__Tuple3__Tuple3__1(t).
+letfun t3_2(t: bitstring) = rust_primitives__hax__Tuple3__Tuple3__2(t).
+letfun resp_decrypt_outer(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__responder__Impl__decrypt_outer_message(self, msg).
+
+(* initiator entry points *)
+letfun init_new(pkR: bitstring, ctx: bitstring, aad: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__Impl__new_kw(pkR, ctx, aad, rng).
+letfun init_write(self: bitstring, payload: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__Impl_1__write_message_external_encoding(self, payload).
+letfun init_read_response(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__Impl__read_response(self, msg).
+letfun init_derive_k2(k0: bitstring, epubR: bitstring, eprivI: bitstring, pkR: bitstring, tx2: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__derive_k2_query_initiator(k0, epubR, eprivI, pkR, tx2).
+
+(* QueryInitiator field projectors *)
+letfun qi_k0(qi: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__QueryInitiator__QueryInitiator__k0(qi).
+letfun qi_tx0(qi: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__QueryInitiator__QueryInitiator__tx0(qi).
+letfun qi_rpk(qi: bitstring) =
+  libcrux_psq__handshake__initiator__query_kw__QueryInitiator__QueryInitiator__responder_longterm_ecdh_pk(qi).
+letfun qi_ephsk(qi: bitstring) =
+  libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair__sk(
+    libcrux_psq__handshake__initiator__query_kw__QueryInitiator__QueryInitiator__initiator_ephemeral_keys(qi)).
+
+(* responder entry points *)
+letfun resp_new(cs: bitstring, ctx: bitstring, aad: bitstring, bound: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__responder__Impl__new_kw(cs, ctx, aad, bound, rng).
+letfun resp_read(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__responder__Impl__read_message_contents(self, msg).
+letfun resp_derive_k2(k0: bitstring, epubI: bitstring, eprivR: bitstring, skR: bitstring, tx2: bitstring, at: bitstring) =
+  libcrux_psq__handshake__responder__derive_k2_query_responder(k0, epubI, eprivR, skR, tx2, at).
+
+(* responder state projectors *)
+letfun r_state(self: bitstring) =
+  libcrux_psq__handshake__responder__Responder__Responder__state(self).
+letfun rqs_tx0(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondQueryState__RespondQueryState__tx0(s).
+letfun rqs_k0(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondQueryState__RespondQueryState__k0(s).
+letfun rqs_epubi(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondQueryState__RespondQueryState__initiator_ephemeral_ecdh_pk(s).
+
+(* crypto + message helpers *)
+letfun dh_new(rng: bitstring) = libcrux_psq__handshake__dhkem__Impl_8__new_kw(rng).
+letfun dh_sk(kp: bitstring) = libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair__sk(kp).
+letfun dh_pk(kp: bitstring) = libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair__pk(kp).
+letfun hs_encrypt(k: bitstring, pt: bitstring, aad: bitstring) =
+  libcrux_psq__aead__Impl_1__handshake_encrypt(k, pt, aad).
+letfun tx2c(prev: bitstring, epubR: bitstring) =
+  libcrux_psq__handshake__transcript__tx2(prev, epubR).
+letfun hm_pk(m: bitstring) =
+  libcrux_psq__handshake__HandshakeMessage__HandshakeMessage__pk(m).
+letfun mk_dhkp(sk: bitstring, pk: bitstring) =
+  libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair(sk, pk).
+letfun mk_vlbytes(x: bitstring) = tls_codec__quic_vec__VLByteSlice__VLByteSlice(x).
+letfun mk_respout(x: bitstring) =
+  libcrux_psq__handshake__responder__ResponderQueryPayloadOut__ResponderQueryPayloadOut(x).
+letfun mk_hsmsg(pk: bitstring, ct: bitstring, tag: bitstring, aad: bitstring, cs: bitstring) =
+  libcrux_psq__handshake__HandshakeMessage__HandshakeMessage(pk, ct, tag, aad, cs).
+letfun query_cs() =
+  libcrux_psq__handshake__ciphersuite__Impl__query_ciphersuite(rust_primitives__hax__Tuple0__Tuple0).
+letfun aead_chacha() = libcrux_psq__aead__AeadType__ChaCha20Poly1305().
+letfun mk_resp_cs(kex: bitstring) =
+  libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite(
+    libcrux_psq__handshake__ciphersuite__CiphersuiteName__X25519_NONE_X25519_CHACHA20POLY1305_HKDFSHA256(),
+    kex,
+    libcrux_psq__handshake__ciphersuite__responder__PqKemKeyPair__None(),
+    libcrux_psq__aead__AeadType__ChaCha20Poly1305()).
+
+(* =========================================================================
+   Setup, roles, compromise
+   ========================================================================= *)
+
+(* Responder long-term key generation + authentic publication of pub_R. *)
+let setup_responder(p: Principal) =
+    new sk_R: bitstring;
+    let pk_R = extern__dh_pub(sk_R) in
+    let cs_R = mk_resp_cs(mk_dhkp(sk_R, pk_R)) in
+    insert resp_sk(p, sk_R);
+    insert resp_pk(p, pk_R);
+    insert resp_cs(p, cs_R);
+    out(c, pk_R).
+
+(* Anonymous, unauthenticated initiator: one query/response round. *)
+let query_initiator(p: Principal) =
+    get resp_pk(=p, pk_R) in
+    new rng_I: bitstring;
+    let qi0 = init_new(pk_R, context, init_aad, rng_I) in
+    let written = init_write(qi0, query_secret) in
+    let qi1 = t2_0(written) in
+    let msg = t2_1(written) in
+    let k0 = qi_k0(qi1) in
+    event QInitSend(p, context, k0);
+    out(c, msg);
+    (* response *)
+    in(c, resp_msg: bitstring);
+    let payload = init_read_response(qi1, resp_msg) in
+    (* read_response succeeds (returns a ResponderQueryPayloadOut) only when the
+       K_2 it derives decrypts the responder ciphertext — i.e. authenticity. *)
+    let libcrux_psq__handshake__responder__ResponderQueryPayloadOut__ResponderQueryPayloadOut(resp_inner) = payload in
+    let epub_R = hm_pk(resp_msg) in
+    let tx2_i = tx2c(qi_tx0(qi1), epub_R) in
+    let k2_i = init_derive_k2(k0, epub_R, qi_ephsk(qi1), pk_R, tx2_i) in
+    event QInitRecv(p, context, epub_R, k2_i).
+
+(* Responder: reads any incoming query (honest or attacker), returns the secret
+   response only for the honest query token, a public one otherwise. *)
+let query_responder(p: Principal) =
+    get resp_sk(=p, sk_R) in
+    get resp_cs(=p, cs_R) in
+    new rng_R0: bitstring;
+    let resp0 = resp_new(cs_R, context, resp_aad, rk_bound, rng_R0) in
+    in(c, msg: bitstring);
+    let rd = resp_read(resp0, msg) in
+    let self1 = t2_0(rd) in
+    let qp = t2_1(rd) in
+    let libcrux_psq__handshake__responder__ResponderState__RespondQuery(rqs) = r_state(self1) in
+    let tx0_r  = rqs_tx0(rqs) in
+    let k0_r   = rqs_k0(rqs) in
+    let epubI_r = rqs_epubi(rqs) in
+    event QRespRecv(p, context, k0_r);
+    (* fresh responder ephemeral (generated here so the process can observe K_2) *)
+    new rng_R1: bitstring;
+    let eph_R = t2_1(dh_new(rng_R1)) in
+    let epub_R  = dh_pk(eph_R) in
+    let epriv_R = dh_sk(eph_R) in
+    let tx2_r = tx2c(tx0_r, epub_R) in
+    let k2_r = resp_derive_k2(k0_r, epubI_r, epriv_R, sk_R, tx2_r, aead_chacha()) in
+    event QRespSend(p, context, epub_R, k2_r);
+    (* application handler: secret response iff the query is the honest token *)
+    if qp = mk_vlbytes(query_secret) then (
+        let enc = hs_encrypt(k2_r, mk_respout(mk_vlbytes(response_secret)), resp_aad) in
+        out(c, mk_hsmsg(epub_R, t2_0(t2_1(enc)), t2_1(t2_1(enc)), resp_aad, query_cs()))
+    ) else (
+        let enc = hs_encrypt(k2_r, mk_respout(mk_vlbytes(public_response)), resp_aad) in
+        out(c, mk_hsmsg(epub_R, t2_0(t2_1(enc)), t2_1(t2_1(enc)), resp_aad, query_cs()))
+    ).
+
+(* Phase-1 compromise of the responder long-term key (HNDL). *)
+let compromise_endpoint(p: Principal) =
+    get resp_sk(=p, sk_R) in
+    event CompromiseEndpoint(p);
+    out(c, sk_R).
+
+(* =========================================================================
+   Resolution control (SOUND — affects only ProVerif's search order/termination,
+   never a verdict). The DH commutativity equation + the attacker freely
+   *building* one-way crypto outputs triggers the classic "decryption-oracle"
+   saturation blow-up (multi-GB, no termination). These nounif hints deprioritise
+   selecting `attacker(<one-way output>)` facts during resolution. Same technique
+   as mandrake / SparsePostQuantumRatchet.
+   ========================================================================= *)
+nounif x: bitstring, y: bitstring;          attacker(extern__kdf(x, y))        / 30000.
+nounif x: bitstring, y: bitstring;          attacker(extern__dh_shared(x, y))  / 30000.
+nounif x: bitstring;                        attacker(extern__dh_pub(x))        / 30000.
+nounif x: bitstring, y: bitstring;          attacker(extern__hash(x, y))       / 30000.
+nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_ct(k, p, a))  / 30000.
+nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_tag(k, p, a)) / 30000.
+(* The KDF input wrappers: the attacker building these (folding DH shared secrets
+   the commutativity equation keeps rewriting) is the main correspondence blow-up. *)
+nounif d: bitstring; attacker(libcrux_psq__handshake__derive_k0__K0Ikm__K0Ikm(d)) / 30000.
+nounif k0: bitstring, a: bitstring, b: bitstring;
+       attacker(libcrux_psq__handshake__K2IkmQuery__K2IkmQuery(k0, a, b)) / 30000.

--- a/libcrux-psq/proofs/proverif/extraction/psq_query_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_query_lib.pvl
@@ -3,13 +3,13 @@
    analysis_auth.pv (auth-core responder, P2/P3). See those files for queries. *)
 
 (* ===========================================================================
-   PSQ — Query mode: security analysis against the EXTRACTED libcrux-psq model
+   PSQ — Query mode: security analysis against the extracted libcrux-psq model
    ===========================================================================
    This file adds a handwritten top-level process and the query-mode security
    queries (P1–P11) on top of the extracted `lib.pvl` (driven via check-pv.sh,
    which composes primitives.pvl + psq_crypto.pvl + missingdecl + lib.clean.pvl).
 
-   The process drives the real extracted letfuns:
+   The process drives the extracted letfuns:
      initiator : QueryInitiator::new_kw, write_message_external_encoding,
                  read_response  (+ derive_k2_query_initiator to expose K_2)
      responder : Responder::new_kw, read_message_contents
@@ -24,8 +24,8 @@
    query_responder, and reproduces psq_query.pv's P1–P11 verdicts. The threat
    model is an active Dolev-Yao attacker (everything goes on `c`) plus a phase-1
    compromise of the responder's long-term DH key (harvest-now-decrypt-later).
-   ProVerif phases are global barriers and the honest roles carry no `phase`
-   instruction, so every honest run completes in phase 0 before the compromise.
+   ProVerif phases are global barriers and the roles carry no `phase`
+   instruction, so every run completes in phase 0 before the compromise.
    =========================================================================== *)
 
 type Principal.
@@ -37,7 +37,7 @@ const init_aad: bitstring.
 const resp_aad: bitstring.
 const rk_bound: bitstring.   (* responder rate-limiter bound (symbolically opaque) *)
 
-(* Secrets. The honest initiator's query token doubles as the responder's
+(* Secrets. The initiator's query token doubles as the responder's
    application gate (a confidential response is only as secret as the query that
    requested it). public_response is what every other (incl. attacker) query gets. *)
 free query_secret:    bitstring [private].
@@ -218,12 +218,11 @@ let compromise_endpoint(p: Principal) =
     out(c, sk_R).
 
 (* =========================================================================
-   Resolution control (SOUND — affects only ProVerif's search order/termination,
+   Resolution control (sound — affects only ProVerif's search order/termination,
    never a verdict). The DH commutativity equation + the attacker freely
-   *building* one-way crypto outputs triggers the classic "decryption-oracle"
+   *building* one-way crypto outputs triggers the "decryption-oracle"
    saturation blow-up (multi-GB, no termination). These nounif hints deprioritise
-   selecting `attacker(<one-way output>)` facts during resolution. Same technique
-   as mandrake / SparsePostQuantumRatchet.
+   selecting `attacker(<one-way output>)` facts during resolution.
    ========================================================================= *)
 nounif x: bitstring, y: bitstring;          attacker(extern__kdf(x, y))        / 30000.
 nounif x: bitstring, y: bitstring;          attacker(extern__dh_shared(x, y))  / 30000.

--- a/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
@@ -359,6 +359,55 @@ let sess_dh_responder(r: Principal) =
     out(c, response).
 
 (* =========================================================================
+   FULL handshake + into_session roles (SIGNATURE auth). Same shape as the DH
+   roles, but the initiator authenticates with a SigningKeyPair (Auth::Sig) and
+   the responder's response K_2 folds only ONE DH term (responder_eph x
+   initiator_eph) — so the responder-authentication correspondences R3/R3i ARE
+   tractable here (unlike DH mode's two response DH terms). Events: InitSessSig /
+   RespSessSig.
+   ========================================================================= *)
+let sess_sig_initiator(i: Principal, r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get client_sig(=i, sk_I, vk_I) in
+    let cs_I = mk_init_cs(cs_name_sig(), pk_R, pqek_R, auth_sig(mk_sig_kp(sk_I, vk_I))) in
+    new rng_I: bitstring;
+    let ri0 = reg_init_new(cs_I, context, inner_aad, outer_aad, rng_I) in
+    let written = reg_init_write(ri0, reg_secret) in
+    let ri1 = t2_0(written) in
+    let msg1 = t2_1(written) in
+    let libcrux_psq__handshake__initiator__registration__RegistrationInitiatorState__Waiting(ws) = ri_state(ri1) in
+    insert session_eph(r, ws_ephsk(ws));
+    out(c, msg1);
+    in(c, response: bitstring);
+    let ri2 = t2_0(reg_init_read(ri1, response)) in
+    let sess_I = reg_init_into_session(ri2) in
+    event InitSessSig(i, r, context, hm_pk(response), sess_key(sess_I)).
+
+let sess_sig_responder(r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    new rng_R: bitstring;
+    (* responder ciphersuite carries the ED25519 name for sig mode *)
+    let cs_R_sig = mk_resp_cs(cs_name_sig(), mk_dhkp(sk_R, pk_R), pqdk_R, pqek_R) in
+    let resp0 = mk_responder_full(cs_R_sig, context, resp_aad, rng_R) in
+    in(c, msg1: bitstring);
+    let self1 = t2_0(resp_read_full(resp0, msg1)) in
+    let libcrux_psq__handshake__responder__ResponderState__RespondRegistration(rrs) = resp_state(self1) in
+    let auth_r = rrs_auth(rrs) in
+    get client_sig(i, sk_I, =libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519__0(
+          libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig__0(auth_r))) in
+    let prep = resp_registration(self1, resp_secret) in
+    let self2 = t2_0(prep) in
+    let pe_mc = t2_1(prep) in
+    let resp_eph_pk = t2_0(pe_mc) in
+    let mc = t2_1(pe_mc) in
+    let sess_R = resp_into_session(self2) in
+    let response = mk_response_msg(resp_eph_pk, mc, resp_aad, cs_name_sig()) in
+    event RespSessSig(i, r, context, resp_eph_pk, sess_key(sess_R));
+    out(c, response).
+
+(* =========================================================================
    Resolution control (SOUND — search order only, never a verdict). The DH
    commutativity equation + the attacker freely *building* one-way crypto
    outputs triggers the decryption-oracle saturation blow-up. Deprioritise

--- a/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
@@ -228,6 +228,26 @@ let m1_dh_initiator(i: Principal, r: Principal) =
     event InitRegDH(i, r, context, k1);
     out(c, msg).
 
+(* Leaky variant: identical to m1_dh_initiator but ALSO tables the run ephemeral
+   scalar (the X25519 epriv_I, projected from the WaitingState) so leak_ephemeral
+   can model a quantum/harvest-now break of the session ephemeral. Used by the
+   PQ-secrecy analysis (compromise ALL classical DH keys at once). *)
+let m1_dh_initiator_leaky(i: Principal, r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get client_dh(=i, sk_I, pk_I) in
+    let cs_I = mk_init_cs(cs_name_dh(), pk_R, pqek_R, auth_dh(mk_dhkp(sk_I, pk_I))) in
+    new rng_I: bitstring;
+    let ri0 = reg_init_new(cs_I, context, inner_aad, outer_aad, rng_I) in
+    let written = reg_init_write(ri0, reg_secret) in
+    let ri1 = t2_0(written) in
+    let msg = t2_1(written) in
+    let libcrux_psq__handshake__initiator__registration__RegistrationInitiatorState__Waiting(ws) = ri_state(ri1) in
+    let k1 = ws_k1(ws) in
+    insert session_eph(r, ws_ephsk(ws));
+    event InitRegDH(i, r, context, k1);
+    out(c, msg).
+
 let m1_dh_responder(r: Principal) =
     get resp_dh(=r, sk_R, pk_R) in
     get resp_pq(=r, pqdk_R, pqek_R) in

--- a/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
@@ -122,6 +122,25 @@ letfun resp_registration(self: bitstring, payload: bitstring) =
   libcrux_psq__handshake__responder__Impl__prepare_message_contents(self, payload).
 letfun resp_into_session(self: bitstring) =
   libcrux_psq__handshake__responder__Impl_2__into_session(self).
+letfun resp_read_full(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__responder__Impl__read_message_contents(self, msg).
+
+(* session helpers (response / into_session) *)
+letfun sess_key(s: bitstring) = libcrux_psq__session__Session__Session__session_key(s).
+letfun hm_pk(m: bitstring) = libcrux_psq__handshake__HandshakeMessage__HandshakeMessage__pk(m).
+letfun mc_ct(m: bitstring) = libcrux_psq__handshake__responder__MessageCiphertext__MessageCiphertext__ciphertext(m).
+letfun mc_tag(m: bitstring) = libcrux_psq__handshake__responder__MessageCiphertext__MessageCiphertext__tag(m).
+(* Build a responder for the FULL read path: working_ciphersuite = None, so
+   read_message_contents' coerce_compatible sets it from the wire name. *)
+letfun mk_responder_full(cs: bitstring, ctx: bitstring, aad: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__responder__Responder__Responder(
+    libcrux_psq__handshake__responder__ResponderState__Initial(),
+    cs, None, recent0, rk_bound, ctx, aad, rng).
+(* Package the responder's (resp_eph_pk, MessageCiphertext) into the response
+   HandshakeMessage the initiator reads (pk, ciphertext, tag, aad, ciphersuite). *)
+letfun mk_response_msg(resp_eph_pk: bitstring, mc: bitstring, aad: bitstring, name: bitstring) =
+  libcrux_psq__handshake__HandshakeMessage__HandshakeMessage(
+    resp_eph_pk, mc_ct(mc), mc_tag(mc), aad, name).
 
 (* Build a Responder with working_ciphersuite pre-set (auth core skips coerce):
    Responder(state=Initial, ciphersuite, working=Some(name), recent_keys,
@@ -271,6 +290,55 @@ let m1_sig_responder(r: Principal) =
     event RespRegSig(i, r, context, k1_r).
 
 (* =========================================================================
+   FULL handshake + into_session roles (DH auth) — response / session layer.
+   Initiator: write msg1, read the response, into_session -> InitSessDH.
+   Responder: read msg1 (FULL read_message_contents path), prepare the response,
+   into_session -> RespSessDH. Events keyed on the per-run responder ephemeral pk
+   (epub_R) + the session key K_S (epub_R lets agreement match while K_2/K_S stay
+   free — same re-keying technique as the query-mode K2 correspondences).
+   ========================================================================= *)
+let sess_dh_initiator(i: Principal, r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get client_dh(=i, sk_I, pk_I) in
+    let cs_I = mk_init_cs(cs_name_dh(), pk_R, pqek_R, auth_dh(mk_dhkp(sk_I, pk_I))) in
+    new rng_I: bitstring;
+    let ri0 = reg_init_new(cs_I, context, inner_aad, outer_aad, rng_I) in
+    let written = reg_init_write(ri0, reg_secret) in
+    let ri1 = t2_0(written) in
+    let msg1 = t2_1(written) in
+    (* expose this run's ephemeral scalar so leak_ephemeral can model a session
+       ephemeral break (forward-secrecy query R8). *)
+    let libcrux_psq__handshake__initiator__registration__RegistrationInitiatorState__Waiting(ws) = ri_state(ri1) in
+    insert session_eph(r, ws_ephsk(ws));
+    out(c, msg1);
+    in(c, response: bitstring);
+    let ri2 = t2_0(reg_init_read(ri1, response)) in
+    let sess_I = reg_init_into_session(ri2) in
+    event InitSessDH(i, r, context, hm_pk(response), sess_key(sess_I)).
+
+let sess_dh_responder(r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get resp_cs(=r, cs_R) in
+    new rng_R: bitstring;
+    let resp0 = mk_responder_full(cs_R, context, resp_aad, rng_R) in
+    in(c, msg1: bitstring);
+    let self1 = t2_0(resp_read_full(resp0, msg1)) in
+    let libcrux_psq__handshake__responder__ResponderState__RespondRegistration(rrs) = resp_state(self1) in
+    let auth_r = rrs_auth(rrs) in
+    get client_dh(i, sk_I, =libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh__0(auth_r)) in
+    let prep = resp_registration(self1, resp_secret) in
+    let self2 = t2_0(prep) in
+    let pe_mc = t2_1(prep) in
+    let resp_eph_pk = t2_0(pe_mc) in
+    let mc = t2_1(pe_mc) in
+    let sess_R = resp_into_session(self2) in
+    let response = mk_response_msg(resp_eph_pk, mc, resp_aad, cs_name_dh()) in
+    event RespSessDH(i, r, context, resp_eph_pk, sess_key(sess_R));
+    out(c, response).
+
+(* =========================================================================
    Resolution control (SOUND — search order only, never a verdict). The DH
    commutativity equation + the attacker freely *building* one-way crypto
    outputs triggers the decryption-oracle saturation blow-up. Deprioritise
@@ -285,6 +353,13 @@ nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_ct(k, p, 
 nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_tag(k, p, a)) / 30000.
 nounif pk: bitstring, ss: bitstring;        attacker(extern__kem_encaps(pk, ss)) / 30000.
 nounif sk: bitstring;                       attacker(extern__kem_pk(sk))       / 30000.
+(* PQ wrappers (the ML-KEM shared-secret / ciphertext / encapsulation-key carriers
+   the attacker folds into the K_1 / tx1 reconstruction — analogous to mandrake's
+   mlkem_ss / mlkem_ct / mlkem_pk nounif). Needed for the responder K_S secrecy
+   (R5 RespSessDH) to saturate in tractable time. *)
+nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQSharedSecret__MlKem(x))    / 30000.
+nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQCiphertext__MlKem(x))      / 30000.
+nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem(x)) / 30000.
 nounif sk: bitstring, m: bitstring;         attacker(extern__sign(sk, m))      / 30000.
 nounif sk: bitstring;                       attacker(extern__vk_of(sk))        / 30000.
 (* KDF input wrappers (the attacker folding DH shared secrets the commutativity

--- a/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
@@ -1,0 +1,302 @@
+(* PSQ registration-mode shared model: setup, roles, crypto aliases, resolution
+   control. Loaded (via -lib) by the registration analyses:
+     analysis_reg_dh_msg1.pv   / analysis_reg_sig_msg1.pv    (message 1)
+     analysis_reg_dh_session.pv / analysis_reg_sig_session.pv (response/session)
+   Mirrors psq-design/models/psq_handshake_lib.pvl's reg_dh_* / reg_sig_* roles,
+   driven against the EXTRACTED libcrux-psq registration letfuns. See those files
+   for the R1–R9 queries and the per-process compromise model.
+
+   The responder is driven against an AUTH CORE (decrypt_outer_message +
+   decrypt_inner_message directly), skipping read_message_contents' rate-limiter,
+   ciphersuite coercion and state-machine bookkeeping (none security-relevant to
+   registration authentication, and coerce_compatible has no ML-KEM branch).
+   This mirrors the query-mode analysis_auth core and keeps the DH-heavy
+   correspondences tractable. The auth core reads `working_ciphersuite`, so the
+   Responder is built with it pre-set to the run's ML-KEM ciphersuite name. *)
+
+type Principal.
+const Alice: Principal.   (* initiator / client   *)
+const Bob:   Principal.   (* responder / endpoint *)
+
+(* Public, attacker-known protocol parameters. *)
+const context:    bitstring.
+const inner_aad:  bitstring.
+const outer_aad:  bitstring.
+const resp_aad:   bitstring.
+const rk_bound:   bitstring.   (* responder rate-limiter bound (symbolically opaque) *)
+const recent0:    bitstring.   (* opaque initial recent-keys deque for the auth core *)
+
+(* Secrets. *)
+free reg_secret:  bitstring [private].   (* the registration payload  *)
+free resp_secret: bitstring [private].   (* the responder's response  *)
+
+(* ---- Key tables (authentic key distribution) --------------------------- *)
+table resp_dh(Principal, bitstring, bitstring).   (* sk_R, pk_R           *)
+table resp_pq(Principal, bitstring, bitstring).   (* pqdk_R, pqek_R       *)
+table resp_cs(Principal, bitstring).              (* ResponderCiphersuite *)
+table client_dh(Principal, bitstring, bitstring). (* sk_I, pk_I  (DH auth)*)
+table client_sig(Principal, bitstring, bitstring).(* sk_I, vk_I (sig auth)*)
+table session_eph(Principal, bitstring).          (* a run ephemeral scalar *)
+
+(* ---- Events; mirror psq_handshake_lib.pvl ------------------------------- *)
+(* i, r, context, K_1 *)
+event InitRegDH(Principal, Principal, bitstring, bitstring).
+event RespRegDH(Principal, Principal, bitstring, bitstring).
+event InitRegSig(Principal, Principal, bitstring, bitstring).
+event RespRegSig(Principal, Principal, bitstring, bitstring).
+(* i, r, context, epub_R (per-run id), K_S *)
+event InitSessDH(Principal, Principal, bitstring, bitstring, bitstring).
+event RespSessDH(Principal, Principal, bitstring, bitstring, bitstring).
+event InitSessSig(Principal, Principal, bitstring, bitstring, bitstring).
+event RespSessSig(Principal, Principal, bitstring, bitstring, bitstring).
+
+(* Fine-grained compromise (a quantum adversary breaks all classical DH +
+   ephemerals but not the PQ-KEM decaps key / a PQ signature). *)
+event CompromiseEndpointClassical(Principal).   (* responder long-term DH key   *)
+event CompromiseEndpointPQ(Principal).          (* responder PQ-KEM decaps key  *)
+event CompromiseClient(Principal).              (* initiator long-term DH/sig key *)
+event LeakEphemeral(Principal).                 (* a session ephemeral DH scalar *)
+
+(* =========================================================================
+   Aliases for the extracted names (cosmetic; keep the roles readable).
+   ========================================================================= *)
+(* tuple projectors *)
+letfun t2_0(t: bitstring) = rust_primitives__hax__Tuple2__Tuple2__0(t).
+letfun t2_1(t: bitstring) = rust_primitives__hax__Tuple2__Tuple2__1(t).
+
+(* constructors for the run setup *)
+letfun mk_dhkp(sk: bitstring, pk: bitstring) =
+  libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair(sk, pk).
+letfun dh_sk(kp: bitstring) = libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair__sk(kp).
+letfun dh_pk(kp: bitstring) = libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair__pk(kp).
+letfun aead_chacha() = libcrux_psq__aead__AeadType__ChaCha20Poly1305().
+letfun cs_name_dh() =
+  libcrux_psq__handshake__ciphersuite__CiphersuiteName__X25519_MLKEM768_X25519_CHACHA20POLY1305_HKDFSHA256().
+letfun cs_name_sig() =
+  libcrux_psq__handshake__ciphersuite__CiphersuiteName__X25519_MLKEM768_ED25519_CHACHA20POLY1305_HKDFSHA256().
+
+(* responder ciphersuite: name, kex=DHKeyPair, pq=MlKem(sk,pk), aead *)
+letfun mk_resp_cs(name: bitstring, kex: bitstring, pqdk: bitstring, pqek: bitstring) =
+  libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite(
+    name, kex,
+    libcrux_psq__handshake__ciphersuite__responder__PqKemKeyPair__MlKem(pqdk, pqek),
+    aead_chacha()).
+
+(* initiator ciphersuite: name, kex=pk_R, pq=MlKem(pqek), auth, aead *)
+letfun mk_init_cs(name: bitstring, pkR: bitstring, pqek: bitstring, auth: bitstring) =
+  libcrux_psq__handshake__ciphersuite__initiator__InitiatorCiphersuite__InitiatorCiphersuite(
+    name, pkR,
+    libcrux_psq__handshake__ciphersuite__initiator__PqKemPublicKey__MlKem(pqek),
+    auth, aead_chacha()).
+letfun auth_dh(kp: bitstring) = libcrux_psq__handshake__ciphersuite__initiator__Auth__DH(kp).
+letfun auth_sig(skp: bitstring) = libcrux_psq__handshake__ciphersuite__initiator__Auth__Sig(skp).
+letfun mk_sig_kp(sk: bitstring, vk: bitstring) =
+  libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk).
+
+(* initiator entry points *)
+letfun reg_init_new(cs: bitstring, ctx: bitstring, iaad: bitstring, oaad: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__initiator__registration__Impl__new_kw(cs, ctx, iaad, oaad, rng).
+letfun reg_init_write(self: bitstring, payload: bitstring) =
+  libcrux_psq__handshake__initiator__registration__Impl_1__write_message_external_encoding(self, payload).
+letfun reg_init_read(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__initiator__registration__Impl_1__read_message_external_encoding(self, msg).
+letfun reg_init_into_session(self: bitstring) =
+  libcrux_psq__handshake__initiator__registration__Impl_2__into_session(self).
+
+(* initiator state projectors: self.state = Waiting(WaitingState(eph_sk, tx1, k1)) *)
+letfun ri_state(self: bitstring) =
+  libcrux_psq__handshake__initiator__registration__RegistrationInitiator__RegistrationInitiator__state(self).
+letfun ws_ephsk(ws: bitstring) =
+  libcrux_psq__handshake__initiator__registration__WaitingState__WaitingState__initiator_ephemeral_ecdh_sk(ws).
+letfun ws_k1(ws: bitstring) =
+  libcrux_psq__handshake__initiator__registration__WaitingState__WaitingState__k1(ws).
+
+(* responder auth-core entry points *)
+letfun resp_new(cs: bitstring, ctx: bitstring, aad: bitstring, bound: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__responder__Impl__new_kw(cs, ctx, aad, bound, rng).
+letfun resp_decrypt_outer(self: bitstring, msg: bitstring) =
+  libcrux_psq__handshake__responder__Impl__decrypt_outer_message(self, msg).
+letfun resp_decrypt_inner(self: bitstring, tx0: bitstring, k0: bitstring, inner: bitstring) =
+  libcrux_psq__handshake__responder__Impl__decrypt_inner_message(self, tx0, k0, inner).
+letfun resp_registration(self: bitstring, payload: bitstring) =
+  libcrux_psq__handshake__responder__Impl__prepare_message_contents(self, payload).
+letfun resp_into_session(self: bitstring) =
+  libcrux_psq__handshake__responder__Impl_2__into_session(self).
+
+(* Build a Responder with working_ciphersuite pre-set (auth core skips coerce):
+   Responder(state=Initial, ciphersuite, working=Some(name), recent_keys,
+             recent_keys_upper_bound, context, aad, rng). *)
+letfun mk_responder(cs: bitstring, name: bitstring, ctx: bitstring, aad: bitstring, rng: bitstring) =
+  libcrux_psq__handshake__responder__Responder__Responder(
+    libcrux_psq__handshake__responder__ResponderState__Initial(),
+    cs, Some(name), recent0, rk_bound, ctx, aad, rng).
+
+(* responder state projectors after the core read: RespondRegistration(rrs) *)
+letfun resp_state(self: bitstring) =
+  libcrux_psq__handshake__responder__Responder__Responder__state(self).
+letfun rrs_tx1(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondRegistrationState__RespondRegistrationState__tx1(s).
+letfun rrs_k1(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondRegistrationState__RespondRegistrationState__k1(s).
+letfun rrs_auth(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondRegistrationState__RespondRegistrationState__initiator_authenticator(s).
+letfun rrs_epubi(s: bitstring) =
+  libcrux_psq__handshake__responder__RespondRegistrationState__RespondRegistrationState__initiator_ephemeral_ecdh_pk(s).
+
+(* =========================================================================
+   Setup + compromise
+   ========================================================================= *)
+let setup_responder(p: Principal) =
+    new sk_R: bitstring;
+    let pk_R = extern__dh_pub(sk_R) in
+    new pqdk_R: bitstring;
+    let pqek_R = extern__kem_pk(pqdk_R) in
+    let cs_R = mk_resp_cs(cs_name_dh(), mk_dhkp(sk_R, pk_R), pqdk_R, pqek_R) in
+    insert resp_dh(p, sk_R, pk_R);
+    insert resp_pq(p, pqdk_R, pqek_R);
+    insert resp_cs(p, cs_R);
+    out(c, (pk_R, pqek_R)).
+
+let create_dh_client(p: Principal) =
+    new sk_I: bitstring;
+    let pk_I = extern__dh_pub(sk_I) in
+    insert client_dh(p, sk_I, pk_I);
+    out(c, pk_I).
+
+let create_sig_client(p: Principal) =
+    new sk_I: bitstring;
+    let vk_I = extern__vk_of(sk_I) in
+    insert client_sig(p, sk_I, vk_I);
+    out(c, vk_I).
+
+let compromise_endpoint_classical(p: Principal) =
+    get resp_dh(=p, sk_R, pk_R) in
+    event CompromiseEndpointClassical(p);
+    out(c, sk_R).
+let compromise_endpoint_pq(p: Principal) =
+    get resp_pq(=p, pqdk_R, pqek_R) in
+    event CompromiseEndpointPQ(p);
+    out(c, pqdk_R).
+let compromise_dh_client(p: Principal) =
+    get client_dh(=p, sk_I, pk_I) in
+    event CompromiseClient(p);
+    out(c, sk_I).
+let compromise_sig_client(p: Principal) =
+    get client_sig(=p, sk_I, vk_I) in
+    event CompromiseClient(p);
+    out(c, sk_I).
+let leak_ephemeral(p: Principal) =
+    get session_eph(=p, e) in
+    event LeakEphemeral(p);
+    out(c, e).
+
+(* =========================================================================
+   Message-1 roles (DH auth). Initiator sends msg 1 and emits InitRegDH;
+   responder processes it through the auth core and emits RespRegDH.
+   ========================================================================= *)
+let m1_dh_initiator(i: Principal, r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get client_dh(=i, sk_I, pk_I) in
+    let cs_I = mk_init_cs(cs_name_dh(), pk_R, pqek_R, auth_dh(mk_dhkp(sk_I, pk_I))) in
+    new rng_I: bitstring;
+    let ri0 = reg_init_new(cs_I, context, inner_aad, outer_aad, rng_I) in
+    let written = reg_init_write(ri0, reg_secret) in
+    let ri1 = t2_0(written) in
+    let msg = t2_1(written) in
+    let libcrux_psq__handshake__initiator__registration__RegistrationInitiatorState__Waiting(ws) = ri_state(ri1) in
+    let k1 = ws_k1(ws) in
+    event InitRegDH(i, r, context, k1);
+    out(c, msg).
+
+let m1_dh_responder(r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get resp_cs(=r, cs_R) in
+    new rng_R: bitstring;
+    let resp0 = mk_responder(cs_R, cs_name_dh(), context, resp_aad, rng_R) in
+    in(c, msg: bitstring);
+    let dec = resp_decrypt_outer(resp0, msg) in
+    let outer_payload = rust_primitives__hax__Tuple3__Tuple3__0(dec) in
+    let tx0_r = rust_primitives__hax__Tuple3__Tuple3__1(dec) in
+    let k0_r  = rust_primitives__hax__Tuple3__Tuple3__2(dec) in
+    let libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration(inner) = outer_payload in
+    let dim = resp_decrypt_inner(resp0, tx0_r, k0_r, inner) in
+    let k1_r = rust_primitives__hax__Tuple5__Tuple5__2(dim) in
+    let auth_r = rust_primitives__hax__Tuple5__Tuple5__3(dim) in
+    (* out-of-band authentic recovery of the initiator identity: the recovered
+       authenticator must be an honest client's DH public key. *)
+    get client_dh(i, sk_I, =libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh__0(auth_r)) in
+    event RespRegDH(i, r, context, k1_r).
+
+(* =========================================================================
+   Message-1 roles (signature auth).
+   ========================================================================= *)
+let m1_sig_initiator(i: Principal, r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get client_sig(=i, sk_I, vk_I) in
+    let cs_I = mk_init_cs(cs_name_sig(), pk_R, pqek_R, auth_sig(mk_sig_kp(sk_I, vk_I))) in
+    new rng_I: bitstring;
+    let ri0 = reg_init_new(cs_I, context, inner_aad, outer_aad, rng_I) in
+    let written = reg_init_write(ri0, reg_secret) in
+    let ri1 = t2_0(written) in
+    let msg = t2_1(written) in
+    let libcrux_psq__handshake__initiator__registration__RegistrationInitiatorState__Waiting(ws) = ri_state(ri1) in
+    let k1 = ws_k1(ws) in
+    event InitRegSig(i, r, context, k1);
+    out(c, msg).
+
+let m1_sig_responder(r: Principal) =
+    get resp_dh(=r, sk_R, pk_R) in
+    get resp_pq(=r, pqdk_R, pqek_R) in
+    get resp_cs(=r, cs_R) in
+    new rng_R: bitstring;
+    (* responder's ciphersuite for sig mode carries the ED25519 name *)
+    let cs_R_sig = mk_resp_cs(cs_name_sig(), mk_dhkp(sk_R, pk_R), pqdk_R, pqek_R) in
+    let resp0 = mk_responder(cs_R_sig, cs_name_sig(), context, resp_aad, rng_R) in
+    in(c, msg: bitstring);
+    let dec = resp_decrypt_outer(resp0, msg) in
+    let outer_payload = rust_primitives__hax__Tuple3__Tuple3__0(dec) in
+    let tx0_r = rust_primitives__hax__Tuple3__Tuple3__1(dec) in
+    let k0_r  = rust_primitives__hax__Tuple3__Tuple3__2(dec) in
+    let libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration(inner) = outer_payload in
+    let dim = resp_decrypt_inner(resp0, tx0_r, k0_r, inner) in
+    let k1_r = rust_primitives__hax__Tuple5__Tuple5__2(dim) in
+    let auth_r = rust_primitives__hax__Tuple5__Tuple5__3(dim) in
+    (* recovered authenticator = Authenticator::Sig(SignatureVerificationKey::Ed25519(vk));
+       project the raw vk to match the client_sig table (stores vk = vk_of(sk)). *)
+    get client_sig(i, sk_I, =libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519__0(
+          libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig__0(auth_r))) in
+    event RespRegSig(i, r, context, k1_r).
+
+(* =========================================================================
+   Resolution control (SOUND — search order only, never a verdict). The DH
+   commutativity equation + the attacker freely *building* one-way crypto
+   outputs triggers the decryption-oracle saturation blow-up. Deprioritise
+   selecting `attacker(<one-way output>)` facts. Same technique as query mode /
+   mandrake / SparsePostQuantumRatchet.
+   ========================================================================= *)
+nounif x: bitstring, y: bitstring;          attacker(extern__kdf(x, y))        / 30000.
+nounif x: bitstring, y: bitstring;          attacker(extern__dh_shared(x, y))  / 30000.
+nounif x: bitstring;                        attacker(extern__dh_pub(x))        / 30000.
+nounif x: bitstring, y: bitstring;          attacker(extern__hash(x, y))       / 30000.
+nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_ct(k, p, a))  / 30000.
+nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_tag(k, p, a)) / 30000.
+nounif pk: bitstring, ss: bitstring;        attacker(extern__kem_encaps(pk, ss)) / 30000.
+nounif sk: bitstring;                       attacker(extern__kem_pk(sk))       / 30000.
+nounif sk: bitstring, m: bitstring;         attacker(extern__sign(sk, m))      / 30000.
+nounif sk: bitstring;                       attacker(extern__vk_of(sk))        / 30000.
+(* KDF input wrappers (the attacker folding DH shared secrets the commutativity
+   equation keeps rewriting is the main correspondence blow-up). *)
+nounif d: bitstring; attacker(libcrux_psq__handshake__derive_k0__K0Ikm__K0Ikm(d)) / 30000.
+nounif a: bitstring, b: bitstring, e: bitstring;
+       attacker(libcrux_psq__handshake__derive_k1_dh__K1IkmDh__K1IkmDh(a, b, e)) / 30000.
+nounif a: bitstring, b: bitstring;
+       attacker(libcrux_psq__handshake__derive_k1_sig__K1IkmSig__K1IkmSig(a, b)) / 30000.
+nounif a: bitstring, b: bitstring;
+       attacker(libcrux_psq__handshake__derive_k1_sig__K1InfoSig__K1InfoSig(a, b)) / 30000.
+nounif a: bitstring, b: bitstring, e: bitstring;
+       attacker(libcrux_psq__handshake__K2IkmRegistrationDh__K2IkmRegistrationDh(a, b, e)) / 30000.
+nounif a: bitstring, b: bitstring;
+       attacker(libcrux_psq__handshake__K2IkmRegistrationSig__K2IkmRegistrationSig(a, b)) / 30000.

--- a/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
+++ b/libcrux-psq/proofs/proverif/extraction/psq_reg_lib.pvl
@@ -3,10 +3,10 @@
      analysis_reg_dh_msg1.pv   / analysis_reg_sig_msg1.pv    (message 1)
      analysis_reg_dh_session.pv / analysis_reg_sig_session.pv (response/session)
    Mirrors psq-design/models/psq_handshake_lib.pvl's reg_dh_* / reg_sig_* roles,
-   driven against the EXTRACTED libcrux-psq registration letfuns. See those files
+   driven against the extracted libcrux-psq registration letfuns. See those files
    for the R1–R9 queries and the per-process compromise model.
 
-   The responder is driven against an AUTH CORE (decrypt_outer_message +
+   The responder is driven against an auth core (decrypt_outer_message +
    decrypt_inner_message directly), skipping read_message_contents' rate-limiter,
    ciphersuite coercion and state-machine bookkeeping (none security-relevant to
    registration authentication, and coerce_compatible has no ML-KEM branch).
@@ -130,7 +130,7 @@ letfun sess_key(s: bitstring) = libcrux_psq__session__Session__Session__session_
 letfun hm_pk(m: bitstring) = libcrux_psq__handshake__HandshakeMessage__HandshakeMessage__pk(m).
 letfun mc_ct(m: bitstring) = libcrux_psq__handshake__responder__MessageCiphertext__MessageCiphertext__ciphertext(m).
 letfun mc_tag(m: bitstring) = libcrux_psq__handshake__responder__MessageCiphertext__MessageCiphertext__tag(m).
-(* Build a responder for the FULL read path: working_ciphersuite = None, so
+(* Build a responder for the full read path: working_ciphersuite = None, so
    read_message_contents' coerce_compatible sets it from the wire name. *)
 letfun mk_responder_full(cs: bitstring, ctx: bitstring, aad: bitstring, rng: bitstring) =
   libcrux_psq__handshake__responder__Responder__Responder(
@@ -228,10 +228,10 @@ let m1_dh_initiator(i: Principal, r: Principal) =
     event InitRegDH(i, r, context, k1);
     out(c, msg).
 
-(* Leaky variant: identical to m1_dh_initiator but ALSO tables the run ephemeral
+(* Leaky variant: identical to m1_dh_initiator but also tables the run ephemeral
    scalar (the X25519 epriv_I, projected from the WaitingState) so leak_ephemeral
    can model a quantum/harvest-now break of the session ephemeral. Used by the
-   PQ-secrecy analysis (compromise ALL classical DH keys at once). *)
+   PQ-secrecy analysis (compromise all classical DH keys at once). *)
 let m1_dh_initiator_leaky(i: Principal, r: Principal) =
     get resp_dh(=r, sk_R, pk_R) in
     get resp_pq(=r, pqdk_R, pqek_R) in
@@ -264,7 +264,7 @@ let m1_dh_responder(r: Principal) =
     let k1_r = rust_primitives__hax__Tuple5__Tuple5__2(dim) in
     let auth_r = rust_primitives__hax__Tuple5__Tuple5__3(dim) in
     (* out-of-band authentic recovery of the initiator identity: the recovered
-       authenticator must be an honest client's DH public key. *)
+       authenticator must be a client's DH public key. *)
     get client_dh(i, sk_I, =libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh__0(auth_r)) in
     event RespRegDH(i, r, context, k1_r).
 
@@ -310,9 +310,9 @@ let m1_sig_responder(r: Principal) =
     event RespRegSig(i, r, context, k1_r).
 
 (* =========================================================================
-   FULL handshake + into_session roles (DH auth) — response / session layer.
+   Full handshake + into_session roles (DH auth) — response / session layer.
    Initiator: write msg1, read the response, into_session -> InitSessDH.
-   Responder: read msg1 (FULL read_message_contents path), prepare the response,
+   Responder: read msg1 (full read_message_contents path), prepare the response,
    into_session -> RespSessDH. Events keyed on the per-run responder ephemeral pk
    (epub_R) + the session key K_S (epub_R lets agreement match while K_2/K_S stay
    free — same re-keying technique as the query-mode K2 correspondences).
@@ -359,10 +359,10 @@ let sess_dh_responder(r: Principal) =
     out(c, response).
 
 (* =========================================================================
-   FULL handshake + into_session roles (SIGNATURE auth). Same shape as the DH
+   Full handshake + into_session roles (signature auth). Same shape as the DH
    roles, but the initiator authenticates with a SigningKeyPair (Auth::Sig) and
-   the responder's response K_2 folds only ONE DH term (responder_eph x
-   initiator_eph) — so the responder-authentication correspondences R3/R3i ARE
+   the responder's response K_2 folds only one DH term (responder_eph x
+   initiator_eph) — so the responder-authentication correspondences R3/R3i are
    tractable here (unlike DH mode's two response DH terms). Events: InitSessSig /
    RespSessSig.
    ========================================================================= *)
@@ -408,11 +408,10 @@ let sess_sig_responder(r: Principal) =
     out(c, response).
 
 (* =========================================================================
-   Resolution control (SOUND — search order only, never a verdict). The DH
+   Resolution control (sound — search order only, never a verdict). The DH
    commutativity equation + the attacker freely *building* one-way crypto
    outputs triggers the decryption-oracle saturation blow-up. Deprioritise
-   selecting `attacker(<one-way output>)` facts. Same technique as query mode /
-   mandrake / SparsePostQuantumRatchet.
+   selecting `attacker(<one-way output>)` facts. Same technique as query mode.
    ========================================================================= *)
 nounif x: bitstring, y: bitstring;          attacker(extern__kdf(x, y))        / 30000.
 nounif x: bitstring, y: bitstring;          attacker(extern__dh_shared(x, y))  / 30000.
@@ -423,9 +422,8 @@ nounif k: bitstring, p: bitstring, a: bitstring; attacker(extern__aead_tag(k, p,
 nounif pk: bitstring, ss: bitstring;        attacker(extern__kem_encaps(pk, ss)) / 30000.
 nounif sk: bitstring;                       attacker(extern__kem_pk(sk))       / 30000.
 (* PQ wrappers (the ML-KEM shared-secret / ciphertext / encapsulation-key carriers
-   the attacker folds into the K_1 / tx1 reconstruction — analogous to mandrake's
-   mlkem_ss / mlkem_ct / mlkem_pk nounif). Needed for the responder K_S secrecy
-   (R5 RespSessDH) to saturate in tractable time. *)
+   the attacker folds into the K_1 / tx1 reconstruction). Needed for the responder
+   K_S secrecy (R5 RespSessDH) to saturate in tractable time. *)
 nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQSharedSecret__MlKem(x))    / 30000.
 nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQCiphertext__MlKem(x))      / 30000.
 nounif x: bitstring; attacker(libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem(x)) / 30000.

--- a/libcrux-psq/proofs/proverif/extraction/sanity_reg_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_reg_passive.pv
@@ -1,0 +1,42 @@
+(* PSQ registration — PASSIVE-FIRST sanity. Non-vacuity foundation: under a
+   PASSIVE attacker the honest registration round-trip must complete ON ITS OWN
+   (no attacker forging / driving the responder). If these four events are NOT
+   reachable under `set attacker = passive.`, every active-attacker verdict below
+   is unsound (a "reachable" RespReg would be the attacker, not the protocol).
+   Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
+
+   Expected: all four reachable -> ProVerif reports each `event(...)` query
+   `is false` (a reachable event makes the "is it never reached?" query false). *)
+
+set attacker = passive.
+set reconstructTrace = true.
+
+(* Honest initiator emitted InitRegDH.        Expected: false (reachable) *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(InitRegDH(i, r, ctx, k)).
+(* Honest responder accepted -> RespRegDH.     Expected: false (reachable) *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k)).
+(* Honest initiator emitted InitRegSig.        Expected: false (reachable) *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(InitRegSig(i, r, ctx, k)).
+(* Honest responder accepted -> RespRegSig.    Expected: false (reachable) *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegSig(i, r, ctx, k)).
+
+(* Stronger non-vacuity: the responder's accepted K_1 AGREES with the honest
+   initiator's K_1 (same run). If the honest run is sound, this correspondence
+   holds (it cannot under an attacker-forged RespReg). Expected: true. *)
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegDH(i, r, ctx, k)) ==> event(InitRegDH(i, r, ctx, k)).
+query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
+      event(RespRegSig(i, r, ctx, k)) ==> event(InitRegSig(i, r, ctx, k)).
+
+process
+    ( setup_responder(Bob)
+    | create_dh_client(Alice)
+    | create_sig_client(Alice)
+    | ( !m1_dh_initiator(Alice, Bob) )
+    | ( !m1_dh_responder(Bob) )
+    | ( !m1_sig_initiator(Alice, Bob) )
+    | ( !m1_sig_responder(Bob) ) )

--- a/libcrux-psq/proofs/proverif/extraction/sanity_reg_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_reg_passive.pv
@@ -1,6 +1,6 @@
-(* PSQ registration — PASSIVE-FIRST sanity. Non-vacuity foundation: under a
-   PASSIVE attacker the honest registration round-trip must complete ON ITS OWN
-   (no attacker forging / driving the responder). If these four events are NOT
+(* PSQ registration — passive-first sanity. Non-vacuity foundation: under a
+   passive attacker the registration round-trip must complete on its own
+   (no attacker forging / driving the responder). If these four events are not
    reachable under `set attacker = passive.`, every active-attacker verdict below
    is unsound (a "reachable" RespReg would be the attacker, not the protocol).
    Shared setup/roles/aliases/nounif: -lib psq_reg_lib.pvl.
@@ -11,21 +11,21 @@
 set attacker = passive.
 set reconstructTrace = true.
 
-(* Honest initiator emitted InitRegDH.        Expected: false (reachable) *)
+(* Initiator emitted InitRegDH.        Expected: false (reachable) *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(InitRegDH(i, r, ctx, k)).
-(* Honest responder accepted -> RespRegDH.     Expected: false (reachable) *)
+(* Responder accepted -> RespRegDH.     Expected: false (reachable) *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegDH(i, r, ctx, k)).
-(* Honest initiator emitted InitRegSig.        Expected: false (reachable) *)
+(* Initiator emitted InitRegSig.        Expected: false (reachable) *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(InitRegSig(i, r, ctx, k)).
-(* Honest responder accepted -> RespRegSig.    Expected: false (reachable) *)
+(* Responder accepted -> RespRegSig.    Expected: false (reachable) *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegSig(i, r, ctx, k)).
 
-(* Stronger non-vacuity: the responder's accepted K_1 AGREES with the honest
-   initiator's K_1 (same run). If the honest run is sound, this correspondence
+(* Stronger non-vacuity: the responder's accepted K_1 agrees with the
+   initiator's K_1 (same run). If the run is sound, this correspondence
    holds (it cannot under an attacker-forged RespReg). Expected: true. *)
 query i: Principal, r: Principal, ctx: bitstring, k: bitstring;
       event(RespRegDH(i, r, ctx, k)) ==> event(InitRegDH(i, r, ctx, k)).

--- a/libcrux-psq/proofs/proverif/extraction/sanity_session_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_session_passive.pv
@@ -1,0 +1,20 @@
+(* PSQ registration — FULL two-message handshake + into_session, PASSIVE attacker.
+   Non-vacuity foundation for the response/session analysis: under a passive
+   attacker the full handshake must complete on its own (initiator write msg1 ->
+   responder full read_message_contents -> responder response + into_session ->
+   initiator read response + into_session), reaching InitSessDH AND RespSessDH.
+   Roles: sess_dh_{initiator,responder} from psq_reg_lib.pvl (the same roles the
+   active-attacker analysis drives). Confirms the CiphersuiteBase::name fix
+   unblocked the full read path through to the session layer. *)
+set attacker = passive.
+set reconstructTrace = true.
+
+(* Expected: both reachable -> each `event(...)` query `is false`. *)
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessDH(i, r, ctx, e, k)).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(RespSessDH(i, r, ctx, e, k)).
+
+process
+    ( setup_responder(Bob) | create_dh_client(Alice)
+    | ( !sess_dh_initiator(Alice, Bob) ) | ( !sess_dh_responder(Bob) ) )

--- a/libcrux-psq/proofs/proverif/extraction/sanity_session_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_session_passive.pv
@@ -1,11 +1,10 @@
-(* PSQ registration — FULL two-message handshake + into_session, PASSIVE attacker.
+(* PSQ registration — two-message handshake + into_session, passive attacker.
    Non-vacuity foundation for the response/session analysis: under a passive
-   attacker the full handshake must complete on its own (initiator write msg1 ->
-   responder full read_message_contents -> responder response + into_session ->
-   initiator read response + into_session), reaching InitSessDH AND RespSessDH.
+   attacker the handshake must complete on its own (initiator write msg1 ->
+   responder read_message_contents -> responder response + into_session ->
+   initiator read response + into_session), reaching InitSessDH and RespSessDH.
    Roles: sess_dh_{initiator,responder} from psq_reg_lib.pvl (the same roles the
-   active-attacker analysis drives). Confirms the CiphersuiteBase::name fix
-   unblocked the full read path through to the session layer. *)
+   active-attacker analysis drives). *)
 set attacker = passive.
 set reconstructTrace = true.
 

--- a/libcrux-psq/proofs/proverif/extraction/sanity_session_sig_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_session_sig_passive.pv
@@ -1,0 +1,12 @@
+(* PSQ registration (sig) — FULL two-message handshake + into_session, PASSIVE.
+   Non-vacuity foundation for the sig response/session analysis: the honest run
+   must reach InitSessSig AND RespSessSig with no attacker help. *)
+set attacker = passive.
+set reconstructTrace = true.
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(InitSessSig(i, r, ctx, e, k)).
+query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;
+      event(RespSessSig(i, r, ctx, e, k)).
+process
+    ( setup_responder(Bob) | create_sig_client(Alice)
+    | ( !sess_sig_initiator(Alice, Bob) ) | ( !sess_sig_responder(Bob) ) )

--- a/libcrux-psq/proofs/proverif/extraction/sanity_session_sig_passive.pv
+++ b/libcrux-psq/proofs/proverif/extraction/sanity_session_sig_passive.pv
@@ -1,6 +1,6 @@
-(* PSQ registration (sig) — FULL two-message handshake + into_session, PASSIVE.
-   Non-vacuity foundation for the sig response/session analysis: the honest run
-   must reach InitSessSig AND RespSessSig with no attacker help. *)
+(* PSQ registration (sig) — full two-message handshake + into_session, passive.
+   Non-vacuity foundation for the sig response/session analysis: the run
+   must reach InitSessSig and RespSessSig with no attacker help. *)
 set attacker = passive.
 set reconstructTrace = true.
 query i: Principal, r: Principal, ctx: bitstring, e: bitstring, k: bitstring;

--- a/libcrux-psq/proofs/proverif/psq_crypto.pvl
+++ b/libcrux-psq/proofs/proverif/psq_crypto.pvl
@@ -1,0 +1,90 @@
+(* ===========================================================================
+   PSQ — symbolic cryptographic model (handwritten)
+   ===========================================================================
+   This file gives the symbolic (Dolev-Yao) model of the crypto primitives that
+   the extracted `lib.pvl` calls into via `#[hax_lib::proverif::replace_body]`
+   annotations on the libcrux-psq crypto wrappers. It is the DIRECT analogue of
+   `psq-design/models/psq_handshake_lib.pvl` (the verified handwritten model),
+   transcribed to the `extern__`-prefixed names the extraction references and to
+   the uniform-bitstring backend (every value is a `bitstring`).
+
+   Loaded by the check script via `-lib`; the auto-declared copies in
+   `missingdecl.pvl` are de-duplicated against the definitions here.
+
+   Boundaries (Rust wrapper  ->  symbolic term):
+     dhkem::DHPrivateKey::new            ->  fresh DH scalar
+     dhkem::DHPrivateKey::to_public      ->  extern__dh_pub(sk)
+     dhkem::DHSharedSecret::derive       ->  extern__dh_shared(sk, pk)
+     transcript::Transcript::add_hash    ->  extern__hash(domsep, old, input)
+     aead::AEADKeyNonce::new             ->  extern__kdf(ikm, info)
+     aead::AEADKeyNonce::handshake_encrypt -> (extern__aead_ct(k,pt,ad),
+                                               extern__aead_tag(k,pt,ad))
+     aead::AEADKeyNonce::handshake_decrypt -> extern__aead_dec(k, ct, tag, ad)
+   =========================================================================== *)
+
+(* ---- Diffie-Hellman (X25519) ------------------------------------------- *)
+(* A public key is dh_pub(sk); a shared secret dh_shared(sk, pk). Honest keys
+   commute via the equation below (the standard symbolic DH abstraction). *)
+fun extern__dh_pub(bitstring): bitstring.
+fun extern__dh_shared(bitstring, bitstring): bitstring.
+equation forall x: bitstring, y: bitstring;
+      extern__dh_shared(x, extern__dh_pub(y)) = extern__dh_shared(y, extern__dh_pub(x)).
+
+(* ---- Transcript hash (SHA-256, running) -------------------------------- *)
+(* One-way, injective in the term algebra (a `fun` with no reduc): the
+   attacker cannot invert it and distinct argument tuples give distinct
+   digests. Arguments mirror `add_hash(old_transcript, input)`; the previous
+   transcript is chained in (None for tx0) and the step inputs are distinctly
+   typed, so the steps stay separated without an explicit domain-separator
+   byte. *)
+fun extern__hash(bitstring, bitstring): bitstring.
+
+(* ---- Key derivation (HKDF-SHA256) -------------------------------------- *)
+(* AEADKeyNonce::new(ikm, info) derives an AEAD key+nonce; one-way in ikm. *)
+fun extern__kdf(bitstring, bitstring): bitstring.
+
+(* ---- AEAD (ChaCha20Poly1305 / AES-128-GCM) ----------------------------- *)
+(* Ciphertext and tag are separate on the wire. Decryption requires BOTH the
+   genuine ciphertext and the genuine tag for the same key/aad: an attacker
+   without the key can produce neither, modelling AEAD confidentiality and
+   integrity. The key already bundles the (single-use) nonce. *)
+fun extern__aead_ct(bitstring, bitstring, bitstring): bitstring.
+fun extern__aead_tag(bitstring, bitstring, bitstring): bitstring.
+reduc forall k: bitstring, pt: bitstring, ad: bitstring;
+      extern__aead_dec(k, extern__aead_ct(k, pt, ad), extern__aead_tag(k, pt, ad), ad) = pt.
+
+(* ===========================================================================
+   Wrapper definitions for crypto functions the engine does not currently emit
+   via `replace_body` (the body replacement applies at the Rust level but no
+   letfun is produced — happens for `&mut rng` key-gen, the stateful SHA-256
+   hasher, and the nested-struct transcript inputs). We give sound definitions
+   for the auto-declared names directly here, so they connect to the term
+   algebra above instead of being marked opaque `[data]` by the missingdecl
+   de-dup. Without this, DH public keys / private keys would be invertible.
+   =========================================================================== *)
+
+(* dhkem::DHPrivateKey::to_public  ->  g^sk (one-way). *)
+letfun libcrux_psq__handshake__dhkem__Impl_6__to_public(sk: bitstring) =
+      extern__dh_pub(sk).
+
+(* dhkem::DHPrivateKey::new(rng)  ->  fresh DH scalar (threads rng unchanged,
+   matching the &mut-rng calling convention: returns (rng, sk)). *)
+letfun libcrux_psq__handshake__dhkem__Impl_6__new_kw(rng: bitstring) =
+      new dh_scalar: bitstring;
+      rust_primitives__hax__Tuple2__Tuple2(rng, dh_scalar).
+
+(* transcript::Transcript::add_hash(old, input)  ->  running hash (one-way). *)
+letfun libcrux_psq__handshake__transcript__Impl__add_hash(old: bitstring, input: bitstring) =
+      extern__hash(old, input).
+
+(* transcript::tx0(context, responder_pk, initiator_pk) = hash(0 | ctx | pkR | pkI). *)
+letfun libcrux_psq__handshake__transcript__tx0(
+        context: bitstring, responder_pk: bitstring, initiator_pk: bitstring) =
+      extern__hash(None, (context, responder_pk, initiator_pk)).
+
+(* transcript::tx1(tx0, authenticator, responder_pq_pk, pq_encaps)
+     = hash(1 | tx0 | auth | [pqek] | [enc_pq]). *)
+letfun libcrux_psq__handshake__transcript__tx1(
+        tx0v: bitstring, authenticator: bitstring,
+        responder_pq_pk: bitstring, pq_encaps: bitstring) =
+      extern__hash(Some(tx0v), (authenticator, responder_pq_pk, pq_encaps)).

--- a/libcrux-psq/proofs/proverif/psq_crypto.pvl
+++ b/libcrux-psq/proofs/proverif/psq_crypto.pvl
@@ -53,6 +53,42 @@ fun extern__aead_tag(bitstring, bitstring, bitstring): bitstring.
 reduc forall k: bitstring, pt: bitstring, ad: bitstring;
       extern__aead_dec(k, extern__aead_ct(k, pt, ad), extern__aead_tag(k, pt, ad), ad) = pt.
 
+(* ---- Serialization round-trip across the AEAD boundary ----------------- *)
+(* `handshake_encrypt`/`handshake_decrypt` seal/open the *structured* payload
+   directly (the tls (de)serialization is dropped — see aead.rs). But the
+   initiator serializes the borrowed `InitiatorOuterPayloadOut::Query` while the
+   responder's `read_message_contents` deserializes into the owned
+   `InitiatorOuterPayload::Query`: two distinct hax-generated constructors that
+   share ONE wire encoding, so a real AEAD round-trip turns one into the other.
+   `handshake_decrypt` applies `pv_deserialize` to model exactly that wire
+   round-trip, so the responder recovers the owned form it destructures. Every
+   other payload (e.g. the responder's `ResponderQueryPayloadOut` response, which
+   the initiator reads raw without destructuring) passes through unchanged.
+
+   These two constructors are declared HERE (and stripped from the extracted
+   `lib.pvl` by check-pv.sh, to avoid a duplicate definition) so `pv_deserialize`
+   can reference them without a forward reference — ProVerif requires every name
+   to be declared before use, and `handshake_decrypt` (in lib.pvl) calls
+   `pv_deserialize`, whose body in turn needs these constructors. *)
+fun libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query(bitstring): bitstring [data].
+fun libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(bitstring): bitstring [data].
+fun pv_deserialize(bitstring): bitstring
+reduc forall p: bitstring;
+        pv_deserialize(libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query(p))
+          = libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(p)
+otherwise forall x: bitstring;
+        pv_deserialize(x) = x.
+
+(* ---- core::mem::take(&mut place) --------------------------------------- *)
+(* Returns the old value and resets the place to its `Default`. The hax `&mut`
+   lowering yields `Tuple2(new_place, returned_old)`, i.e. `(default, old)`; the
+   auto-declared opaque unary stub in `missingdecl.pvl` (which would be
+   destructured as a `Tuple2` and fail) is superseded by this definition (the
+   check-pv.sh de-dup drops the stub once this name is defined). The responder's
+   `prepare_message_contents` uses it on `self.state`. *)
+letfun core__mem__take(place: bitstring) =
+      rust_primitives__hax__Tuple2__Tuple2(bitstring_default(), place).
+
 (* ===========================================================================
    Wrapper definitions for crypto functions the engine does not currently emit
    via `replace_body` (the body replacement applies at the Rust level but no

--- a/libcrux-psq/proofs/proverif/psq_crypto.pvl
+++ b/libcrux-psq/proofs/proverif/psq_crypto.pvl
@@ -70,12 +70,76 @@ reduc forall k: bitstring, pt: bitstring, ad: bitstring;
    can reference them without a forward reference — ProVerif requires every name
    to be declared before use, and `handshake_decrypt` (in lib.pvl) calls
    `pv_deserialize`, whose body in turn needs these constructors. *)
+(* All of these constructors are DECLARED here (and stripped from the extracted
+   lib.clean.pvl by check-pv.sh, to avoid duplicate definitions) so that
+   `pv_deserialize` below — and the signature model further down — can reference
+   them without a forward reference. Their projector reducs + use sites stay in
+   lib.clean and resolve against these declarations. *)
 fun libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query(bitstring): bitstring [data].
 fun libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(bitstring): bitstring [data].
+fun libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(bitstring): bitstring [data].
+fun libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration(bitstring): bitstring [data].
+fun libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(bitstring, bitstring, bitstring, bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__InnerMessage__InnerMessage(bitstring, bitstring, bitstring, bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__AuthMessageOut__Dh(bitstring): bitstring [data].
+fun libcrux_psq__handshake__AuthMessageOut__Sig(bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__AuthMessage__Dh(bitstring): bitstring [data].
+fun libcrux_psq__handshake__AuthMessage__Sig(bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__initiator__InitiatorInnerPayloadOut__InitiatorInnerPayloadOut(bitstring): bitstring [data].
+fun libcrux_psq__handshake__initiator__InitiatorInnerPayload__InitiatorInnerPayload(bitstring): bitstring [data].
+fun libcrux_psq__handshake__responder__ResponderRegistrationPayloadOut__ResponderRegistrationPayloadOut(bitstring): bitstring [data].
+fun libcrux_psq__handshake__responder__ResponderRegistrationPayload__ResponderRegistrationPayload(bitstring): bitstring [data].
+fun tls_codec__quic_vec__VLByteSlice__VLByteSlice(bitstring): bitstring [data].
+
+(* The wire round-trip bridge. The initiator AEAD-seals a *borrowed* `…Out`
+   payload; the responder AEAD-opens into the *owned* payload it destructures —
+   distinct hax-generated constructors that share ONE wire encoding, so a real
+   AEAD round-trip maps one to the other. `handshake_decrypt` applies
+   `pv_deserialize` to model exactly that. The registration outer payload nests
+   an `InnerMessageOut` whose `VLByteSlice` fields become the owned `InnerMessage`
+   (we strip the `VLByteSlice` wrapper, so the responder's `as_slice` /
+   `deserialize_encapsulation` — modelled as identity — recover the raw inner
+   ciphertext / aad / pq-encapsulation) and whose `AuthMessageOut` becomes the
+   owned `AuthMessage`. The inner registration payload and the responder's
+   registration response each have their own `…Out → owned` clause. Everything
+   else (e.g. a payload read raw without destructuring) passes through unchanged. *)
 fun pv_deserialize(bitstring): bitstring
 reduc forall p: bitstring;
         pv_deserialize(libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query(p))
           = libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(p)
+(* NB: the extracted `InnerMessageOut` *constructor* lists `auth` FIRST
+   (ciphersuite source-literal order: auth, ciphertext, tag, aad,
+   pq_encapsulation), whereas the owned `InnerMessage` projectors the responder
+   reads follow declaration order (ciphertext, tag, aad, pq_encapsulation, auth).
+   `InnerMessageOut` is only ever constructed (by the initiator) and consumed
+   here, so we match its actual construction order on the LHS and rebuild the
+   owned `InnerMessage` in projector order on the RHS. *)
+otherwise forall ic: bitstring, it: bitstring, ia: bitstring, pqe: bitstring, pk: bitstring;
+        pv_deserialize(libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+            libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+              libcrux_psq__handshake__AuthMessageOut__Dh(pk),
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(ic), it,
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(ia),
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(pqe))))
+          = libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration(
+              libcrux_psq__handshake__InnerMessage__InnerMessage(ic, it, ia, pqe,
+                libcrux_psq__handshake__AuthMessage__Dh(pk)))
+otherwise forall ic: bitstring, it: bitstring, ia: bitstring, pqe: bitstring, vk: bitstring, sig: bitstring;
+        pv_deserialize(libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+            libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+              libcrux_psq__handshake__AuthMessageOut__Sig(vk, sig),
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(ic), it,
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(ia),
+              tls_codec__quic_vec__VLByteSlice__VLByteSlice(pqe))))
+          = libcrux_psq__handshake__responder__InitiatorOuterPayload__Registration(
+              libcrux_psq__handshake__InnerMessage__InnerMessage(ic, it, ia, pqe,
+                libcrux_psq__handshake__AuthMessage__Sig(vk, sig)))
+otherwise forall p: bitstring;
+        pv_deserialize(libcrux_psq__handshake__initiator__InitiatorInnerPayloadOut__InitiatorInnerPayloadOut(p))
+          = libcrux_psq__handshake__initiator__InitiatorInnerPayload__InitiatorInnerPayload(p)
+otherwise forall p: bitstring;
+        pv_deserialize(libcrux_psq__handshake__responder__ResponderRegistrationPayloadOut__ResponderRegistrationPayloadOut(p))
+          = libcrux_psq__handshake__responder__ResponderRegistrationPayload__ResponderRegistrationPayload(p)
 otherwise forall x: bitstring;
         pv_deserialize(x) = x.
 
@@ -119,8 +183,283 @@ letfun libcrux_psq__handshake__transcript__tx0(
       extern__hash(None, (context, responder_pk, initiator_pk)).
 
 (* transcript::tx1(tx0, authenticator, responder_pq_pk, pq_encaps)
-     = hash(1 | tx0 | auth | [pqek] | [enc_pq]). *)
+     = hash(1 | tx0 | auth | [pqek] | [enc_pq]).
+   The responder-PQ-key argument arrives in TWO shapes: the initiator passes the
+   raw `PqKemPublicKey::MlKem(pqek)` because hax dropped the `self.ciphersuite.pq
+   .into()` conversion in prepare_message_contents (same From/Into resolution bug
+   as Impl_2__from / the sig vk), while the responder passes the proper
+   `Some(PQEncapsulationKey::MlKem(pqek))` from `encapsulation_key()`. Both wrap
+   the same `pqek`, so we canonicalize to `pqek` before hashing — otherwise the
+   two tx1 (hence K_1) disagree and the honest inner decrypt fails. *)
+fun libcrux_psq__handshake__ciphersuite__initiator__PqKemPublicKey__MlKem(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem(bitstring): bitstring [data].
+letfun pv_canon_pqpk(p: bitstring) =
+      let libcrux_psq__handshake__ciphersuite__initiator__PqKemPublicKey__MlKem(pqek) = p in pqek
+      else let Some(libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem(pqek)) = p in pqek
+      else p.
 letfun libcrux_psq__handshake__transcript__tx1(
         tx0v: bitstring, authenticator: bitstring,
         responder_pq_pk: bitstring, pq_encaps: bitstring) =
-      extern__hash(Some(tx0v), (authenticator, responder_pq_pk, pq_encaps)).
+      extern__hash(Some(tx0v), (authenticator, pv_canon_pqpk(responder_pq_pk), pq_encaps)).
+
+(* ===========================================================================
+   REGISTRATION MODE crypto
+   ===========================================================================
+   Everything below is exercised only by registration mode (query mode never
+   reaches it). It mirrors psq-design/models/psq_handshake_lib.pvl. *)
+
+(* ---- Post-quantum KEM (ML-KEM-768) ------------------------------------- *)
+(* Standard symbolic KEM: a decapsulation key sk has public key kem_pk(sk); an
+   encapsulation to pk yields a ciphertext kem_encaps(pk, ss) carrying a fresh
+   shared secret ss; only the holder of sk can recover ss. This is the trust
+   anchor for HNDL confidentiality (R4/R6/R7) — a classical-DH break does not
+   help, only `pqdk_R` (CompromiseEndpointPQ) does. The libcrux wrappers
+   `mlkem768::{encapsulate,decapsulate}` are external (no body extracted), so we
+   define them directly; the `(ct, ss)` pair / `PQCiphertext` wrapping is done by
+   the extracted `pq_encapsulate` / `pq_decapsulate` around these. *)
+fun extern__kem_pk(bitstring): bitstring.
+fun extern__kem_encaps(bitstring, bitstring): bitstring.
+reduc forall sk: bitstring, ss: bitstring;
+      extern__kem_decaps(sk, extern__kem_encaps(extern__kem_pk(sk), ss)) = ss.
+
+letfun libcrux_ml_kem__mlkem768__encapsulate(pk: bitstring, rand: bitstring) =
+      new ss: bitstring;
+      rust_primitives__hax__Tuple2__Tuple2(extern__kem_encaps(pk, ss), ss).
+letfun libcrux_ml_kem__mlkem768__decapsulate(sk: bitstring, ct: bitstring) =
+      extern__kem_decaps(sk, ct).
+
+(* ---- Digital signatures (Ed25519 / ML-DSA-65) -------------------------- *)
+(* EUF-CMA, modelled as a PARTIAL destructor: `extern__sig_verify(vk, m, sig)`
+   has a reducing clause ONLY for a genuine signature `sign(sk, m)` under the
+   matching `vk_of(sk)`; on a forgery it has no value and FAILS. The single
+   caller (`verify_tx1`) lowers `vk.verify(..)?` to
+   `let wildcard = verify(..) in <continue> else bitstring_err()`, so a failure
+   correctly aborts the responder read (there is no `assert!`/`not_kw` to swallow
+   it). The `vk_of(sk)` binding is what makes signature-based initiator
+   authentication PQ-secure (R2a true): a quantum adversary that breaks classical
+   DH still cannot produce `sign(sk_I, .)` without `sk_I`. *)
+(* Key/signature enum constructors (declared here, stripped from lib.clean). *)
+fun libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(bitstring): bitstring [data].
+fun extern__vk_of(bitstring): bitstring.
+fun extern__sign(bitstring, bitstring): bitstring.
+fun extern__sig_verify(bitstring, bitstring, bitstring): bitstring
+reduc forall sk: bitstring, m: bitstring;
+      extern__sig_verify(extern__vk_of(sk), m, extern__sign(sk, m)) = rust_primitives__hax__Tuple0__Tuple0.
+
+(* ciphersuite::initiator::SigningKeyPair::sign(self, rng, tx). `&mut rng` makes
+   it return (rng, signature); we project the inner signing scalar from the
+   key pair and wrap the EUF-CMA term in the right Signature variant (the peer
+   recovers `vk = vk_of(sk)` from the SignatureVerificationKey, so the two bind). *)
+letfun libcrux_psq__handshake__ciphersuite__initiator__Impl_3__sign(
+        self: bitstring, rng: bitstring, tx: bitstring) =
+      rust_primitives__hax__Tuple2__Tuple2(rng,
+        let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk) = self in
+          libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(extern__sign(sk, tx))
+        else let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk) = self in
+          libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(extern__sign(sk, tx))
+        else bitstring_err()).
+
+(* ciphersuite::types::SignatureVerificationKey::verify(self, tx1, sig). Unwrap
+   the key/sig enums and run the partial destructor; mismatched variants fail
+   (== reject). *)
+(* NB: the wire `vk` reaching `verify` is actually the raw SigningKeyPair, not a
+   SignatureVerificationKey: hax dropped the `sig_auth.into()` conversion in the
+   initiator's AuthMessageOut::Sig construction (same From/Into resolution gap as
+   Impl_2__from). We therefore also accept the SigningKeyPair form and project its
+   inner verification key (field 1 = vk_of(sk)). Sound for authentication: only
+   the vk is used; the spurious sk in the wrapper is ignored, and a forgery still
+   cannot produce sign(sk, tx1) without sk. *)
+letfun libcrux_psq__handshake__ciphersuite__types__Impl_4__verify(
+        self: bitstring, tx1: bitstring, sig: bitstring) =
+      let libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(vk) = self in
+        (let libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(s) = sig in
+           extern__sig_verify(vk, tx1, s) else bitstring_err())
+      else let libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(vk) = self in
+        (let libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(s) = sig in
+           extern__sig_verify(vk, tx1, s) else bitstring_err())
+      else let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk) = self in
+        (let libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(s) = sig in
+           extern__sig_verify(vk, tx1, s) else bitstring_err())
+      else let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk) = self in
+        (let libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(s) = sig in
+           extern__sig_verify(vk, tx1, s) else bitstring_err())
+      else bitstring_err().
+
+(* ml-dsa signature `as_ref` (used to bytes-ify the signature in derive_k1_sig);
+   identity in the term algebra. *)
+letfun libcrux_ml_dsa__types__Impl_4__as_ref(x: bitstring) = x.
+
+(* ---- handshake_encrypt — strip the sk_I that hax left on the sig wire ---- *)
+(* The initiator builds `AuthMessageOut::Sig { vk: &sig_auth.into(), .. }` but hax
+   DROPPED the `.into()` (SigningKeyPair -> SignatureVerificationKey; same From/Into
+   gap as Impl_2__from / Impl_4__verify), so the *sealed* outer payload carries the
+   raw `SigningKeyPair(sk_I, vk_I)` — the client's PRIVATE signing key sk_I is on the
+   wire. An attacker who breaks the responder's classical key (R2a's threat model)
+   decrypts the outer and reads sk_I straight out — via the raw `aead_dec` destructor,
+   bypassing the `pv_deserialize` bridge and Impl_2__from/Impl_4__verify (which only
+   guard the responder's *consumption*, not what is sealed) — then forges, making R2a
+   spuriously FALSE for signature auth. Model the dropped `.into()` at the seal
+   boundary: canonicalize the payload before AEAD-sealing, replacing
+   `SigningKeyPair(sk,vk)` with `SignatureVerificationKey(vk)` inside any
+   `AuthMessageOut::Sig`. SOUND: only the public vk is ever meant to be on the wire;
+   Impl_2__from's catch-all maps `AuthMessage::Sig(SignatureVerificationKey(vk),_)` to
+   the SAME `Authenticator::Sig(SignatureVerificationKey(vk))` as the SigningKeyPair
+   form, so tx1 / K_1 / verify are unchanged and the honest run is preserved. Query /
+   DH / inner-payload / response payloads don't match the Sig pattern -> pass through.
+   (`handshake_encrypt` is stripped from lib.clean by check-pv.sh's STRIP_LETFUN.) *)
+letfun pv_canon_wire(p: bitstring) =
+      let libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+            libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+              libcrux_psq__handshake__AuthMessageOut__Sig(
+                libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk), sig),
+              c1, c2, c3, c4)) = p in
+        libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+          libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+            libcrux_psq__handshake__AuthMessageOut__Sig(
+              libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(vk), sig),
+            c1, c2, c3, c4))
+      else let libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+            libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+              libcrux_psq__handshake__AuthMessageOut__Sig(
+                libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk), sig),
+              c1, c2, c3, c4)) = p in
+        libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Registration(
+          libcrux_psq__handshake__InnerMessageOut__InnerMessageOut(
+            libcrux_psq__handshake__AuthMessageOut__Sig(
+              libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(vk), sig),
+            c1, c2, c3, c4))
+      else p.
+letfun libcrux_psq__aead__Impl_1__handshake_encrypt(
+        self: bitstring, payload: bitstring, aad: bitstring) =
+      let p2 = pv_canon_wire(payload) in
+      rust_primitives__hax__Tuple2__Tuple2(self,
+        rust_primitives__hax__Tuple2__Tuple2(
+          extern__aead_ct(self, p2, aad), extern__aead_tag(self, p2, aad))).
+
+(* rng.fill_bytes(&mut buf): &mut self (rng) + &mut buf, so hax threads it as
+   (rng', buf'); buf' is filled with fresh randomness. WITHOUT this the auto-
+   declared opaque stub is not a Tuple2, so `let (rng',rand') = fill_bytes(..)`
+   in pq_encapsulate (and ml-dsa sign) FAILS — silently killing the honest
+   registration initiator's message construction. (Query mode never reaches it.)
+   The freshness is otherwise abstracted into encapsulate's `new ss` / sign, so
+   the filled value only needs to exist. *)
+letfun rand_core__Rng__fill_bytes(rng: bitstring, buf: bitstring) =
+      new filled: bitstring;
+      rust_primitives__hax__Tuple2__Tuple2(rng, filled).
+
+(* Option::transpose (Option<Result<T>> -> Result<Option<T>>). In the model the
+   Result layer is collapsed (pq_decapsulate returns the bare shared secret), so
+   transpose is the identity. WITHOUT this the auto-declared opaque stub makes the
+   responder's pq_shared_secret = transpose(Some(ss)) while the initiator uses
+   Some(ss) directly -> K_1 disagrees -> the honest inner decrypt fails. *)
+letfun core__option__Impl_4__transpose(o: bitstring) = o.
+
+(* The two ciphersuite structs, declared HERE (and stripped from lib.clean by
+   check-pv.sh) so the `name` projector below can pattern-match them before
+   lib.pvl loads. Their field projectors stay in lib.clean and resolve against
+   these declarations. *)
+fun libcrux_psq__handshake__ciphersuite__initiator__InitiatorCiphersuite__InitiatorCiphersuite(
+      bitstring, bitstring, bitstring, bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite(
+      bitstring, bitstring, bitstring, bitstring): bitstring [data].
+
+(* ---- CiphersuiteBase::name — MUST project, not be an opaque [data] fun ---- *)
+(* `CiphersuiteBase::name(&self) -> CiphersuiteName` returns the public ciphersuite
+   identifier (an enum discriminant), i.e. `self.name` (field 0). The auto-declared
+   stub in missingdecl.pvl is `fun …__name(bitstring): bitstring [data].`, i.e. an
+   INJECTIVE constructor — so ProVerif synthesises the projector `1-proj-…__name`
+   and the attacker INVERTS `name(cs)` back to the whole ciphersuite `cs`. The
+   INITIATOR puts `name(self.ciphersuite)` on the wire (write_message), and its
+   `InitiatorCiphersuite` embeds the secret `Auth::DH(DHKeyPair(sk_I,_))` /
+   `Auth::Sig(SigningKeyPair(sk_I,_))` — so the public name field leaks the client's
+   private key, spuriously breaking R2b (DH classical-soundness) and R2a (sig). The
+   real `name()` returns only the public enum label and is NOT invertible to the
+   struct. Model it faithfully as the field-0 projection (both ciphersuite structs
+   store the CiphersuiteName first); fall through to identity if it is already a
+   bare name. Strips the leak; the name still round-trips as a public constant. *)
+letfun libcrux_psq__handshake__ciphersuite__traits__CiphersuiteBase__name(cs: bitstring) =
+      let libcrux_psq__handshake__ciphersuite__initiator__InitiatorCiphersuite__InitiatorCiphersuite(
+            nm: bitstring, pkr: bitstring, pq: bitstring, auth: bitstring, aead: bitstring) = cs in nm
+      else let libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite(
+            nm: bitstring, kex: bitstring, pq: bitstring, aead: bitstring) = cs in nm
+      else cs.
+
+(* ---- Authenticator::from — fix a trait-resolution gap ------------------- *)
+(* The crate has two `From<_> for Authenticator` impls: `From<Auth>` (initiator
+   side, sign_tx1) and `From<&AuthMessage>` (responder side, verify_tx1). hax
+   collapsed both call sites onto the single extracted `types::Impl_2__from`,
+   which only handles the initiator `Auth` enum — so on the responder a wire
+   `AuthMessage` falls through to `bitstring_err()` and tx1 can never agree,
+   making every registration handshake unreachable. It also dropped the
+   `sig_auth.into()` (SigningKeyPair -> SignatureVerificationKey) conversion in
+   the `Auth::Sig` arm. We override `Impl_2__from` (stripped from lib.clean by
+   check-pv.sh) to handle BOTH inputs and to perform the vk conversion, so the
+   initiator's `Authenticator` (built from its Auth) and the responder's (built
+   from the wire AuthMessage) coincide for the same identity:
+     DH : Auth::DH(kp)            and  AuthMessage::Dh(pk)        -> Authenticator::Dh(pk)
+     Sig: Auth::Sig(SKP(sk,vk))   and  AuthMessage::Sig(vk,_)     -> Authenticator::Sig(vk)
+   (the wire vk = vk_of(sk), set up by the role, so both sides match). *)
+fun libcrux_psq__handshake__ciphersuite__initiator__Auth__DH(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__initiator__Auth__Sig(bitstring): bitstring [data].
+fun libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair(bitstring, bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh(bitstring): bitstring [data].
+fun libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(bitstring): bitstring [data].
+letfun libcrux_psq__handshake__ciphersuite__types__Impl_2__from(value: bitstring) =
+      let libcrux_psq__handshake__ciphersuite__initiator__Auth__DH(
+            libcrux_psq__handshake__dhkem__DHKeyPair__DHKeyPair(sk, pk)) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh(pk)
+      else let libcrux_psq__handshake__ciphersuite__initiator__Auth__Sig(
+            libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk)) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(
+          libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(vk))
+      else let libcrux_psq__handshake__ciphersuite__initiator__Auth__Sig(
+            libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk)) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(
+          libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(vk))
+      else let libcrux_psq__handshake__AuthMessage__Dh(pk) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Dh(pk)
+      (* responder side: the wire AuthMessage::Sig carries the raw SigningKeyPair
+         (hax dropped the .into()); project its vk so the responder's Authenticator
+         matches the initiator's (built from Auth::Sig above). *)
+      else let libcrux_psq__handshake__AuthMessage__Sig(
+            libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk), sig) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(
+          libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(vk))
+      else let libcrux_psq__handshake__AuthMessage__Sig(
+            libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk), sig) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(
+          libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(vk))
+      else let libcrux_psq__handshake__AuthMessage__Sig(vk, sig) = value in
+        libcrux_psq__handshake__ciphersuite__types__Authenticator__Sig(vk)
+      else bitstring_err().
+
+(* ---- Session key schedule ---------------------------------------------- *)
+(* session::session_key::derive_session_key(k2, tx2, aead) = KDF(K_2, tx2) — the
+   final session key K_S; one-way in K_2 (so K_S secrecy reduces to K_2's). *)
+letfun libcrux_psq__session__session_key__derive_session_key(
+        k2: bitstring, tx2: bitstring, aead_type: bitstring) =
+      extern__kdf(k2, tx2).
+(* session::derive_pk_binder(session_key, auth, ecdh_pk, pq_pk) — one-way; binds
+   the peer identities into the session. Not itself a queried secret. *)
+letfun libcrux_psq__session__derive_pk_binder(
+        session_key: bitstring, auth: bitstring, ecdh_pk: bitstring, pq_pk: bitstring) =
+      extern__kdf(session_key, auth).
+
+(* ---- Serialization carriers (transparent / injective) ------------------ *)
+(* The structured payloads are sealed/opened directly; the tls (de)serialization
+   is the identity in the term algebra (the term structure IS the wire form, so
+   distinct terms give distinct encodings — injective, no re-partition attack).
+   `Impl_25__as_slice` / `cursor::new` / `tls_(de)serialize` therefore pass their
+   argument through; the `pv_deserialize` bridge above already stripped the
+   `VLByteSlice` wrappers off the registration inner fields, so these see raw
+   terms. *)
+letfun tls_codec__quic_vec__Impl_25__as_slice(x: bitstring) = x.
+letfun std__io__cursor__Impl__new_kw(x: bitstring) = x.
+letfun tls_codec__Serialize__tls_serialize_detached(x: bitstring) = x.
+letfun tls_codec__Deserialize__tls_deserialize(x: bitstring) =
+      rust_primitives__hax__Tuple2__Tuple2(nat_lit(0), x).

--- a/libcrux-psq/proofs/proverif/psq_crypto.pvl
+++ b/libcrux-psq/proofs/proverif/psq_crypto.pvl
@@ -3,7 +3,7 @@
    ===========================================================================
    This file gives the symbolic (Dolev-Yao) model of the crypto primitives that
    the extracted `lib.pvl` calls into via `#[hax_lib::proverif::replace_body]`
-   annotations on the libcrux-psq crypto wrappers. It is the DIRECT analogue of
+   annotations on the libcrux-psq crypto wrappers. It is the direct analogue of
    `psq-design/models/psq_handshake_lib.pvl` (the verified handwritten model),
    transcribed to the `extern__`-prefixed names the extraction references and to
    the uniform-bitstring backend (every value is a `bitstring`).
@@ -23,7 +23,7 @@
    =========================================================================== *)
 
 (* ---- Diffie-Hellman (X25519) ------------------------------------------- *)
-(* A public key is dh_pub(sk); a shared secret dh_shared(sk, pk). Honest keys
+(* A public key is dh_pub(sk); a shared secret dh_shared(sk, pk). Keys
    commute via the equation below (the standard symbolic DH abstraction). *)
 fun extern__dh_pub(bitstring): bitstring.
 fun extern__dh_shared(bitstring, bitstring): bitstring.
@@ -44,7 +44,7 @@ fun extern__hash(bitstring, bitstring): bitstring.
 fun extern__kdf(bitstring, bitstring): bitstring.
 
 (* ---- AEAD (ChaCha20Poly1305 / AES-128-GCM) ----------------------------- *)
-(* Ciphertext and tag are separate on the wire. Decryption requires BOTH the
+(* Ciphertext and tag are separate on the wire. Decryption requires both the
    genuine ciphertext and the genuine tag for the same key/aad: an attacker
    without the key can produce neither, modelling AEAD confidentiality and
    integrity. The key already bundles the (single-use) nonce. *)
@@ -59,18 +59,18 @@ reduc forall k: bitstring, pt: bitstring, ad: bitstring;
    initiator serializes the borrowed `InitiatorOuterPayloadOut::Query` while the
    responder's `read_message_contents` deserializes into the owned
    `InitiatorOuterPayload::Query`: two distinct hax-generated constructors that
-   share ONE wire encoding, so a real AEAD round-trip turns one into the other.
+   share one wire encoding, so an AEAD round-trip turns one into the other.
    `handshake_decrypt` applies `pv_deserialize` to model exactly that wire
    round-trip, so the responder recovers the owned form it destructures. Every
    other payload (e.g. the responder's `ResponderQueryPayloadOut` response, which
    the initiator reads raw without destructuring) passes through unchanged.
 
-   These two constructors are declared HERE (and stripped from the extracted
+   These two constructors are declared here (and stripped from the extracted
    `lib.pvl` by check-pv.sh, to avoid a duplicate definition) so `pv_deserialize`
    can reference them without a forward reference — ProVerif requires every name
    to be declared before use, and `handshake_decrypt` (in lib.pvl) calls
    `pv_deserialize`, whose body in turn needs these constructors. *)
-(* All of these constructors are DECLARED here (and stripped from the extracted
+(* All of these constructors are declared here (and stripped from the extracted
    lib.clean.pvl by check-pv.sh, to avoid duplicate definitions) so that
    `pv_deserialize` below — and the signature model further down — can reference
    them without a forward reference. Their projector reducs + use sites stay in
@@ -93,7 +93,7 @@ fun tls_codec__quic_vec__VLByteSlice__VLByteSlice(bitstring): bitstring [data].
 
 (* The wire round-trip bridge. The initiator AEAD-seals a *borrowed* `…Out`
    payload; the responder AEAD-opens into the *owned* payload it destructures —
-   distinct hax-generated constructors that share ONE wire encoding, so a real
+   distinct hax-generated constructors that share one wire encoding, so an
    AEAD round-trip maps one to the other. `handshake_decrypt` applies
    `pv_deserialize` to model exactly that. The registration outer payload nests
    an `InnerMessageOut` whose `VLByteSlice` fields become the owned `InnerMessage`
@@ -107,7 +107,7 @@ fun pv_deserialize(bitstring): bitstring
 reduc forall p: bitstring;
         pv_deserialize(libcrux_psq__handshake__initiator__InitiatorOuterPayloadOut__Query(p))
           = libcrux_psq__handshake__responder__InitiatorOuterPayload__Query(p)
-(* NB: the extracted `InnerMessageOut` *constructor* lists `auth` FIRST
+(* NB: the extracted `InnerMessageOut` *constructor* lists `auth` first
    (ciphersuite source-literal order: auth, ciphertext, tag, aad,
    pq_encapsulation), whereas the owned `InnerMessage` projectors the responder
    reads follow declaration order (ciphertext, tag, aad, pq_encapsulation, auth).
@@ -184,13 +184,13 @@ letfun libcrux_psq__handshake__transcript__tx0(
 
 (* transcript::tx1(tx0, authenticator, responder_pq_pk, pq_encaps)
      = hash(1 | tx0 | auth | [pqek] | [enc_pq]).
-   The responder-PQ-key argument arrives in TWO shapes: the initiator passes the
+   The responder-PQ-key argument arrives in two shapes: the initiator passes the
    raw `PqKemPublicKey::MlKem(pqek)` because hax dropped the `self.ciphersuite.pq
    .into()` conversion in prepare_message_contents (same From/Into resolution bug
    as Impl_2__from / the sig vk), while the responder passes the proper
    `Some(PQEncapsulationKey::MlKem(pqek))` from `encapsulation_key()`. Both wrap
    the same `pqek`, so we canonicalize to `pqek` before hashing — otherwise the
-   two tx1 (hence K_1) disagree and the honest inner decrypt fails. *)
+   two tx1 (hence K_1) disagree and the inner decrypt fails. *)
 fun libcrux_psq__handshake__ciphersuite__initiator__PqKemPublicKey__MlKem(bitstring): bitstring [data].
 fun libcrux_psq__handshake__ciphersuite__types__PQEncapsulationKey__MlKem(bitstring): bitstring [data].
 letfun pv_canon_pqpk(p: bitstring) =
@@ -203,7 +203,7 @@ letfun libcrux_psq__handshake__transcript__tx1(
       extern__hash(Some(tx0v), (authenticator, pv_canon_pqpk(responder_pq_pk), pq_encaps)).
 
 (* ===========================================================================
-   REGISTRATION MODE crypto
+   Registration mode crypto
    ===========================================================================
    Everything below is exercised only by registration mode (query mode never
    reaches it). It mirrors psq-design/models/psq_handshake_lib.pvl. *)
@@ -229,9 +229,9 @@ letfun libcrux_ml_kem__mlkem768__decapsulate(sk: bitstring, ct: bitstring) =
       extern__kem_decaps(sk, ct).
 
 (* ---- Digital signatures (Ed25519 / ML-DSA-65) -------------------------- *)
-(* EUF-CMA, modelled as a PARTIAL destructor: `extern__sig_verify(vk, m, sig)`
-   has a reducing clause ONLY for a genuine signature `sign(sk, m)` under the
-   matching `vk_of(sk)`; on a forgery it has no value and FAILS. The single
+(* EUF-CMA, modelled as a partial destructor: `extern__sig_verify(vk, m, sig)`
+   has a reducing clause only for a genuine signature `sign(sk, m)` under the
+   matching `vk_of(sk)`; on a forgery it has no value and fails. The single
    caller (`verify_tx1`) lowers `vk.verify(..)?` to
    `let wildcard = verify(..) in <continue> else bitstring_err()`, so a failure
    correctly aborts the responder read (there is no `assert!`/`not_kw` to swallow
@@ -267,7 +267,7 @@ letfun libcrux_psq__handshake__ciphersuite__initiator__Impl_3__sign(
 (* ciphersuite::types::SignatureVerificationKey::verify(self, tx1, sig). Unwrap
    the key/sig enums and run the partial destructor; mismatched variants fail
    (== reject). *)
-(* NB: the wire `vk` reaching `verify` is actually the raw SigningKeyPair, not a
+(* NB: the wire `vk` reaching `verify` is the raw SigningKeyPair, not a
    SignatureVerificationKey: hax dropped the `sig_auth.into()` conversion in the
    initiator's AuthMessageOut::Sig construction (same From/Into resolution gap as
    Impl_2__from). We therefore also accept the SigningKeyPair form and project its
@@ -296,20 +296,20 @@ letfun libcrux_ml_dsa__types__Impl_4__as_ref(x: bitstring) = x.
 
 (* ---- handshake_encrypt — strip the sk_I that hax left on the sig wire ---- *)
 (* The initiator builds `AuthMessageOut::Sig { vk: &sig_auth.into(), .. }` but hax
-   DROPPED the `.into()` (SigningKeyPair -> SignatureVerificationKey; same From/Into
+   dropped the `.into()` (SigningKeyPair -> SignatureVerificationKey; same From/Into
    gap as Impl_2__from / Impl_4__verify), so the *sealed* outer payload carries the
-   raw `SigningKeyPair(sk_I, vk_I)` — the client's PRIVATE signing key sk_I is on the
+   raw `SigningKeyPair(sk_I, vk_I)` — the client's private signing key sk_I is on the
    wire. An attacker who breaks the responder's classical key (R2a's threat model)
    decrypts the outer and reads sk_I straight out — via the raw `aead_dec` destructor,
    bypassing the `pv_deserialize` bridge and Impl_2__from/Impl_4__verify (which only
    guard the responder's *consumption*, not what is sealed) — then forges, making R2a
-   spuriously FALSE for signature auth. Model the dropped `.into()` at the seal
+   spuriously false for signature auth. Model the dropped `.into()` at the seal
    boundary: canonicalize the payload before AEAD-sealing, replacing
    `SigningKeyPair(sk,vk)` with `SignatureVerificationKey(vk)` inside any
-   `AuthMessageOut::Sig`. SOUND: only the public vk is ever meant to be on the wire;
+   `AuthMessageOut::Sig`. Sound: only the public vk is ever meant to be on the wire;
    Impl_2__from's catch-all maps `AuthMessage::Sig(SignatureVerificationKey(vk),_)` to
-   the SAME `Authenticator::Sig(SignatureVerificationKey(vk))` as the SigningKeyPair
-   form, so tx1 / K_1 / verify are unchanged and the honest run is preserved. Query /
+   the same `Authenticator::Sig(SignatureVerificationKey(vk))` as the SigningKeyPair
+   form, so tx1 / K_1 / verify are unchanged and the run is preserved. Query /
    DH / inner-payload / response payloads don't match the Sig pattern -> pass through.
    (`handshake_encrypt` is stripped from lib.clean by check-pv.sh's STRIP_LETFUN.) *)
 letfun pv_canon_wire(p: bitstring) =
@@ -342,9 +342,9 @@ letfun libcrux_psq__aead__Impl_1__handshake_encrypt(
           extern__aead_ct(self, p2, aad), extern__aead_tag(self, p2, aad))).
 
 (* rng.fill_bytes(&mut buf): &mut self (rng) + &mut buf, so hax threads it as
-   (rng', buf'); buf' is filled with fresh randomness. WITHOUT this the auto-
+   (rng', buf'); buf' is filled with fresh randomness. Without this the auto-
    declared opaque stub is not a Tuple2, so `let (rng',rand') = fill_bytes(..)`
-   in pq_encapsulate (and ml-dsa sign) FAILS — silently killing the honest
+   in pq_encapsulate (and ml-dsa sign) fails — killing the
    registration initiator's message construction. (Query mode never reaches it.)
    The freshness is otherwise abstracted into encapsulate's `new ss` / sign, so
    the filled value only needs to exist. *)
@@ -354,12 +354,12 @@ letfun rand_core__Rng__fill_bytes(rng: bitstring, buf: bitstring) =
 
 (* Option::transpose (Option<Result<T>> -> Result<Option<T>>). In the model the
    Result layer is collapsed (pq_decapsulate returns the bare shared secret), so
-   transpose is the identity. WITHOUT this the auto-declared opaque stub makes the
+   transpose is the identity. Without this the auto-declared opaque stub makes the
    responder's pq_shared_secret = transpose(Some(ss)) while the initiator uses
-   Some(ss) directly -> K_1 disagrees -> the honest inner decrypt fails. *)
+   Some(ss) directly -> K_1 disagrees -> the inner decrypt fails. *)
 letfun core__option__Impl_4__transpose(o: bitstring) = o.
 
-(* The two ciphersuite structs, declared HERE (and stripped from lib.clean by
+(* The two ciphersuite structs, declared here (and stripped from lib.clean by
    check-pv.sh) so the `name` projector below can pattern-match them before
    lib.pvl loads. Their field projectors stay in lib.clean and resolve against
    these declarations. *)
@@ -368,17 +368,17 @@ fun libcrux_psq__handshake__ciphersuite__initiator__InitiatorCiphersuite__Initia
 fun libcrux_psq__handshake__ciphersuite__responder__ResponderCiphersuite__ResponderCiphersuite(
       bitstring, bitstring, bitstring, bitstring): bitstring [data].
 
-(* ---- CiphersuiteBase::name — MUST project, not be an opaque [data] fun ---- *)
+(* ---- CiphersuiteBase::name — must project, not be an opaque [data] fun ---- *)
 (* `CiphersuiteBase::name(&self) -> CiphersuiteName` returns the public ciphersuite
    identifier (an enum discriminant), i.e. `self.name` (field 0). The auto-declared
    stub in missingdecl.pvl is `fun …__name(bitstring): bitstring [data].`, i.e. an
-   INJECTIVE constructor — so ProVerif synthesises the projector `1-proj-…__name`
-   and the attacker INVERTS `name(cs)` back to the whole ciphersuite `cs`. The
-   INITIATOR puts `name(self.ciphersuite)` on the wire (write_message), and its
+   injective constructor — so ProVerif synthesises the projector `1-proj-…__name`
+   and the attacker inverts `name(cs)` back to the whole ciphersuite `cs`. The
+   initiator puts `name(self.ciphersuite)` on the wire (write_message), and its
    `InitiatorCiphersuite` embeds the secret `Auth::DH(DHKeyPair(sk_I,_))` /
    `Auth::Sig(SigningKeyPair(sk_I,_))` — so the public name field leaks the client's
    private key, spuriously breaking R2b (DH classical-soundness) and R2a (sig). The
-   real `name()` returns only the public enum label and is NOT invertible to the
+   `name()` returns only the public enum label and is not invertible to the
    struct. Model it faithfully as the field-0 projection (both ciphersuite structs
    store the CiphersuiteName first); fall through to identity if it is already a
    bare name. Strips the leak; the name still round-trips as a public constant. *)
@@ -398,7 +398,7 @@ letfun libcrux_psq__handshake__ciphersuite__traits__CiphersuiteBase__name(cs: bi
    making every registration handshake unreachable. It also dropped the
    `sig_auth.into()` (SigningKeyPair -> SignatureVerificationKey) conversion in
    the `Auth::Sig` arm. We override `Impl_2__from` (stripped from lib.clean by
-   check-pv.sh) to handle BOTH inputs and to perform the vk conversion, so the
+   check-pv.sh) to handle both inputs and to perform the vk conversion, so the
    initiator's `Authenticator` (built from its Auth) and the responder's (built
    from the wire AuthMessage) coincide for the same identity:
      DH : Auth::DH(kp)            and  AuthMessage::Dh(pk)        -> Authenticator::Dh(pk)
@@ -452,7 +452,7 @@ letfun libcrux_psq__session__derive_pk_binder(
 
 (* ---- Serialization carriers (transparent / injective) ------------------ *)
 (* The structured payloads are sealed/opened directly; the tls (de)serialization
-   is the identity in the term algebra (the term structure IS the wire form, so
+   is the identity in the term algebra (the term structure is the wire form, so
    distinct terms give distinct encodings — injective, no re-partition attack).
    `Impl_25__as_slice` / `cursor::new` / `tls_(de)serialize` therefore pass their
    argument through; the `pv_deserialize` bridge above already stripped the

--- a/libcrux-psq/proofs/proverif/psq_crypto.pvl
+++ b/libcrux-psq/proofs/proverif/psq_crypto.pvl
@@ -462,4 +462,4 @@ letfun tls_codec__quic_vec__Impl_25__as_slice(x: bitstring) = x.
 letfun std__io__cursor__Impl__new_kw(x: bitstring) = x.
 letfun tls_codec__Serialize__tls_serialize_detached(x: bitstring) = x.
 letfun tls_codec__Deserialize__tls_deserialize(x: bitstring) =
-      rust_primitives__hax__Tuple2__Tuple2(nat_lit(0), x).
+      rust_primitives__hax__Tuple2__Tuple2(nat_0, x).

--- a/libcrux-psq/src/aead.rs
+++ b/libcrux-psq/src/aead.rs
@@ -350,11 +350,15 @@ impl AEADKeyNonce {
     // ProVerif: AEAD open. The reduc in psq_crypto.pvl only fires for a genuine
     // (ciphertext, tag) pair under the same key+aad, so decryption fails (the
     // term has no value, blocking the branch) on any forgery — modelling AEAD
-    // integrity. Bypasses tls deserialization (the recovered payload is the
-    // structured plaintext directly).
+    // integrity. `pv_deserialize` then models the tls deserialization the real
+    // `decrypt_deserialize` performs: the borrowed `…Out` payload the peer
+    // serialized and the owned payload this side parses share one wire encoding,
+    // so the round-trip maps one to the other (identity for payloads read raw).
     #[cfg_attr(
         feature = "hax-pv",
-        hax_lib::proverif::replace_body("extern__aead_dec(self, ciphertext, tag, aad)")
+        hax_lib::proverif::replace_body(
+            "pv_deserialize(extern__aead_dec(self, ciphertext, tag, aad))"
+        )
     )]
     pub(crate) fn handshake_decrypt<T: Deserialize>(
         &mut self,

--- a/libcrux-psq/src/aead.rs
+++ b/libcrux-psq/src/aead.rs
@@ -93,6 +93,13 @@ impl AEADKeyNonce {
         Ok(new_key)
     }
 
+    // ProVerif: HKDF-SHA256 key derivation. `extern__kdf(ikm, info)` is the
+    // derived AEAD key+nonce (K_n); one-way in `ikm`. The AEAD choice
+    // (`aead_type`) is irrelevant to the symbolic abstraction.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("extern__kdf(ikm, info)")
+    )]
     pub(crate) fn new(
         ikm: &impl SerializeBytes,
         info: &impl SerializeBytes,
@@ -214,6 +221,18 @@ impl AEADKeyNonce {
         Ok((ciphertext, tag))
     }
 
+    // ProVerif: AEAD seal. Ciphertext and tag are produced from the key, the
+    // (structured) payload and the aad; both are needed to decrypt (see the
+    // reduc in psq_crypto.pvl). Bypasses tls serialization and the nonce
+    // bookkeeping — the single-use key already fixes the nonce.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body(
+            "rust_primitives__hax__Tuple2__Tuple2(\
+               extern__aead_ct(self, payload, aad), \
+               extern__aead_tag(self, payload, aad))"
+        )
+    )]
     pub(crate) fn handshake_encrypt<T: Serialize>(
         &mut self,
         payload: &T,
@@ -328,6 +347,15 @@ impl AEADKeyNonce {
         T::tls_deserialize_exact(&payload_serialized_buf).map_err(AEADError::Deserialize)
     }
 
+    // ProVerif: AEAD open. The reduc in psq_crypto.pvl only fires for a genuine
+    // (ciphertext, tag) pair under the same key+aad, so decryption fails (the
+    // term has no value, blocking the branch) on any forgery — modelling AEAD
+    // integrity. Bypasses tls deserialization (the recovered payload is the
+    // structured plaintext directly).
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("extern__aead_dec(self, ciphertext, tag, aad)")
+    )]
     pub(crate) fn handshake_decrypt<T: Deserialize>(
         &mut self,
         ciphertext: &[u8],

--- a/libcrux-psq/src/handshake/ciphersuite/initiator.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/initiator.rs
@@ -66,6 +66,21 @@ impl<'a> From<&'a (Ed25519SigningKey, Ed25519VerificationKey)> for SigningKeyPai
 }
 
 impl<'a> SigningKeyPair<'a> {
+    // ProVerif: EUF-CMA signing. `extern__sign(sk, msg)` is one-way; the matching
+    // `extern__sig_verify` reduc (psq_crypto.pvl) accepts it only under
+    // `vk_of(sk)`. We project the inner signing scalar from the SigningKeyPair so
+    // the verification key the peer recovers (`SignatureVerificationKey` carries
+    // `vk = vk_of(sk)`, set up by the role) binds to the same `sk`.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body(
+            "let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__Ed25519(sk, vk) = self in \
+               libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(extern__sign(sk, tx)) \
+             else let libcrux_psq__handshake__ciphersuite__initiator__SigningKeyPair__MlDsa65(sk, vk) = self in \
+               libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(extern__sign(sk, tx)) \
+             else bitstring_err()"
+        )
+    )]
     pub(crate) fn sign(
         &self,
         rng: &mut impl CryptoRng,

--- a/libcrux-psq/src/handshake/ciphersuite/types.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/types.rs
@@ -81,6 +81,27 @@ pub enum SignatureType {
 }
 
 impl SignatureVerificationKey {
+    // ProVerif: EUF-CMA signature verification, modelled as a PARTIAL destructor
+    // (`extern__sig_verify` in psq_crypto.pvl has a reduc only for a genuine
+    // `sign(sk, m)` under `vk_of(sk)`). The sole caller `verify_tx1` lowers
+    // `vk.verify(..)?` to `let wildcard = verify(..) in <continue> else
+    // bitstring_err()`, so a verification FAILURE (forgery: no matching reduc)
+    // correctly propagates to the else-branch and aborts the responder read —
+    // there is no `assert!`/`not_kw` here to swallow it (cf. the mandrake
+    // sig-verify soundness lesson). We unwrap the key/sig enums and check the
+    // inner terms; mismatched variants fail (== reject).
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body(
+            "let libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__Ed25519(vk) = self in \
+               (let libcrux_psq__handshake__ciphersuite__types__Signature__Ed25519(s) = signature in \
+                  extern__sig_verify(vk, tx1, s) else bitstring_err()) \
+             else let libcrux_psq__handshake__ciphersuite__types__SignatureVerificationKey__MlDsa65(vk) = self in \
+               (let libcrux_psq__handshake__ciphersuite__types__Signature__MlDsa65(s) = signature in \
+                  extern__sig_verify(vk, tx1, s) else bitstring_err()) \
+             else bitstring_err()"
+        )
+    )]
     pub(crate) fn verify(
         &self,
         tx1: &Transcript,

--- a/libcrux-psq/src/handshake/dhkem.rs
+++ b/libcrux-psq/src/handshake/dhkem.rs
@@ -67,6 +67,12 @@ impl AsRef<[u8]> for DHPrivateKey {
 
 impl DHSharedSecret {
     /// Derive a shared secret, DH-KEM style.
+    // ProVerif: X25519 DH. `extern__dh_shared(sk, pk)` with the commutativity
+    // equation in psq_crypto.pvl is the standard symbolic DH abstraction.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("extern__dh_shared(sk, pk)")
+    )]
     pub(crate) fn derive(sk: &DHPrivateKey, pk: &DHPublicKey) -> Result<DHSharedSecret, Error> {
         Ok(DHSharedSecret(
             libcrux_ecdh::derive(Algorithm::X25519, pk.0, &sk.0).map_err(|_| Error::CryptoError)?,
@@ -76,6 +82,12 @@ impl DHSharedSecret {
 
 impl DHPrivateKey {
     /// Creates a new KEM private key.
+    // ProVerif: a fresh DH scalar. `new dh_scalar` gives an independent secret
+    // per call (so distinct ephemerals never coincide), regardless of `rng`.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("(new dh_scalar: bitstring; dh_scalar)")
+    )]
     pub fn new(rng: &mut impl CryptoRng) -> Self {
         Self(
             libcrux_ecdh::generate_secret(libcrux_ecdh::Algorithm::X25519, rng)
@@ -84,6 +96,11 @@ impl DHPrivateKey {
     }
 
     /// Compute the KEM public key from the KEM private key.
+    // ProVerif: g^sk.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("extern__dh_pub(self)")
+    )]
     pub fn to_public(&self) -> DHPublicKey {
         DHPublicKey(
             secret_to_public(libcrux_ecdh::Algorithm::X25519, &self.0)

--- a/libcrux-psq/src/handshake/initiator/query.rs
+++ b/libcrux-psq/src/handshake/initiator/query.rs
@@ -111,6 +111,12 @@ impl<'a> QueryInitiator<'a> {
 }
 
 impl<'a> Channel<Error, HandshakeMessage> for QueryInitiator<'a> {
+    // ProVerif: the buffer-based wire encoding (`tls_serialize` into a caller
+    // `&mut [u8]`) is pure, security-irrelevant serialization that the &mut
+    // analysis rejects. The model drives the protocol via
+    // `write_message_external_encoding` (returns the `HandshakeMessage` term),
+    // so stub this body out for extraction.
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let (ciphertext, tag) = self.prepare_message_contents(payload)?;
 

--- a/libcrux-psq/src/handshake/initiator/query.rs
+++ b/libcrux-psq/src/handshake/initiator/query.rs
@@ -116,7 +116,7 @@ impl<'a> Channel<Error, HandshakeMessage> for QueryInitiator<'a> {
     // analysis rejects. The model drives the protocol via
     // `write_message_external_encoding` (returns the `HandshakeMessage` term),
     // so stub this body out for extraction.
-    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_0"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let (ciphertext, tag) = self.prepare_message_contents(payload)?;
 

--- a/libcrux-psq/src/handshake/initiator/registration.rs
+++ b/libcrux-psq/src/handshake/initiator/registration.rs
@@ -191,6 +191,18 @@ impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
                     aad: VLByteSlice(self.inner_aad),
                     pq_encapsulation: VLByteSlice(&pq_encapsulation_serialized),
                 });
+                // ProVerif: rebind the outer key to a clean owned local so the
+                // &mut-self `handshake_encrypt` receiver is a direct local. `state.k0`
+                // sits behind `&mut Box<InitialState>`, which the hax `&mut` analysis
+                // rejects as an arbitrary lhs (query mode encrypts via `self.k0`, a
+                // direct field of `&mut self`). `.clone()` is the identity in the
+                // symbolic model, so the K_0 key term is preserved.
+                #[cfg(feature = "hax-pv")]
+                let (outer_ciphertext, outer_tag) = {
+                    let mut k0 = state.k0.clone();
+                    k0.handshake_encrypt(&outer_payload, self.outer_aad)?
+                };
+                #[cfg(not(feature = "hax-pv"))]
                 let (outer_ciphertext, outer_tag) =
                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;
 
@@ -225,6 +237,13 @@ impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
                     aad: VLByteSlice(self.inner_aad),
                     pq_encapsulation: VLByteSlice(&pq_encapsulation_serialized),
                 });
+                // ProVerif: rebind to a clean local (see the DH arm above).
+                #[cfg(feature = "hax-pv")]
+                let (outer_ciphertext, outer_tag) = {
+                    let mut k0 = state.k0.clone();
+                    k0.handshake_encrypt(&outer_payload, self.outer_aad)?
+                };
+                #[cfg(not(feature = "hax-pv"))]
                 let (outer_ciphertext, outer_tag) =
                     state.k0.handshake_encrypt(&outer_payload, self.outer_aad)?;
                 (k1, outer_ciphertext, outer_tag)
@@ -235,6 +254,12 @@ impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
 }
 
 impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for RegistrationInitiator<'a, Rng> {
+    // ProVerif: the buffer-based wire encoding (`tls_serialize` into a caller
+    // `&mut [u8]`) is pure, security-irrelevant serialization that the &mut
+    // analysis rejects. The model drives the protocol via
+    // `write_message_external_encoding` (returns the `HandshakeMessage` term),
+    // so stub this body out for extraction (same as the query initiator).
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let mut old_state = self.write_state()?;
 

--- a/libcrux-psq/src/handshake/initiator/registration.rs
+++ b/libcrux-psq/src/handshake/initiator/registration.rs
@@ -259,7 +259,7 @@ impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for RegistrationInitia
     // analysis rejects. The model drives the protocol via
     // `write_message_external_encoding` (returns the `HandshakeMessage` term),
     // so stub this body out for extraction (same as the query initiator).
-    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_0"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let mut old_state = self.write_state()?;
 

--- a/libcrux-psq/src/handshake/responder.rs
+++ b/libcrux-psq/src/handshake/responder.rs
@@ -438,6 +438,10 @@ impl<'a, Rng: CryptoRng> Responder<'a, Rng> {
 }
 
 impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for Responder<'a, Rng> {
+    // ProVerif: buffer-based wire encoding is security-irrelevant serialization;
+    // the model uses `write_message_external_encoding` (returns the
+    // `HandshakeMessage` term). Stub the body out for extraction.
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let (responder_ephemeral_ecdh_pk, message_contents) =
             self.prepare_message_contents(payload)?;
@@ -511,6 +515,15 @@ impl<'a, Rng: CryptoRng> IntoSession for Responder<'a, Rng> {
             return Err(SessionError::IntoSession);
         };
 
+        // ProVerif: `core::mem::take(&mut state.initiator_authenticator)` mutates
+        // through a `&mut` field, which the engine's Arbitrary_lhs phase rejects
+        // (HAX0008). Read the value with `.clone()` instead under extraction —
+        // equivalent for the symbolic model (the post-take `None` is never used).
+        #[cfg(feature = "hax-pv")]
+        let Some(initiator_authenticator) = state.initiator_authenticator.clone() else {
+            return Err(SessionError::IntoSession);
+        };
+        #[cfg(not(feature = "hax-pv"))]
         let Some(initiator_authenticator) = take(&mut state.initiator_authenticator) else {
             return Err(SessionError::IntoSession);
         };

--- a/libcrux-psq/src/handshake/responder.rs
+++ b/libcrux-psq/src/handshake/responder.rs
@@ -441,7 +441,7 @@ impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for Responder<'a, Rng>
     // ProVerif: buffer-based wire encoding is security-irrelevant serialization;
     // the model uses `write_message_external_encoding` (returns the
     // `HandshakeMessage` term). Stub the body out for extraction.
-    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_lit(0)"))]
+    #[cfg_attr(feature = "hax-pv", hax_lib::proverif::replace_body("nat_0"))]
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let (responder_ephemeral_ecdh_pk, message_contents) =
             self.prepare_message_contents(payload)?;

--- a/libcrux-psq/src/handshake/transcript.rs
+++ b/libcrux-psq/src/handshake/transcript.rs
@@ -24,6 +24,16 @@ impl Transcript {
         Self::add_hash::<TX0_DOMAIN_SEP>(None, initial_input)
     }
 
+    // ProVerif: running transcript hash. `extern__hash` is one-way and
+    // injective in the term algebra; the chained previous transcript plus the
+    // (distinctly-typed) step input bind each step distinctly — the const
+    // domain separator can't be interpolated into the replace_body text and is
+    // redundant given the chaining. Avoids the stateful SHA-256 hasher
+    // (new/update/finish) the &mut analysis can't model.
+    #[cfg_attr(
+        feature = "hax-pv",
+        hax_lib::proverif::replace_body("extern__hash(old_transcript, input)")
+    )]
     pub(crate) fn add_hash<const DOMAIN_SEPARATOR: u8>(
         old_transcript: Option<&Transcript>,
         input: impl Serialize,


### PR DESCRIPTION
Extract and verify ProVerif models from the PSQ handshake code.

The models are extracted from `libcrux-psq` via the hax ProVerif backend and checked with ProVerif. `libcrux-psq/proofs/proverif/check-pv.sh` re-extracts, composes the symbolic crypto model (`psq_crypto.pvl`), and asserts every query verdict. Result: `CHECK PASSED` — query mode P1–P11, registration DH/sig msg1 + session, and post-quantum forward-secrecy/authenticity.

## Verifying locally (requires the unreleased hax ProVerif backend)

- **Engine + `cargo-hax` frontend** — build from `cryspen/hax` branch `proverif-rust-backend` (draft PR cryspen/hax#2068). Build `hax-rust-engine` (`cd rust-engine && cargo build --release`) and force it via `HAX_RUST_ENGINE_BINARY`; the `cargo-hax` frontend comes from the same branch.
- **`hax-lib` macros** (`pv_extern` / `replace_body` / `pv_*`, gated behind the `hax-pv` feature) — git-pinned in `libcrux-psq/Cargo.toml` to `cryspen/hax` rev `1a99a1948` (a `proverif-rust-backend` rev; the `pv_*` macro surface is compatible with the #2068 tip).
- **ProVerif 2.05**.

Run:

```
HAX_PROVERIF_DIR=<hax checkout @ proverif-rust-backend, release-built> \
  libcrux-psq/proofs/proverif/check-pv.sh
```

AI assisted.