### PR TITLE
feat(hpke): add DH-KEM(P-521) to the RustCrypto provider

### DIFF
--- a/crates/protocols/hpke/rust_crypto_provider/Cargo.toml
+++ b/crates/protocols/hpke/rust_crypto_provider/Cargo.toml
@@ -23,6 +23,7 @@ k256 = { version = "0.13", features = [
     "ecdh",
 ], default-features = false }
 p384 = { version = "0.13", default-features = false, features = ["arithmetic"] }
+p521 = { version = "0.13", default-features = false, features = ["arithmetic"] }
 x25519-dalek = { version = "2", features = ["static_secrets"] }
 chacha20poly1305 = { version = "0.10", default-features = false, features = [
     "alloc",

--- a/crates/protocols/hpke/rust_crypto_provider/src/lib.rs
+++ b/crates/protocols/hpke/rust_crypto_provider/src/lib.rs
@@ -31,6 +31,11 @@ use p384::{
     SecretKey as p384SecretKey,
 };
 
+use p521::{
+    elliptic_curve::ecdh::diffie_hellman as p521diffie_hellman, PublicKey as p521PublicKey,
+    SecretKey as p521SecretKey,
+};
+
 use x25519_dalek::{PublicKey as X25519PublicKey, StaticSecret as X25519StaticSecret};
 
 mod aead;
@@ -134,6 +139,15 @@ impl HpkeCrypto for HpkeRustCrypto {
                     .as_slice()
                     .into())
             }
+            KemAlgorithm::DhKemP521 => {
+                let sk = p521SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                let pk =
+                    p521PublicKey::from_sec1_bytes(pk).map_err(|_| Error::KemInvalidPublicKey)?;
+                Ok(p521diffie_hellman(sk.to_nonzero_scalar(), pk.as_affine())
+                    .raw_secret_bytes()
+                    .as_slice()
+                    .into())
+            }
             KemAlgorithm::DhKemK256 => {
                 let sk = k256SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
                 let pk =
@@ -197,6 +211,10 @@ impl HpkeCrypto for HpkeRustCrypto {
                 let sk = p384SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
                 Ok(sk.public_key().to_encoded_point(false).as_bytes().into())
             }
+            KemAlgorithm::DhKemP521 => {
+                let sk = p521SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
+                Ok(sk.public_key().to_encoded_point(false).as_bytes().into())
+            }
             KemAlgorithm::DhKemK256 => {
                 let sk = k256SecretKey::from_slice(sk).map_err(|_| Error::KemInvalidSecretKey)?;
                 Ok(sk.public_key().to_encoded_point(false).as_bytes().into())
@@ -231,6 +249,13 @@ impl HpkeCrypto for HpkeRustCrypto {
                 let sk = sk.to_bytes().as_slice().into();
                 Ok((pk, sk))
             }
+            KemAlgorithm::DhKemP521 => {
+                let rng = &mut prng.rng;
+                let sk = p521SecretKey::random(&mut RandShim(rng));
+                let pk = sk.public_key().to_encoded_point(false).as_bytes().into();
+                let sk = sk.to_bytes().as_slice().into();
+                Ok((pk, sk))
+            }
             KemAlgorithm::DhKemK256 => {
                 let rng = &mut prng.rng;
                 let sk = k256SecretKey::random(&mut RandShim(rng));
@@ -256,6 +281,9 @@ impl HpkeCrypto for HpkeRustCrypto {
                 .map_err(|_| Error::KemInvalidSecretKey)
                 .map(|_| sk.into()),
             KemAlgorithm::DhKemP384 => p384SecretKey::from_slice(sk)
+                .map_err(|_| Error::KemInvalidSecretKey)
+                .map(|_| sk.into()),
+            KemAlgorithm::DhKemP521 => p521SecretKey::from_slice(sk)
                 .map_err(|_| Error::KemInvalidSecretKey)
                 .map(|_| sk.into()),
             KemAlgorithm::DhKemK256 => k256SecretKey::from_slice(sk)
@@ -334,7 +362,8 @@ impl HpkeCrypto for HpkeRustCrypto {
             KemAlgorithm::DhKem25519
             | KemAlgorithm::DhKemP256
             | KemAlgorithm::DhKemK256
-            | KemAlgorithm::DhKemP384 => Ok(()),
+            | KemAlgorithm::DhKemP384
+            | KemAlgorithm::DhKemP521 => Ok(()),
             // XXX: These are broken and pre-releases. Disabling them until they are stable.
             #[cfg(feature = "experimental")]
             KemAlgorithm::XWingDraft06 | KemAlgorithm::MlKem768 | KemAlgorithm::MlKem1024 => Ok(()),

--- a/crates/protocols/hpke/tests/test_hpke.rs
+++ b/crates/protocols/hpke/tests/test_hpke.rs
@@ -1651,6 +1651,57 @@ generate_test_case!(
     HpkeRustCrypto
 );
 
+// P521 based test cases
+
+generate_test_case!(
+    base_dhkemp521_hkdfsha512_Aes256Gcm,
+    HpkeMode::Base,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::Aes256Gcm,
+    HpkeRustCrypto
+);
+generate_test_case!(
+    base_dhkemp521_hkdfsha512_Aes128Gcm,
+    HpkeMode::Base,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::Aes128Gcm,
+    HpkeRustCrypto
+);
+generate_test_case!(
+    base_dhkemp521_hkdfsha512_chacha20poly1305,
+    HpkeMode::Base,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::ChaCha20Poly1305,
+    HpkeRustCrypto
+);
+generate_test_case!(
+    psk_dhkemp521_hkdfsha512_Aes256Gcm,
+    HpkeMode::Psk,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::Aes256Gcm,
+    HpkeRustCrypto
+);
+generate_test_case!(
+    auth_dhkemp521_hkdfsha512_Aes256Gcm,
+    HpkeMode::Auth,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::Aes256Gcm,
+    HpkeRustCrypto
+);
+generate_test_case!(
+    authpsk_dhkemp521_hkdfsha512_Aes256Gcm,
+    HpkeMode::AuthPsk,
+    KemAlgorithm::DhKemP521,
+    KdfAlgorithm::HkdfSha512,
+    AeadAlgorithm::Aes256Gcm,
+    HpkeRustCrypto
+);
+
 // ML-KEM based test cases
 
 #[cfg(feature = "experimental")]

--- a/crates/protocols/hpke/tests/test_hpke_kat.rs
+++ b/crates/protocols/hpke/tests/test_hpke_kat.rs
@@ -326,6 +326,7 @@ fn kats_rust_crypto() {
         KemAlgorithm::DhKem25519,
         KemAlgorithm::DhKemP256,
         KemAlgorithm::DhKemP384,
+        KemAlgorithm::DhKemP521,
         KemAlgorithm::DhKemK256,
     ];
 


### PR DESCRIPTION
`KemAlgorithm::DhKemP521` is defined in `hpke-rs-crypto` with its RFC 9180 parameters (Nsk=66, Nsecret=64, KDF -> HKDF-SHA512) and `hpke-rs` already routes it through DHKEM, including the 0x01 rejection-sampling bitmask from RFC 9180 section 7.1.3. The sibling `hpke-rs-libcrux` provider has implemented it since 3fd9f5c9d. Only `hpke-rs-rust-crypto` was missing the arms, so the KEM could not be used with this backend at all: `dh`, `secret_to_public`, `kem_key_gen` and `dh_validate_sk` fell through to their catch-all error arms.

Adds the four arms mirroring the existing `DhKemP384` ones, plus `DhKemP521` in `supports_kem`, and `p521` alongside `p384` in the dependencies.

Test coverage mirrors what the libcrux provider already has: the six P-521 cases from `mod libcrux_p_curves` are duplicated against `HpkeRustCrypto` (base, psk, auth and authpsk; AES-256-GCM, AES-128-GCM and ChaCha20Poly1305). `DhKemP521` is also added to the expected KEM set in `kats_rust_crypto`, so the RFC 9180 P-521 known-answer vectors in `test_vectors.json` are now exercised against this backend rather than silently skipped.

`cargo test -p hpke-rs -p hpke-rs-rust-crypto`: 173 passed, 0 failed.