### PR TITLE
Make hax-lib a `target.'cfg(hax)'` dependency

### DIFF
--- a/.github/workflows/kmac-hax.yml
+++ b/.github/workflows/kmac-hax.yml
@@ -18,7 +18,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FSTAR_REV: v2026.03.24
-  HAX_LIB_VERSION: 0.3.7
+  HAX_LIB_VERSION: 0.4.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mldsa-hax.yml
+++ b/.github/workflows/mldsa-hax.yml
@@ -16,7 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FSTAR_REV: v2026.03.24
-  HAX_LIB_VERSION: 0.3.7
+  HAX_LIB_VERSION: 0.4.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mlkem-hax.yml
+++ b/.github/workflows/mlkem-hax.yml
@@ -16,7 +16,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FSTAR_REV: v2026.03.24
-  HAX_LIB_VERSION: 0.3.7
+  HAX_LIB_VERSION: 0.4.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/sha3-hax.yml
+++ b/.github/workflows/sha3-hax.yml
@@ -15,7 +15,7 @@ on:
 env:
   CARGO_TERM_COLOR: always
   FSTAR_REV: v2026.03.24
-  HAX_LIB_VERSION: 0.3.7
+  HAX_LIB_VERSION: 0.4.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.4.0-rc.1" }
+hax-lib = { version = "0.4.0" }
 libcrux-aead = { version = "=0.0.9", path = "crates/primitives/aead" }
 libcrux-aes = { version = "=0.0.9", path = "crates/algorithms/aes" }
 libcrux-blake2 = { version = "=0.0.8", path = "crates/algorithms/blake2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ readme = "Readme.md"
 allow-branch = ["main"]
 
 [workspace.dependencies]
-hax-lib = { version = "0.3.7" }
+hax-lib = { version = "0.4.0-rc.1" }
 libcrux-aead = { version = "=0.0.9", path = "crates/primitives/aead" }
 libcrux-aes = { version = "=0.0.9", path = "crates/algorithms/aes" }
 libcrux-blake2 = { version = "=0.0.8", path = "crates/algorithms/blake2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -218,9 +218,6 @@ psq = []
 [dependencies]
 getrandom = { version = "0.4", optional = true }
 
-# Proofs
-hax-lib.workspace = true
-
 # External Cryspen code.
 hpke-rs = { workspace = true, features = ["libcrux"] }
 
@@ -254,6 +251,9 @@ libcrux-psq.workspace = true
 
 # WASM API
 wasm-bindgen = { version = "0.2.87", optional = true }
+
+[target.'cfg(hax)'.dependencies]
+hax-lib.workspace = true
 
 [build-dependencies]
 libcrux-platform = { version = "=0.0.3", path = "crates/sys/platform" }

--- a/crates/algorithms/kmac/Cargo.toml
+++ b/crates/algorithms/kmac/Cargo.toml
@@ -14,8 +14,13 @@ repository.workspace = true
 path = "src/kmac.rs"
 
 [dependencies]
-hax-lib.workspace = true
 libcrux-sha3.workspace = true
+
+[target.'cfg(hax)'.dependencies]
+hax-lib.workspace = true
 
 [dev-dependencies]
 libcrux-kats = { workspace = true, features = ["kmac"] }
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(hax)'] }

--- a/crates/algorithms/kmac/src/internals/kmac.rs
+++ b/crates/algorithms/kmac/src/internals/kmac.rs
@@ -2,7 +2,7 @@ use libcrux_sha3::portable::incremental::{left_encode, left_encode_byte, right_e
 
 const KMAC_LABEL: &[u8; 4] = b"KMAC";
 
-#[hax_lib::requires(RATE == 136 || RATE == 168)]
+#[cfg_attr(hax, hax_lib::requires(RATE == 136 || RATE == 168))]
 pub fn compute_kmac<'a, const RATE: usize, CShakeState: CShake<RATE>>(
     tag: &'a mut [u8],
     tag_length: usize,

--- a/crates/algorithms/kmac/src/kmac.rs
+++ b/crates/algorithms/kmac/src/kmac.rs
@@ -14,7 +14,7 @@ use libcrux_sha3::portable::incremental::{CShake128, CShake256};
 ///
 /// C.f. [NIST SP 800-185](https://csrc.nist.gov/pubs/sp/800/185/final),
 /// section 4.
-#[hax_lib::requires(key.len() >= 16)]
+#[cfg_attr(hax, hax_lib::requires(key.len() >= 16))]
 pub fn kmac_128<'a>(tag: &'a mut [u8], key: &[u8], data: &[u8], customization: &[u8]) -> &'a [u8] {
     // Assert that key is long enough, i.e. at least 128 bits
     assert!(key.len() >= 16);
@@ -26,7 +26,7 @@ pub fn kmac_128<'a>(tag: &'a mut [u8], key: &[u8], data: &[u8], customization: &
 ///
 /// C.f. [NIST SP 800-185](https://csrc.nist.gov/pubs/sp/800/185/final),
 /// section 4.
-#[hax_lib::requires(key.len() >= 32)]
+#[cfg_attr(hax, hax_lib::requires(key.len() >= 32))]
 pub fn kmac_256<'a>(tag: &'a mut [u8], key: &[u8], data: &[u8], customization: &[u8]) -> &'a [u8] {
     // Assert that key is long enough, i.e. at least 256 bits
     assert!(key.len() >= 32);

--- a/crates/algorithms/sha3/Cargo.toml
+++ b/crates/algorithms/sha3/Cargo.toml
@@ -17,6 +17,8 @@ bench = false # so libtest doesn't eat the arguments to criterion
 libcrux-platform = { version = "0.0.3", path = "../../sys/platform" }
 libcrux-intrinsics.workspace = true
 libcrux-traits.workspace = true
+
+[target.'cfg(hax)'.dependencies]
 hax-lib.workspace = true
 
 [features]

--- a/crates/algorithms/sha3/src/generic_keccak.rs
+++ b/crates/algorithms/sha3/src/generic_keccak.rs
@@ -3,13 +3,12 @@
 
 use core::ops::Index;
 
-use crate::traits::*;
+#[cfg(hax)]
+use hax_lib::{constructors::from_bool, int::ToInt};
 
 #[cfg(hax)]
 use crate::proof_utils::{slices_same_len, valid_rate};
-
-#[cfg(hax)]
-use hax_lib::{constructors::from_bool, int::ToInt};
+use crate::traits::*;
 
 /// A generic Xof API.
 pub(crate) mod xof;
@@ -37,7 +36,7 @@ pub(crate) struct KeccakState<const N: usize, T: KeccakItem<N>> {
     pub(crate) st: [T; 25],
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     /// Create a new Shake128 x4 state.
     #[inline(always)]
@@ -48,7 +47,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     }
 
     /// Set element `[i, j] = v`.
-    #[hax_lib::requires(i < 5 && j < 5)]
+    #[cfg_attr(hax, hax_lib::requires(i < 5 && j < 5))]
     fn set(&mut self, i: usize, j: usize, v: T) {
         set_ij(&mut self.st, i, j, v);
     }
@@ -231,7 +230,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(i < ROUNDCONSTANTS.len())]
+    #[cfg_attr(hax, hax_lib::requires(i < ROUNDCONSTANTS.len()))]
     fn iota(&mut self, i: usize) {
         self.set(0, 0, T::xor_constant(self[(0, 0)], ROUNDCONSTANTS[i]));
     }
@@ -248,7 +247,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
       from_bool(
         N != 0 &&
         valid_rate(RATE) &&
@@ -256,7 +255,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
       ).and(
         slices_same_len(input)
       )
-    )]
+    ))]
     fn absorb_block<const RATE: usize>(&mut self, input: &[&[u8]; N], start: usize)
     where
         Self: Absorb<N>,
@@ -269,7 +268,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
       from_bool(
         N != 0 &&
         valid_rate(RATE) &&
@@ -278,7 +277,7 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
       ).and(
         slices_same_len(input)
       )
-    )]
+    ))]
     pub(crate) fn absorb_final<const RATE: usize, const DELIM: u8>(
         &mut self,
         input: &[&[u8]; N],
@@ -298,12 +297,12 @@ impl<const N: usize, T: KeccakItem<N>> KeccakState<N, T> {
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<const N: usize, T: KeccakItem<N>> Index<(usize, usize)> for KeccakState<N, T> {
     type Output = T;
 
     /// Get element `[i, j]`.
-    #[hax_lib::requires(index.0 < 5 && index.1 < 5)]
+    #[cfg_attr(hax, hax_lib::requires(index.0 < 5 && index.1 < 5))]
     fn index(&self, index: (usize, usize)) -> &Self::Output {
         get_ij(&self.st, index.0, index.1)
     }
@@ -312,9 +311,9 @@ impl<const N: usize, T: KeccakItem<N>> Index<(usize, usize)> for KeccakState<N, 
 /// Cross-spec tests: compare each permutation step against the hacspec spec.
 #[cfg(test)]
 mod cross_spec_tests {
+    use hacspec_sha3::{keccak_f as spec_kf, sponge as spec_sponge};
+
     use super::*;
-    use hacspec_sha3::keccak_f as spec_kf;
-    use hacspec_sha3::sponge as spec_sponge;
 
     fn wrap(st: [u64; 25]) -> KeccakState<1, u64> {
         KeccakState { st }
@@ -502,9 +501,10 @@ mod cross_spec_tests {
 /// property that the F* generalization proof is built on.
 #[cfg(all(test, feature = "simd128"))]
 mod neon_to_spec_tests {
-    use super::*;
     use hacspec_sha3::keccak_f as spec_kf;
     use libcrux_intrinsics::arm64::*;
+
+    use super::*;
 
     /// Extract lane `l` (0 or 1) from a KeccakState<2, uint64x2_t> → [u64; 25]
     fn extract_lane(state: &KeccakState<2, _uint64x2_t>, lane: usize) -> [u64; 25] {

--- a/crates/algorithms/sha3/src/generic_keccak/portable.rs
+++ b/crates/algorithms/sha3/src/generic_keccak/portable.rs
@@ -1,37 +1,36 @@
 use super::*;
-
 #[cfg(hax)]
 use crate::proof_utils::{lemma_mul_succ_le, valid_rate};
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl KeccakState<1, u64> {
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         start.to_int() + RATE.to_int() <= out.len().to_int()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     pub(crate) fn squeeze_next_block<const RATE: usize>(&mut self, out: &mut [u8], start: usize) {
         self.keccakf1600();
         self.squeeze::<RATE>(out, start, RATE);
     }
 
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         RATE <= out.len()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     pub(crate) fn squeeze_first_block<const RATE: usize>(&self, out: &mut [u8]) {
         self.squeeze::<RATE>(out, 0, RATE);
     }
 
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         3 * RATE <= out.len()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     pub(crate) fn squeeze_first_three_blocks<const RATE: usize>(&mut self, out: &mut [u8]) {
         self.squeeze::<RATE>(out, 0, RATE);
 
@@ -43,11 +42,11 @@ impl KeccakState<1, u64> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         5 * RATE <= out.len()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     pub(crate) fn squeeze_first_five_blocks<const RATE: usize>(&mut self, out: &mut [u8]) {
         self.squeeze::<RATE>(out, 0, RATE);
 
@@ -65,9 +64,9 @@ impl KeccakState<1, u64> {
     }
 }
 
-#[hax_lib::requires(valid_rate(RATE))]
-#[hax_lib::ensures(|_| future(output).len() == output.len())]
-#[hax_lib::fstar::options("--split_queries always --z3rlimit 300")]
+#[cfg_attr(hax, hax_lib::requires(valid_rate(RATE)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(output).len() == output.len()))]
+#[cfg_attr(hax, hax_lib::fstar::options("--split_queries always --z3rlimit 300"))]
 #[inline]
 pub(crate) fn keccak1<const RATE: usize, const DELIM: u8>(input: &[u8], output: &mut [u8]) {
     // Initialize Keccak state
@@ -94,6 +93,7 @@ pub(crate) fn keccak1<const RATE: usize, const DELIM: u8>(input: &[u8], output: 
     } else {
         s.squeeze::<RATE>(output, 0, RATE);
         for i in 1..output_blocks {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_: usize| output.len() == output_len);
             #[cfg(hax)]
             lemma_mul_succ_le(i, output_blocks, RATE);

--- a/crates/algorithms/sha3/src/generic_keccak/xof.rs
+++ b/crates/algorithms/sha3/src/generic_keccak/xof.rs
@@ -1,20 +1,22 @@
 #[cfg(hax)]
 use hax_lib::int::*;
 
+#[cfg(hax)]
+use crate::proof_utils::valid_rate;
 use crate::{
     generic_keccak::KeccakState,
     traits::{Absorb, KeccakItem, Squeeze},
 };
 
-#[cfg(hax)]
-use crate::proof_utils::valid_rate;
-
 // TODO: Should not be needed. Use hax_lib::fstar::options("") below.
 // Known bug: https://github.com/cryspen/hax/issues/1698
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 #push-options "--split_queries always --z3rlimit 300"
 "#
+    )
 )]
 
 /// The internal keccak state that can also buffer inputs to absorb.
@@ -60,8 +62,10 @@ pub(crate) struct KeccakXofState<
 /// type `(x: usize{x <. v_N}) -> t_Slice u8`, not the bare `usize -> t_Slice u8`
 /// that `t_FnOnce` resolves against), so it must be given explicitly.
 #[inline(always)]
-#[hax_lib::fstar::replace(
-    "let buf_to_slices
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        "let buf_to_slices
       (v_PARALLEL_LANES v_RATE: usize)
       (buf: t_Array (t_Array u8 v_RATE) v_PARALLEL_LANES)
     : t_Array (t_Slice u8) v_PARALLEL_LANES =
@@ -70,6 +74,7 @@ pub(crate) struct KeccakXofState<
     #(usize -> t_Slice u8)
     (fun i -> Core_models.Array.impl_23__as_slice #u8 v_RATE (buf.[ i ]))
 "
+    )
 )]
 fn buf_to_slices<const PARALLEL_LANES: usize, const RATE: usize>(
     buf: &[[u8; RATE]; PARALLEL_LANES],
@@ -77,8 +82,8 @@ fn buf_to_slices<const PARALLEL_LANES: usize, const RATE: usize>(
     core::array::from_fn(|i| buf[i].as_slice())
 }
 
-#[hax_lib::attributes]
-#[hax_lib::fstar::options("--split_queries always --z3rlimit 300")] // TODO: Has no effect. See above.
+#[cfg_attr(hax, hax_lib::attributes)]
+#[cfg_attr(hax, hax_lib::fstar::options("--split_queries always --z3rlimit 300"))] // TODO: Has no effect. See above.
 impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_LANES>>
     KeccakXofState<PARALLEL_LANES, RATE, STATE>
 {
@@ -88,14 +93,14 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
     }
 
     /// Generate a new keccak xof state.
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         PARALLEL_LANES == 1 &&
         valid_rate(RATE)
-    )]
-    #[hax_lib::ensures(|result|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         result.state_inv() &&
         result.squeeze_pos == RATE
-    )]
+    ))]
     pub(crate) fn new() -> Self {
         Self {
             inner: KeccakState::new(),
@@ -126,11 +131,11 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
     /// If `consumed > 0` is returned, `self.buf` contains a full block to be
     /// loaded.
     // Note: consciously not inlining this function to avoid using too much stack
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         PARALLEL_LANES == 1 &&
         self.state_inv()
-    )]
-    #[hax_lib::ensures(|consumed|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|consumed|
         future(self).state_inv() &&
         if consumed == 0 {
             future(self).buf_len == self.buf_len && (
@@ -142,7 +147,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
             future(self).buf_len == RATE &&
             consumed.to_int() == RATE.to_int() - self.buf_len.to_int()
         }
-    )]
+    ))]
     pub(crate) fn fill_buffer(&mut self, inputs: &[&[u8]; PARALLEL_LANES]) -> usize {
         let input_len = inputs[0].len();
 
@@ -159,6 +164,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
 
             #[allow(clippy::needless_range_loop)]
             for i in 0..PARALLEL_LANES {
+                #[cfg(hax)]
                 hax_lib::loop_invariant!(|_: usize| {
                     self.buf_len == self_buf_len && self.squeeze_pos == self_squeeze_pos
                 });
@@ -174,14 +180,14 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
     }
 
     // Note: consciously not inlining this function to avoid using too much stack
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         PARALLEL_LANES == 1 &&
         self.state_inv()
-    )]
-    #[hax_lib::ensures(|remainder|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|remainder|
         future(self).state_inv() &&
         future(self).buf_len.to_int() + remainder.to_int() <= RATE.to_int()
-    )]
+    ))]
     pub(crate) fn absorb_full(&mut self, inputs: &[&[u8]; PARALLEL_LANES]) -> usize
     where
         KeccakState<PARALLEL_LANES, STATE>: Absorb<PARALLEL_LANES>,
@@ -225,6 +231,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
         };
 
         for i in 0..num_blocks {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(
                 |_: usize| self.buf_len == self_buf_len && self.squeeze_pos == self_squeeze_pos
             );
@@ -253,11 +260,11 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
     ///
     /// This works best with relatively small `inputs`.
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         PARALLEL_LANES == 1 &&
         self.state_inv()
-    )]
-    #[hax_lib::ensures(|_| future(self).state_inv())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state_inv()))]
     pub(crate) fn absorb(&mut self, inputs: &[&[u8]; PARALLEL_LANES])
     where
         KeccakState<PARALLEL_LANES, STATE>: Absorb<PARALLEL_LANES>,
@@ -284,6 +291,7 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
 
             #[allow(clippy::needless_range_loop)]
             for i in 0..PARALLEL_LANES {
+                #[cfg(hax)]
                 hax_lib::loop_invariant!(
                     |_: usize| self.buf_len == self_buf_len && self.squeeze_pos == self_squeeze_pos
                 );
@@ -301,11 +309,11 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
     /// The `inputs` block may be empty. Everything in the `inputs` block beyond
     /// `RATE` bytes is ignored.
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         PARALLEL_LANES == 1 &&
         self.state_inv()
-    )]
-    #[hax_lib::ensures(|_| future(self).state_inv())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state_inv()))]
     pub(crate) fn absorb_final<const DELIMITER: u8>(&mut self, inputs: &[&[u8]; PARALLEL_LANES])
     where
         KeccakState<PARALLEL_LANES, STATE>: Absorb<PARALLEL_LANES>,
@@ -323,19 +331,19 @@ impl<const PARALLEL_LANES: usize, const RATE: usize, STATE: KeccakItem<PARALLEL_
 /// Squeeze we only implement for N = 1 right now.
 /// This is because it's not needed for N > 1 right now, but also because hax
 /// can't handle the required mutability for it.
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<const RATE: usize, STATE: KeccakItem<1>> KeccakXofState<1, RATE, STATE> {
     /// Squeeze output bytes into `out`.
     ///
     /// Supports arbitrary-sized requests across multiple calls.
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         self.state_inv()
-    )]
-    #[hax_lib::ensures(|_|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_|
         future(self).state_inv() &&
         future(out).len() == out.len()
-    )]
+    ))]
     pub(crate) fn squeeze(&mut self, out: &mut [u8])
     where
         KeccakState<1, STATE>: Squeeze<STATE>,
@@ -404,6 +412,7 @@ impl<const RATE: usize, STATE: KeccakItem<1>> KeccakXofState<1, RATE, STATE> {
 
             // Apply f then extract for each subsequent full block.
             for i in 1..blocks {
+                #[cfg(hax)]
                 hax_lib::loop_invariant!(|_: usize| out.len() == out_len
                     && self_buf_len == self.buf_len
                     && self_squeeze_pos == self.squeeze_pos);

--- a/crates/algorithms/sha3/src/lib.rs
+++ b/crates/algorithms/sha3/src/lib.rs
@@ -12,11 +12,10 @@ mod generic_keccak;
 
 #[cfg(not(any(hax, eurydice)))]
 mod impl_digest_trait;
-#[cfg(not(any(hax, eurydice)))]
-pub use impl_digest_trait::*;
-
 #[cfg(hax)]
 use hax_lib::int::*;
+#[cfg(not(any(hax, eurydice)))]
+pub use impl_digest_trait::*;
 
 mod traits;
 
@@ -87,11 +86,11 @@ pub const fn digest_size(mode: Algorithm) -> usize {
 }
 
 /// SHA3
-#[hax_lib::fstar::options("--split_queries always")]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::options("--split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(
     payload.len().to_int() <= u32::MAX.to_int() &&
     digest_size(algorithm) == LEN
-)]
+))]
 pub fn hash<const LEN: usize>(algorithm: Algorithm, payload: &[u8]) -> [u8; LEN] {
     debug_assert!(payload.len() <= u32::MAX as usize);
     debug_assert_eq!(digest_size(algorithm), LEN);
@@ -111,9 +110,9 @@ pub use hash as sha3;
 
 /// SHA3 224
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     data.len().to_int() <= u32::MAX.to_int()
-)]
+))]
 pub fn sha224(data: &[u8]) -> [u8; SHA3_224_DIGEST_SIZE] {
     let mut out = [0u8; SHA3_224_DIGEST_SIZE];
     sha224_ema(&mut out, data);
@@ -125,10 +124,10 @@ pub fn sha224(data: &[u8]) -> [u8; SHA3_224_DIGEST_SIZE] {
 /// Preconditions:
 /// - `digest.len() == 28`
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     payload.len().to_int() <= u32::MAX.to_int() &&
     digest.len().to_int() == int!(28)
-)]
+))]
 pub fn sha224_ema(digest: &mut [u8], payload: &[u8]) {
     debug_assert!(payload.len() <= u32::MAX as usize);
     debug_assert!(digest.len() == 28);
@@ -138,9 +137,9 @@ pub fn sha224_ema(digest: &mut [u8], payload: &[u8]) {
 
 /// SHA3 256
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     data.len().to_int() <= u32::MAX.to_int()
-)]
+))]
 pub fn sha256(data: &[u8]) -> [u8; SHA3_256_DIGEST_SIZE] {
     let mut out = [0u8; SHA3_256_DIGEST_SIZE];
     sha256_ema(&mut out, data);
@@ -149,10 +148,10 @@ pub fn sha256(data: &[u8]) -> [u8; SHA3_256_DIGEST_SIZE] {
 
 /// SHA3 256
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     payload.len().to_int() <= u32::MAX.to_int() &&
     digest.len().to_int() == int!(32)
-)]
+))]
 pub fn sha256_ema(digest: &mut [u8], payload: &[u8]) {
     debug_assert!(payload.len() <= u32::MAX as usize);
     debug_assert!(digest.len() == 32);
@@ -162,9 +161,9 @@ pub fn sha256_ema(digest: &mut [u8], payload: &[u8]) {
 
 /// SHA3 384
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     data.len().to_int() <= u32::MAX.to_int()
-)]
+))]
 pub fn sha384(data: &[u8]) -> [u8; SHA3_384_DIGEST_SIZE] {
     let mut out = [0u8; SHA3_384_DIGEST_SIZE];
     sha384_ema(&mut out, data);
@@ -173,10 +172,10 @@ pub fn sha384(data: &[u8]) -> [u8; SHA3_384_DIGEST_SIZE] {
 
 /// SHA3 384
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     payload.len().to_int() <= u32::MAX.to_int() &&
     digest.len().to_int() == int!(48)
-)]
+))]
 pub fn sha384_ema(digest: &mut [u8], payload: &[u8]) {
     debug_assert!(payload.len() <= u32::MAX as usize);
     debug_assert!(digest.len() == 48);
@@ -186,9 +185,9 @@ pub fn sha384_ema(digest: &mut [u8], payload: &[u8]) {
 
 /// SHA3 512
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     data.len().to_int() <= u32::MAX.to_int()
-)]
+))]
 pub fn sha512(data: &[u8]) -> [u8; SHA3_512_DIGEST_SIZE] {
     let mut out = [0u8; SHA3_512_DIGEST_SIZE];
     sha512_ema(&mut out, data);
@@ -197,10 +196,10 @@ pub fn sha512(data: &[u8]) -> [u8; SHA3_512_DIGEST_SIZE] {
 
 /// SHA3 512
 #[cfg_attr(not(eurydice), inline(always))]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     payload.len().to_int() <= u32::MAX.to_int() &&
     digest.len().to_int() == int!(64)
-)]
+))]
 pub fn sha512_ema(digest: &mut [u8], payload: &[u8]) {
     debug_assert!(payload.len() <= u32::MAX as usize);
     debug_assert!(digest.len() == 64);

--- a/crates/algorithms/sha3/src/portable.rs
+++ b/crates/algorithms/sha3/src/portable.rs
@@ -1,5 +1,4 @@
 use generic_keccak::KeccakState as GenericState;
-use hax_lib;
 #[cfg(hax)]
 use hax_lib::int::*;
 

--- a/crates/algorithms/sha3/src/portable/incremental.rs
+++ b/crates/algorithms/sha3/src/portable/incremental.rs
@@ -26,20 +26,20 @@ mod private {
     /// for every `RATE`, so the generic `CShake` impl can unfold it, while
     /// `kmac` (generic over `CShake`) sees it abstractly. No runtime meaning.
     #[cfg(not(eurydice))]
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     pub trait CShakeInv {
         #[cfg(hax)]
-        #[hax_lib::requires(true)]
-        #[hax_lib::ensures(|_| true)]
+        #[cfg_attr(hax, hax_lib::requires(true))]
+        #[cfg_attr(hax, hax_lib::ensures(|_| true))]
         fn cshake_inv(&self) -> bool;
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     #[cfg(not(eurydice))]
     impl<const RATE: usize> CShakeInv for super::CShakeIncremental<RATE> {
         #[cfg(hax)]
-        #[hax_lib::requires(true)]
-        #[hax_lib::ensures(|_| true)]
+        #[cfg_attr(hax, hax_lib::requires(true))]
+        #[cfg_attr(hax, hax_lib::ensures(|_| true))]
         fn cshake_inv(&self) -> bool {
             self.state.state_inv()
         }
@@ -56,29 +56,29 @@ pub struct Shake256Xof {
     state: KeccakXofState<1, 136, u64>,
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 /// A trait for portable, incremental CSHAKE implementations
 // XXX: The names here have the `_cshake` suffix to work around an F* extraction name clash bug.
 #[cfg(not(eurydice))]
 pub trait CShake<const RATE: usize>: private::Sealed + private::CShakeInv {
     /// Create new absorb state
-    #[requires(RATE == 136 || RATE == 168)]
-    #[hax_lib::ensures(|result| result.cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(RATE == 136 || RATE == 168))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.cshake_inv()))]
     fn new_cshake(name: &[u8], customization: &[u8]) -> Self;
 
     /// Absorb input
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn absorb_cshake(&mut self, input: &[u8]);
 
     /// Absorb final input (may be empty)
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn absorb_final_cshake(&mut self, input: &[u8]);
 
     /// Squeeze output bytes
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn squeeze_cshake(&mut self, out: &mut [u8]);
 }
 
@@ -97,45 +97,45 @@ pub trait Xof<const RATE: usize>: private::Sealed {
     fn squeeze(&mut self, out: &mut [u8]);
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Xof<168> for Shake128Xof {
-    #[hax_lib::ensures(|result|result.state.state_inv())]
+    #[cfg_attr(hax, hax_lib::ensures(|result|result.state.state_inv()))]
     fn new() -> Self {
         Self {
             state: KeccakXofState::<1, 168, u64>::new(),
         }
     }
 
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb(&mut self, input: &[u8]) {
         self.state.absorb(&[input]);
     }
 
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb_final(&mut self, input: &[u8]) {
         self.state.absorb_final::<0x1fu8>(&[input]);
     }
 
     /// Shake128 squeeze
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         self.state.state_inv()
-    )]
-    #[hax_lib::ensures(|_|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_|
         future(self).state.state_inv() &&
         future(out).len() == out.len()
-    )]
+    ))]
     fn squeeze(&mut self, out: &mut [u8]) {
         self.state.squeeze(out);
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 #[cfg(not(eurydice))]
 impl Xof<168> for CShake128 {
     /// CShake128 new state
-    #[hax_lib::ensures(|result| result.state.state_inv())]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.state.state_inv()))]
     fn new() -> Self {
         Self {
             state: KeccakXofState::<1, 168, u64>::new(),
@@ -143,35 +143,35 @@ impl Xof<168> for CShake128 {
     }
 
     /// CShake128 absorb
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb(&mut self, input: &[u8]) {
         self.state.absorb(&[input]);
     }
 
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb_final(&mut self, input: &[u8]) {
         self.state.absorb_final::<0x4u8>(&[input]);
     }
 
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         self.state.state_inv()
-    )]
-    #[hax_lib::ensures(|_|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_|
         self.state.state_inv() &&
         future(out).len() == out.len()
-    )]
+    ))]
     fn squeeze(&mut self, out: &mut [u8]) {
         self.state.squeeze(out);
     }
 }
 
 /// Shake256 XOF in absorb state
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Xof<136> for Shake256Xof {
     /// Shake256 new state
-    #[hax_lib::ensures(|result| result.state.state_inv())]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.state.state_inv()))]
     fn new() -> Self {
         Self {
             state: KeccakXofState::<1, 136, u64>::new(),
@@ -179,37 +179,37 @@ impl Xof<136> for Shake256Xof {
     }
 
     /// Shake256 absorb
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb(&mut self, input: &[u8]) {
         self.state.absorb(&[input]);
     }
 
     /// Shake256 absorb final
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb_final(&mut self, input: &[u8]) {
         self.state.absorb_final::<0x1fu8>(&[input]);
     }
 
     /// Shake256 squeeze
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         self.state.state_inv()
-    )]
-    #[hax_lib::ensures(|_|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_|
         future(self).state.state_inv() &&
         future(out).len() == out.len()
-    )]
+    ))]
     fn squeeze(&mut self, out: &mut [u8]) {
         self.state.squeeze(out);
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 #[cfg(not(eurydice))]
 impl Xof<136> for CShake256 {
     /// CShake256 new state
-    #[hax_lib::ensures(|result| result.state.state_inv())]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.state.state_inv()))]
     fn new() -> Self {
         Self {
             state: KeccakXofState::<1, 136, u64>::new(),
@@ -217,25 +217,25 @@ impl Xof<136> for CShake256 {
     }
 
     /// CShake256 absorb
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb(&mut self, input: &[u8]) {
         self.state.absorb(&[input]);
     }
 
-    #[hax_lib::requires(self.state.state_inv())]
-    #[hax_lib::ensures(|_| future(self).state.state_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.state.state_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).state.state_inv()))]
     fn absorb_final(&mut self, input: &[u8]) {
         self.state.absorb_final::<0x4u8>(&[input]);
     }
 
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         self.state.state_inv()
-    )]
-    #[hax_lib::ensures(|_|
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_|
         self.state.state_inv() &&
         future(out).len() == out.len()
-    )]
+    ))]
     fn squeeze(&mut self, out: &mut [u8]) {
         self.state.squeeze(out);
     }
@@ -251,9 +251,9 @@ pub fn shake128_init() -> KeccakState {
 
 /// Absorb
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         data0.len().to_int() < hax_lib::int!(168)
-    )]
+))]
 pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8]) {
     s.state
         .absorb_final::<168, 0x1fu8>(&[data0], 0, data0.len());
@@ -261,30 +261,30 @@ pub fn shake128_absorb_final(s: &mut KeccakState, data0: &[u8]) {
 
 /// Squeeze three blocks
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         out0.len().to_int() >= hax_lib::int!(504) // 3 * 168 = 504
-    )]
-#[hax_lib::ensures(|_| future(out0).len() == out0.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out0).len() == out0.len()))]
 pub fn shake128_squeeze_first_three_blocks(s: &mut KeccakState, out0: &mut [u8]) {
     s.state.squeeze_first_three_blocks::<168>(out0);
 }
 
 /// Squeeze five blocks
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         out0.len().to_int() >= hax_lib::int!(840) // 5 * 168 = 840
-    )]
-#[hax_lib::ensures(|_| future(out0).len() == out0.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out0).len() == out0.len()))]
 pub fn shake128_squeeze_first_five_blocks(s: &mut KeccakState, out0: &mut [u8]) {
     s.state.squeeze_first_five_blocks::<168>(out0);
 }
 
 /// Squeeze another block
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         out0.len().to_int() >= hax_lib::int!(168)
-    )]
-#[hax_lib::ensures(|_| future(out0).len() == out0.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out0).len() == out0.len()))]
 pub fn shake128_squeeze_next_block(s: &mut KeccakState, out0: &mut [u8]) {
     s.state.squeeze_next_block::<168>(out0, 0)
 }
@@ -299,41 +299,41 @@ pub fn shake256_init() -> KeccakState {
 
 /// Absorb some data for SHAKE-256 for the last time
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         data.len().to_int() < hax_lib::int!(136)
-    )]
+))]
 pub fn shake256_absorb_final(s: &mut KeccakState, data: &[u8]) {
     s.state.absorb_final::<136, 0x1fu8>(&[data], 0, data.len());
 }
 
 /// Squeeze the first SHAKE-256 block
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         out.len().to_int() >= hax_lib::int!(136)
-    )]
-#[hax_lib::ensures(|_| future(out).len() == out.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
 pub fn shake256_squeeze_first_block(s: &mut KeccakState, out: &mut [u8]) {
     s.state.squeeze_first_block::<136>(out);
 }
 
 /// Squeeze the next SHAKE-256 block
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
         out.len().to_int() >= hax_lib::int!(136)
-    )]
-#[hax_lib::ensures(|_| future(out).len() == out.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
 pub fn shake256_squeeze_next_block(s: &mut KeccakState, out: &mut [u8]) {
     s.state.squeeze_next_block::<136>(out, 0);
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 #[cfg(not(eurydice))]
 impl<const RATE: usize> CShake<RATE> for CShakeIncremental<RATE>
 where
     CShakeIncremental<RATE>: private::Sealed,
 {
-    #[requires(RATE == 136 || RATE == 168)]
-    #[hax_lib::ensures(|result| result.cshake_inv())]
+    #[cfg_attr(hax, requires(RATE == 136 || RATE == 168))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.cshake_inv()))]
     fn new_cshake(name: &[u8], customization: &[u8]) -> Self {
         let mut state = KeccakXofState::<1, RATE, u64>::new();
 
@@ -373,20 +373,20 @@ where
         Self { state }
     }
 
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn absorb_cshake(&mut self, input: &[u8]) {
         self.state.absorb(&[input]);
     }
 
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn absorb_final_cshake(&mut self, input: &[u8]) {
         self.state.absorb_final::<0x4u8>(&[input]);
     }
 
-    #[hax_lib::requires(self.cshake_inv())]
-    #[hax_lib::ensures(|_| future(self).cshake_inv())]
+    #[cfg_attr(hax, hax_lib::requires(self.cshake_inv()))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(self).cshake_inv()))]
     fn squeeze_cshake(&mut self, out: &mut [u8]) {
         self.state.squeeze(out);
     }

--- a/crates/algorithms/sha3/src/portable/incremental/cshake.rs
+++ b/crates/algorithms/sha3/src/portable/incremental/cshake.rs
@@ -11,7 +11,7 @@ pub fn left_encode_byte(num: u8) -> [u8; 2] {
     [1u8, num]
 }
 
-#[hax_lib::ensures(|result| result.len() <= 9)]
+#[cfg_attr(hax, hax_lib::ensures(|result| result.len() <= 9))]
 #[inline(always)]
 pub(crate) fn encode(num: usize, buffer: &mut [u8; 9], left_encode: bool) -> &[u8] {
     let zero_size = zero_bytes(num);
@@ -33,14 +33,14 @@ pub(crate) fn encode(num: usize, buffer: &mut [u8; 9], left_encode: bool) -> &[u
     &buffer[..output_length]
 }
 
-#[hax_lib::ensures(|result| result.len() <= 9)]
+#[cfg_attr(hax, hax_lib::ensures(|result| result.len() <= 9))]
 #[inline(always)]
 /// Left-encode any `num < u64::MAX`.
 pub fn left_encode(num: usize, buffer: &mut [u8; 9]) -> &[u8] {
     encode(num, buffer, true)
 }
 
-#[hax_lib::ensures(|result| result.len() <= 9)]
+#[cfg_attr(hax, hax_lib::ensures(|result| result.len() <= 9))]
 #[inline(always)]
 /// Right-encode any `num < u64::MAX`.
 pub fn right_encode(num: usize, buffer: &mut [u8; 9]) -> &[u8] {

--- a/crates/algorithms/sha3/src/proof_utils.rs
+++ b/crates/algorithms/sha3/src/proof_utils.rs
@@ -28,14 +28,17 @@ mod lemmas {
     ///
     /// This is used in the `squeeze` function to verify correct buffer indexing
     /// when squeezing multiple blocks.
-    #[hax_lib::fstar::replace(
-        r#"
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::replace(
+            r#"
 let lemma_div_mul_mod (a b: usize)
     : Lemma
         (requires b <>. mk_usize 0)
         (ensures (a /! b) *! b +! (a %! b) =. a)
     = ()
 "#
+        )
     )]
     pub(crate) fn lemma_div_mul_mod(_a: usize, _b: usize) {}
 
@@ -46,8 +49,10 @@ let lemma_div_mul_mod (a b: usize)
     ///
     /// This is used in the `keccak` functions to verify that block iterations
     /// stay within bounds.
-    #[hax_lib::fstar::replace(
-        r#"
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::replace(
+            r#"
 let rec lemma_mul_succ_le (k n d: usize)
   : Lemma
     (requires (v k) < (v n))
@@ -57,6 +62,7 @@ let rec lemma_mul_succ_le (k n d: usize)
   else if v k = v n - 1 then ()
   else lemma_mul_succ_le k (n -! mk_usize 1) d
 "#
+        )
     )]
     pub(crate) fn lemma_mul_succ_le(_k: usize, _n: usize, _d: usize) {}
 }

--- a/crates/algorithms/sha3/src/simd/portable.rs
+++ b/crates/algorithms/sha3/src/simd/portable.rs
@@ -5,14 +5,13 @@ use hax_lib::int::*;
 
 #[cfg(hax)]
 use crate::proof_utils::valid_rate;
-
 use crate::{generic_keccak::KeccakState, traits::*};
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     LEFT.to_int() + RIGHT.to_int() == 64.to_int() &&
     RIGHT > 0
-)]
+))]
 fn rotate_left<const LEFT: i32, const RIGHT: i32>(x: u64) -> u64 {
     #[cfg(not(eurydice))]
     debug_assert!(LEFT + RIGHT == 64);
@@ -30,10 +29,10 @@ fn _vrax1q_u64(a: u64, b: u64) -> u64 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     LEFT.to_int() + RIGHT.to_int() == 64.to_int() &&
     RIGHT > 0
-)]
+))]
 fn _vxarq_u64<const LEFT: i32, const RIGHT: i32>(a: u64, b: u64) -> u64 {
     rotate_left::<LEFT, RIGHT>(a ^ b)
 }
@@ -49,10 +48,10 @@ fn _veorq_n_u64(a: u64, c: u64) -> u64 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     valid_rate(RATE) &&
     start.to_int() + RATE.to_int() <= blocks.len().to_int()
-)]
+))]
 pub(crate) fn load_block<const RATE: usize>(state: &mut [u64; 25], blocks: &[u8], start: usize) {
     #[cfg(not(eurydice))]
     {
@@ -83,11 +82,11 @@ pub(crate) fn load_block<const RATE: usize>(state: &mut [u64; 25], blocks: &[u8]
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     valid_rate(RATE) &&
     len < RATE &&
     start.to_int() + len.to_int() <= blocks.len().to_int()
-)]
+))]
 pub(crate) fn load_last<const RATE: usize, const DELIMITER: u8>(
     state: &mut [u64; 25],
     blocks: &[u8],
@@ -106,12 +105,12 @@ pub(crate) fn load_last<const RATE: usize, const DELIMITER: u8>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     valid_rate(RATE) &&
     len <= RATE &&
     start.to_int() + len.to_int() <= out.len().to_int()
-)]
-#[hax_lib::ensures(|_| future(out).len() == out.len())]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
 pub(crate) fn store_block<const RATE: usize>(
     s: &[u64; 25],
     out: &mut [u8],
@@ -124,6 +123,7 @@ pub(crate) fn store_block<const RATE: usize>(
     let out_len = out.len(); // ghost variable
 
     for i in 0..octets {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| out.len() == out_len);
 
         let bytes = get_ij(s, i / 5, i % 5).to_le_bytes();
@@ -139,7 +139,7 @@ pub(crate) fn store_block<const RATE: usize>(
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl KeccakItem<1> for u64 {
     #[inline(always)]
     fn zero() -> Self {
@@ -154,10 +154,10 @@ impl KeccakItem<1> for u64 {
         _vrax1q_u64(a, b)
     }
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         LEFT.to_int() + RIGHT.to_int() == 64.to_int() &&
         RIGHT > 0
-    )]
+    ))]
     fn xor_and_rotate<const LEFT: i32, const RIGHT: i32>(a: Self, b: Self) -> Self {
         _vxarq_u64::<LEFT, RIGHT>(a, b)
     }
@@ -175,21 +175,21 @@ impl KeccakItem<1> for u64 {
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Absorb<1> for KeccakState<1, u64> {
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         start.to_int() + RATE.to_int() <= input[0].len().to_int()
-    )]
+    ))]
     fn load_block<const RATE: usize>(&mut self, input: &[&[u8]; 1], start: usize) {
         load_block::<RATE>(&mut self.st, input[0], start);
     }
 
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         len < RATE &&
         start.to_int() + len.to_int() <= input[0].len().to_int()
-    )]
+    ))]
     fn load_last<const RATE: usize, const DELIMITER: u8>(
         &mut self,
         input: &[&[u8]; 1],
@@ -200,14 +200,14 @@ impl Absorb<1> for KeccakState<1, u64> {
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Squeeze<u64> for KeccakState<1, u64> {
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         len <= RATE &&
         start.to_int() + len.to_int() <= out.len().to_int()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     fn squeeze<const RATE: usize>(&self, out: &mut [u8], start: usize, len: usize) {
         store_block::<RATE>(&self.st, out, start, len);
     }

--- a/crates/algorithms/sha3/src/traits.rs
+++ b/crates/algorithms/sha3/src/traits.rs
@@ -6,13 +6,13 @@ use crate::proof_utils::{slices_same_len, valid_rate};
 
 // XXX: These should be default functions on `KeccakItem`, but hax doesn't
 //      support that yet. cryspen/hax#888
-#[hax_lib::requires(i < 5 && j < 5)]
+#[cfg_attr(hax, hax_lib::requires(i < 5 && j < 5))]
 #[inline(always)]
 pub(crate) fn get_ij<const N: usize, T: KeccakItem<N>>(arr: &[T; 25], i: usize, j: usize) -> &T {
     &arr[5 * i + j]
 }
 
-#[hax_lib::requires(i < 5 && j < 5)]
+#[cfg_attr(hax, hax_lib::requires(i < 5 && j < 5))]
 #[inline(always)]
 pub(crate) fn set_ij<const N: usize, T: KeccakItem<N>>(
     arr: &mut [T; 25],
@@ -24,46 +24,46 @@ pub(crate) fn set_ij<const N: usize, T: KeccakItem<N>>(
 }
 
 /// A Keccak Item for multiplexing arithmetic implementations.
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait KeccakItem<const N: usize>: Clone + Copy {
     /// Zero
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn zero() -> Self;
 
     /// `a ^ b ^ c ^ d ^ e`
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn xor5(a: Self, b: Self, c: Self, d: Self, e: Self) -> Self;
 
     /// `a ^ (b <<< 1)``
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn rotate_left1_and_xor(a: Self, b: Self) -> Self;
 
     /// `(a ^ b) <<< LEFT`
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         LEFT.to_int() + RIGHT.to_int() == 64.to_int() &&
         RIGHT > 0 &&
         RIGHT < 64
-    )]
+    ))]
     fn xor_and_rotate<const LEFT: i32, const RIGHT: i32>(a: Self, b: Self) -> Self;
 
     /// `a ^ (b & !c)`
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn and_not_xor(a: Self, b: Self, c: Self) -> Self;
 
     /// `a ^ c`
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn xor_constant(a: Self, c: u64) -> Self;
 
     /// `a ^ b`
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn xor(a: Self, b: Self) -> Self;
 }
 
 /// Trait to load new bytes into the state.
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Absorb<const N: usize> {
     /// Absorb a block
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
       from_bool(
         N != 0 &&
         valid_rate(RATE) &&
@@ -71,11 +71,11 @@ pub(crate) trait Absorb<const N: usize> {
       ).and(
         slices_same_len(input)
       )
-    )]
+    ))]
     fn load_block<const RATE: usize>(&mut self, input: &[&[u8]; N], start: usize);
 
     /// Absorb the last block (may be partial)
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
       from_bool(
         N != 0 &&
         valid_rate(RATE) &&
@@ -84,7 +84,7 @@ pub(crate) trait Absorb<const N: usize> {
       ).and(
         slices_same_len(input)
       )
-    )]
+    ))]
     fn load_last<const RATE: usize, const DELIMITER: u8>(
         &mut self,
         input: &[&[u8]; N],
@@ -104,7 +104,7 @@ pub(crate) trait Absorb<const N: usize> {
 /// handle the mutability required for a generic implementation.
 ///
 /// Store blocks `N = 1`
-#[hax_lib::fstar::replace(
+#[cfg_attr(hax, hax_lib::fstar::replace(
     interface, "
 class t_Squeeze (v_Self: Type0) (v_T: Type0) = {
   // TODO: This super variable is problematic and makes typecheck fail
@@ -144,15 +144,15 @@ class t_Squeeze (v_Self: Type0) (v_T: Type0) = {
 // [@@ FStar.Tactics.Typeclasses.tcinstance]
 // let _ = fun (v_Self:Type0) (v_T:Type0) {|i: t_Squeeze v_Self v_T|} -> i._super_18390613159176269294
 "
-)]
-#[hax_lib::attributes]
+))]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Squeeze<T: KeccakItem<1>> {
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         valid_rate(RATE) &&
         len <= RATE &&
         start.to_int() + len.to_int() <= out.len().to_int()
-    )]
-    #[hax_lib::ensures(|_| future(out).len() == out.len())]
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
     fn squeeze<const RATE: usize>(&self, out: &mut [u8], start: usize, len: usize);
 }
 

--- a/crates/utils/core-models/src/abstractions/bit.rs
+++ b/crates/utils/core-models/src/abstractions/bit.rs
@@ -69,6 +69,15 @@ impl From<bool> for Bit {
 
 /// A trait for types that represent machine integers.
 #[hax_lib::attributes]
+#[hax_lib::fstar::after(
+    r"
+instance impl_MachineInteger_poly (t: inttype): t_MachineInteger (int_t t) =
+  { f_bits = (fun () -> mk_u32 (bits t));
+    f_bits_pre = (fun () -> True);
+    f_bits_post = (fun () r -> r == mk_u32 (bits t));
+    f_SIGNED = signed t }
+"
+)]
 pub trait MachineInteger {
     /// The size of this integer type in bits.
     #[hax_lib::requires(true)]
@@ -89,17 +98,6 @@ macro_rules! generate_machine_integer_impls {
     };
 }
 generate_machine_integer_impls!(u8, u16, u32, u64, u128, i8, i16, i32, i64, i128);
-
-#[hax_lib::fstar::replace(
-    r"
-instance impl_MachineInteger_poly (t: inttype): t_MachineInteger (int_t t) =
-  { f_bits = (fun () -> mk_u32 (bits t));
-    f_bits_pre = (fun () -> True);
-    f_bits_post = (fun () r -> r == mk_u32 (bits t));
-    f_SIGNED = signed t }
-"
-)]
-const _: () = {};
 
 #[hax_lib::exclude]
 impl Bit {

--- a/crates/utils/intrinsics/Cargo.toml
+++ b/crates/utils/intrinsics/Cargo.toml
@@ -11,10 +11,10 @@ description = "Libcrux intrinsics crate"
 exclude = ["/proofs"]
 
 [dependencies]
-hax-lib.workspace = true
 
 [target.'cfg(hax)'.dependencies]
 core-models = { path = "../core-models", version = "0.0.7" }
+hax-lib.workspace = true
 
 [features]
 simd128 = []

--- a/crates/utils/intrinsics/src/arm64_extract.rs
+++ b/crates/utils/intrinsics/src/arm64_extract.rs
@@ -3,23 +3,23 @@
 
 #![allow(non_camel_case_types, unsafe_code, unused_variables)]
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _uint16x4_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _int16x4_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _int16x8_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _uint8x16_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _uint16x8_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _uint32x4_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _int32x4_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _uint64x2_t = u8;
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 pub type _int64x2_t = u8;
 
 #[inline(always)]

--- a/crates/utils/intrinsics/src/avx2.rs
+++ b/crates/utils/intrinsics/src/avx2.rs
@@ -12,7 +12,7 @@ pub type Vec256 = __m256i;
 pub type Vec128 = __m128i;
 pub type Vec256Float = __m256;
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
     // Note: in this module the `debug_assert_eq!` are essentially sanity
@@ -27,7 +27,7 @@ pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
     #[cfg(not(hax))]
@@ -37,7 +37,7 @@ pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
     #[cfg(not(hax))]
@@ -47,7 +47,7 @@ pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
     #[cfg(not(hax))]
@@ -57,7 +57,7 @@ pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_storeu_si128_u128(output: &mut u128, vector: Vec128) {
     unsafe {
@@ -65,7 +65,7 @@ pub fn mm_storeu_si128_u128(output: &mut u128, vector: Vec128) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_storeu_si128_u8(output: &mut [u8], vector: Vec128) {
     #[cfg(not(hax))]
@@ -75,7 +75,7 @@ pub fn mm_storeu_si128_u8(output: &mut [u8], vector: Vec128) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
     #[cfg(not(hax))]
@@ -85,8 +85,8 @@ pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
     }
 }
 
-#[hax_lib::opaque]
-#[hax_lib::ensures(|_r| future(output).len() == output.len())]
+#[cfg_attr(hax, hax_lib::opaque)]
+#[cfg_attr(hax, hax_lib::ensures(|_r| future(output).len() == output.len()))]
 #[inline(always)]
 pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
     #[cfg(not(hax))]
@@ -96,7 +96,7 @@ pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
     }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
     #[cfg(not(hax))]
@@ -104,13 +104,13 @@ pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
     unsafe { _mm_loadu_si128(input.as_ptr() as *const Vec128) }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm_loadu_si128_u128(input: &u128) -> Vec128 {
     unsafe { _mm_loadu_si128(input as *const u128 as *const __m128i) }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_loadu_si256_u8(input: &[u8]) -> Vec256 {
     #[cfg(not(hax))]
@@ -118,7 +118,7 @@ pub fn mm256_loadu_si256_u8(input: &[u8]) -> Vec256 {
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_loadu_si256_i16(input: &[i16]) -> Vec256 {
     #[cfg(not(hax))]
@@ -126,7 +126,7 @@ pub fn mm256_loadu_si256_i16(input: &[i16]) -> Vec256 {
     unsafe { _mm256_loadu_si256(input.as_ptr() as *const Vec256) }
 }
 
-#[hax_lib::opaque]
+#[cfg_attr(hax, hax_lib::opaque)]
 #[inline(always)]
 pub fn mm256_loadu_si256_i32(input: &[i32]) -> Vec256 {
     #[cfg(not(hax))]
@@ -150,7 +150,7 @@ pub fn mm256_set_m128i(hi: Vec128, lo: Vec128) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_set_epi8(
     byte15: i8,
     byte14: i8,
@@ -178,7 +178,7 @@ pub fn mm_set_epi8(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set_epi8(
     byte31: i8,
     byte30: i8,
@@ -223,13 +223,13 @@ pub fn mm256_set_epi8(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set1_epi16(constant: i16) -> Vec256 {
     unsafe { _mm256_set1_epi16(constant) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set_epi16(
     input15: i16,
     input14: i16,
@@ -257,25 +257,25 @@ pub fn mm256_set_epi16(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_set1_epi16(constant: i16) -> Vec128 {
     unsafe { _mm_set1_epi16(constant) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set1_epi32(constant: i32) -> Vec256 {
     unsafe { _mm256_set1_epi32(constant) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_set_epi32(input3: i32, input2: i32, input1: i32, input0: i32) -> Vec128 {
     unsafe { _mm_set_epi32(input3, input2, input1, input0) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set_epi32(
     input7: i32,
     input6: i32,
@@ -294,163 +294,163 @@ pub fn mm256_set_epi32(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_add_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_add_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_add_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_add_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_madd_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_madd_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_add_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_add_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_add_epi64(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_add_epi64(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_abs_epi32(a: Vec256) -> Vec256 {
     unsafe { _mm256_abs_epi32(a) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_sub_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_sub_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_sub_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_sub_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_sub_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_mullo_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mullo_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_mullo_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_mullo_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_cmpgt_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_cmpgt_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_cmpgt_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_cmpgt_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_cmpeq_epi32(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_cmpeq_epi32(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_sign_epi32(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_sign_epi32(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_castsi256_ps(a: Vec256) -> Vec256Float {
     unsafe { _mm256_castsi256_ps(a) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_castps_si256(a: Vec256Float) -> Vec256 {
     unsafe { _mm256_castps_si256(a) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_movemask_ps(a: Vec256Float) -> i32 {
     unsafe { _mm256_movemask_ps(a) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_mulhi_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_mulhi_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_mullo_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mullo_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_mulhi_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mulhi_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_mul_epu32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mul_epu32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_mul_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_mul_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_and_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_and_si256(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_or_si256(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_or_si256(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_testz_si256(lhs: Vec256, rhs: Vec256) -> i32 {
     unsafe { _mm256_testz_si256(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_xor_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
     // This floating point xor may or may not be faster than regular xor.
     // Local testing seems to indicate that it's a little more stable in
@@ -469,13 +469,13 @@ pub fn mm256_xor_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_xor_si128(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_xor_si128(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -483,7 +483,7 @@ pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
@@ -491,7 +491,7 @@ pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -499,7 +499,7 @@ pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
@@ -507,7 +507,7 @@ pub fn mm256_srli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_srli_epi64<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
@@ -515,8 +515,8 @@ pub fn mm_srli_epi64<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(SHIFT_BY > 0 && SHIFT_BY < 64)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::requires(SHIFT_BY > 0 && SHIFT_BY < 64))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
@@ -524,7 +524,7 @@ pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -532,7 +532,7 @@ pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_slli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 32);
@@ -540,7 +540,7 @@ pub fn mm256_slli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_slli_si128<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -548,7 +548,7 @@ pub fn mm_slli_si128<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_srli_si128<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -556,19 +556,19 @@ pub fn mm_srli_si128<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_shuffle_epi8(vector: Vec128, control: Vec128) -> Vec128 {
     unsafe { _mm_shuffle_epi8(vector, control) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_shuffle_epi8(vector: Vec256, control: Vec256) -> Vec256 {
     unsafe { _mm256_shuffle_epi8(vector, control) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_shuffle_epi32<const CONTROL: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
@@ -576,7 +576,7 @@ pub fn mm256_shuffle_epi32<const CONTROL: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_shuffle_epi32<const CONTROL: i32>(vector: Vec128) -> Vec128 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
@@ -584,7 +584,7 @@ pub fn mm_shuffle_epi32<const CONTROL: i32>(vector: Vec128) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_permute4x64_epi64<const CONTROL: i32>(vector: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
@@ -592,61 +592,61 @@ pub fn mm256_permute4x64_epi64<const CONTROL: i32>(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_unpackhi_epi64(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpackhi_epi64(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_unpackhi_epi64(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_unpackhi_epi64(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_unpacklo_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpacklo_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_unpackhi_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpackhi_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_castsi256_si128(vector: Vec256) -> Vec128 {
     unsafe { _mm256_castsi256_si128(vector) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_castsi128_si256(vector: Vec128) -> Vec256 {
     unsafe { _mm256_castsi128_si256(vector) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_cvtepi16_epi32(vector: Vec128) -> Vec256 {
     unsafe { _mm256_cvtepi16_epi32(vector) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_packs_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_packs_epi16(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_packs_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_packs_epi32(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL == 0 || CONTROL == 1);
@@ -654,7 +654,7 @@ pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_inserti128_si256<const CONTROL: i32>(vector: Vec256, vector_i128: Vec128) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL == 0 || CONTROL == 1);
@@ -662,7 +662,7 @@ pub fn mm256_inserti128_si256<const CONTROL: i32>(vector: Vec256, vector_i128: V
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_blend_epi16<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
@@ -670,7 +670,7 @@ pub fn mm256_blend_epi16<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_blend_epi32<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(CONTROL >= 0 && CONTROL < 256);
@@ -681,7 +681,7 @@ pub fn mm256_blend_epi32<const CONTROL: i32>(lhs: Vec256, rhs: Vec256) -> Vec256
 // It is not offered by the AVX2 instruction set.
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn vec256_blendv_epi32(a: Vec256, b: Vec256, mask: Vec256) -> Vec256 {
     unsafe {
         _mm256_castps_si256(_mm256_blendv_ps(
@@ -693,49 +693,49 @@ pub fn vec256_blendv_epi32(a: Vec256, b: Vec256, mask: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_movemask_epi8(vector: Vec128) -> i32 {
     unsafe { _mm_movemask_epi8(vector) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_permutevar8x32_epi32(vector: Vec256, control: Vec256) -> Vec256 {
     unsafe { _mm256_permutevar8x32_epi32(vector, control) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srlv_epi32(vector: Vec256, counts: Vec256) -> Vec256 {
     unsafe { _mm256_srlv_epi32(vector, counts) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_srlv_epi64(vector: Vec256, counts: Vec256) -> Vec256 {
     unsafe { _mm256_srlv_epi64(vector, counts) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_sllv_epi32(vector: Vec128, counts: Vec128) -> Vec128 {
     unsafe { _mm_sllv_epi32(vector, counts) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_sllv_epi32(vector: Vec256, counts: Vec256) -> Vec256 {
     unsafe { _mm256_sllv_epi32(vector, counts) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_slli_epi64<const LEFT: i32>(x: Vec256) -> Vec256 {
     unsafe { _mm256_slli_epi64::<LEFT>(x) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_bsrli_epi128<const SHIFT_BY: i32>(x: Vec256) -> Vec256 {
     #[cfg(not(hax))]
     debug_assert!(SHIFT_BY > 0 && SHIFT_BY < 16);
@@ -743,61 +743,61 @@ pub fn mm256_bsrli_epi128<const SHIFT_BY: i32>(x: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_andnot_si256(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_andnot_si256(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set1_epi64x(a: i64) -> Vec256 {
     unsafe { _mm256_set1_epi64x(a) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_set_epi64x(input3: i64, input2: i64, input1: i64, input0: i64) -> Vec256 {
     unsafe { _mm256_set_epi64x(input3, input2, input1, input0) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_unpacklo_epi64(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unsafe { _mm256_unpacklo_epi64(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_unpacklo_epi64(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unsafe { _mm_unpacklo_epi64(lhs, rhs) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm256_permute2x128_si256<const IMM8: i32>(a: Vec256, b: Vec256) -> Vec256 {
     unsafe { _mm256_permute2x128_si256::<IMM8>(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_clmulepi64_si128<const IMM8: i32>(a: Vec128, b: Vec128) -> Vec128 {
     unsafe { _mm_clmulepi64_si128(a, b, IMM8) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_aesenc_si128(a: Vec128, b: Vec128) -> Vec128 {
     unsafe { _mm_aesenc_si128(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_aesenclast_si128(a: Vec128, b: Vec128) -> Vec128 {
     unsafe { _mm_aesenclast_si128(a, b) }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub fn mm_aeskeygenassist_si128<const RCON: i32>(a: Vec128) -> Vec128 {
     unsafe { _mm_aeskeygenassist_si128(a, RCON) }
 }

--- a/crates/utils/intrinsics/src/avx2_extract.rs
+++ b/crates/utils/intrinsics/src/avx2_extract.rs
@@ -5,25 +5,31 @@
 
 #[cfg(hax)]
 #[derive(Clone, Copy, Debug)]
-#[hax_lib::fstar::replace(
-    interface,
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        r#"
 unfold type $:{Vec256} = bit_vec 256
 val vec256_as_i16x16 (x: bit_vec 256) : t_Array i16 (sz 16)
 let get_lane (v: bit_vec 256) (i:nat{i < 16}) = Seq.index (vec256_as_i16x16 v) i
 "#
+    )
 )]
 pub struct Vec256(u8);
 
 #[cfg(hax)]
 #[derive(Copy, Clone, Debug)]
-#[hax_lib::fstar::replace(
-    interface,
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        r#"
 unfold type $:{Vec128} = bit_vec 128
 val vec128_as_i16x8 (x: bit_vec 128) : t_Array i16 (sz 8)
 let get_lane128 (v: bit_vec 128) (i:nat{i < 8}) = Seq.index (vec128_as_i16x8 v) i
 "#
+    )
 )]
 pub struct Vec128(u8);
 
@@ -39,7 +45,7 @@ pub fn mm256_storeu_si256_u8(output: &mut [u8], vector: Vec256) {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|()| future(output).len() == output.len())]
+#[cfg_attr(hax, hax_lib::ensures(|()| future(output).len() == output.len()))]
 #[inline(always)]
 pub fn mm256_storeu_si256_i16(output: &mut [i16], vector: Vec256) {
     debug_assert_eq!(output.len(), 16);
@@ -53,8 +59,8 @@ pub fn mm256_storeu_si256_i32(output: &mut [i32], vector: Vec256) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(output.len() >= 8)]
-#[hax_lib::ensures(|_| future(output).len() == output.len())]
+#[cfg_attr(hax, hax_lib::requires(output.len() >= 8))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(output).len() == output.len()))]
 pub fn mm_storeu_si128(output: &mut [i16], vector: Vec128) {
     debug_assert!(output.len() >= 8);
     unimplemented!()
@@ -66,14 +72,20 @@ pub fn mm_storeu_si128_i32(output: &mut [i32], vector: Vec128) {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_storeu_bytes_si128}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_storeu_bytes_si128}")
+)]
 #[inline(always)]
 pub fn mm_storeu_bytes_si128(output: &mut [u8], vector: Vec128) {
     debug_assert_eq!(output.len(), 16);
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_loadu_si128}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_loadu_si128}")
+)]
 #[inline(always)]
 pub fn mm_loadu_si128(input: &[u8]) -> Vec128 {
     debug_assert_eq!(input.len(), 16);
@@ -99,7 +111,7 @@ pub fn mm256_loadu_si256_i32(input: &[i32]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == Seq.create 16 (mk_i16 0)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == Seq.create 16 (mk_i16 0)")))]
 pub fn mm256_setzero_si256() -> Vec256 {
     unimplemented!()
 }
@@ -109,7 +121,10 @@ pub fn mm256_set_m128i(hi: Vec128, lo: Vec128) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_set_epi8}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_set_epi8}")
+)]
 #[inline(always)]
 pub fn mm_set_epi8(
     byte15: i8,
@@ -132,7 +147,10 @@ pub fn mm_set_epi8(
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_set_epi8}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_set_epi8}")
+)]
 #[inline(always)]
 pub fn mm256_set_epi8(
     byte31: i8,
@@ -171,11 +189,13 @@ pub fn mm256_set_epi8(
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
-                                    Spec.Utils.create (sz 16) $constant"))]
-#[hax_lib::fstar::replace(
-    interface,
-    r#"
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
+                                    Spec.Utils.create (sz 16) $constant")))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        r#"
 include BitVec.Intrinsics {mm256_set1_epi16 as ${mm256_set1_epi16}}
 val lemma_mm256_set1_epi16 constant
   : Lemma (   vec256_as_i16x16 (mm256_set1_epi16 constant)
@@ -183,13 +203,14 @@ val lemma_mm256_set1_epi16 constant
           )
           [SMTPat (vec256_as_i16x16 (mm256_set1_epi16 constant))]
 "#
+    )
 )]
 #[inline(always)]
 pub fn mm256_set1_epi16(constant: i16) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
+#[cfg_attr(hax, hax_lib::fstar::replace(
     interface,
     r#"
 include BitVec.Intrinsics {mm256_set_epi16 as ${mm256_set_epi16}}
@@ -198,7 +219,7 @@ let lemma_mm256_set_epi16 v15 v14 v13 v12 v11 v10 v9 v8 v7 v6 v5 v4 v3 v2 v1 v0 
             Spec.Utils.create16 v0 v1 v2 v3 v4 v5 v6 v7 v8 v9 v10 v11 v12 v13 v14 v15)
             [SMTPat (vec256_as_i16x16 (${mm256_set_epi16} v15 v14 v13 v12 v11 v10 v9 v8 v7 v6 v5 v4 v3 v2 v1 v0))] = admit()
 "#
-)]
+))]
 pub fn mm256_set_epi16(
     input15: i16,
     input14: i16,
@@ -220,8 +241,8 @@ pub fn mm256_set_epi16(
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
-                                    Spec.Utils.create (sz 8) $constant"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
+                                    Spec.Utils.create (sz 8) $constant")))]
 #[inline(always)]
 pub fn mm_set1_epi16(constant: i16) -> Vec128 {
     unimplemented!()
@@ -237,7 +258,10 @@ pub fn mm_set_epi32(input3: i32, input2: i32, input1: i32, input0: i32) -> Vec12
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_set_epi32}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_set_epi32}")
+)]
 #[inline(always)]
 pub fn mm256_set_epi32(
     input7: i32,
@@ -252,30 +276,33 @@ pub fn mm256_set_epi32(
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
-            Spec.Utils.map2 (+.) (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
+            Spec.Utils.map2 (+.) (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)")))]
 #[inline(always)]
 pub fn mm_add_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
-            Spec.Utils.map2 (-.) (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
+            Spec.Utils.map2 (-.) (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)")))]
 #[inline(always)]
 pub fn mm_sub_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
-            Spec.Utils.map2 (+.) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
+            Spec.Utils.map2 (+.) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)")))]
 #[inline(always)]
 pub fn mm256_add_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_madd_epi16 as ${mm256_madd_epi16}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_madd_epi16 as ${mm256_madd_epi16}}"
+    )
 )]
 #[inline(always)]
 pub fn mm256_madd_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
@@ -286,8 +313,8 @@ pub fn mm256_add_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
-            Spec.Utils.map2 (-.) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
+            Spec.Utils.map2 (-.) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)")))]
 pub fn mm256_sub_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
@@ -306,28 +333,31 @@ pub fn mm256_sub_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        r#"
 include BitVec.Intrinsics {mm256_mullo_epi16 as ${mm256_mullo_epi16}}
 let lemma_mm256_mullo_epi16 v1 v2 :
    Lemma (vec256_as_i16x16 (${mm256_mullo_epi16} v1 v2) == 
        Spec.Utils.map2 mul_mod (vec256_as_i16x16 v1) (vec256_as_i16x16 v2))
        [SMTPat (vec256_as_i16x16 (${mm256_mullo_epi16} v1 v2))] = admit()
 "#
+    )
 )]
 pub fn mm256_mullo_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
-            Spec.Utils.map2 mul_mod (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
+            Spec.Utils.map2 mul_mod (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)")))]
 pub fn mm_mullo_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unimplemented!()
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i % 16 >= 1 ==> result i == 0"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i % 16 >= 1 ==> result i == 0"#)))]
 pub fn mm256_cmpgt_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
@@ -355,9 +385,9 @@ pub fn mm256_movemask_ps(a: Vec256Float) -> i32 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec128_as_i16x8 $result == 
             Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16) 
-                (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)"))]
+                (vec128_as_i16x8 $lhs) (vec128_as_i16x8 $rhs)")))]
 pub fn mm_mulhi_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unimplemented!()
 }
@@ -366,8 +396,8 @@ pub fn mm256_mullo_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
-            Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
+            Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16) (vec256_as_i16x16 $lhs) (vec256_as_i16x16 $rhs)")))]
 pub fn mm256_mulhi_epi16(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
@@ -381,9 +411,11 @@ pub fn mm256_mul_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        r#"
 include BitVec.Intrinsics {mm256_and_si256 as ${mm256_and_si256}}
 val lemma_mm256_and_si256 lhs rhs
   : Lemma (   vec256_as_i16x16 (mm256_and_si256 lhs rhs)
@@ -391,6 +423,7 @@ val lemma_mm256_and_si256 lhs rhs
           )
           [SMTPat (vec256_as_i16x16 (mm256_and_si256 lhs rhs))]
 "#
+    )
 )]
 #[inline(always)]
 pub fn mm256_and_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
@@ -410,9 +443,9 @@ pub fn mm256_xor_si256(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-#[hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
-            Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (vec256_as_i16x16 $vector)"))]
+#[cfg_attr(hax, hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("vec256_as_i16x16 $result == 
+            Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (vec256_as_i16x16 $vector)")))]
 pub fn mm256_srai_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
     unimplemented!()
@@ -422,9 +455,12 @@ pub fn mm256_srai_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_srli_epi16 as ${mm256_srli_epi16::<0>}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_srli_epi16 as ${mm256_srli_epi16::<0>}}"
+    )
 )]
 pub fn mm256_srli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -440,18 +476,24 @@ pub fn mm_srli_epi64<const SHIFT_BY: i32>(vector: Vec128) -> Vec128 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_srli_epi64 as ${mm256_srli_epi64::<0>}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_srli_epi64 as ${mm256_srli_epi64::<0>}}"
+    )
 )]
 pub fn mm256_srli_epi64<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 64);
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_slli_epi16 as ${mm256_slli_epi16::<0>}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_slli_epi16 as ${mm256_slli_epi16::<0>}}"
+    )
 )]
 pub fn mm256_slli_epi16<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     debug_assert!(SHIFT_BY >= 0 && SHIFT_BY < 16);
@@ -463,11 +505,17 @@ pub fn mm256_slli_epi32<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_shuffle_epi8}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm_shuffle_epi8}")
+)]
 pub fn mm_shuffle_epi8(vector: Vec128, control: Vec128) -> Vec128 {
     unimplemented!()
 }
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_shuffle_epi8}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_shuffle_epi8}")
+)]
 pub fn mm256_shuffle_epi8(vector: Vec256, control: Vec256) -> Vec256 {
     unimplemented!()
 }
@@ -493,9 +541,12 @@ pub fn mm256_unpackhi_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_castsi256_si128 as ${mm256_castsi256_si128}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_castsi256_si128 as ${mm256_castsi256_si128}}"
+    )
 )]
 pub fn mm256_castsi256_si128(vector: Vec256) -> Vec128 {
     unimplemented!()
@@ -508,9 +559,12 @@ pub fn mm256_cvtepi16_epi32(vector: Vec128) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm_packs_epi16 as ${mm_packs_epi16}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm_packs_epi16 as ${mm_packs_epi16}}"
+    )
 )]
 pub fn mm_packs_epi16(lhs: Vec128, rhs: Vec128) -> Vec128 {
     unimplemented!()
@@ -519,9 +573,12 @@ pub fn mm256_packs_epi32(lhs: Vec256, rhs: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_extracti128_si256 as ${mm256_extracti128_si256::<0>}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_extracti128_si256 as ${mm256_extracti128_si256::<0>}}"
+    )
 )]
 pub fn mm256_extracti128_si256<const CONTROL: i32>(vector: Vec256) -> Vec128 {
     debug_assert!(CONTROL == 0 || CONTROL == 1);
@@ -552,16 +609,22 @@ pub fn vec256_blendv_epi32(a: Vec256, b: Vec256, mask: Vec256) -> Vec256 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm_movemask_epi8 as ${mm_movemask_epi8}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm_movemask_epi8 as ${mm_movemask_epi8}}"
+    )
 )]
 #[inline(always)]
 pub fn mm_movemask_epi8(vector: Vec128) -> i32 {
     unimplemented!()
 }
 
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_permutevar8x32_epi32}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_permutevar8x32_epi32}")
+)]
 #[inline(always)]
 pub fn mm256_permutevar8x32_epi32(vector: Vec256, control: Vec256) -> Vec256 {
     unimplemented!()
@@ -582,7 +645,10 @@ pub fn mm_sllv_epi32(vector: Vec128, counts: Vec128) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_sllv_epi32}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_sllv_epi32}")
+)]
 pub fn mm256_sllv_epi32(vector: Vec256, counts: Vec256) -> Vec256 {
     unimplemented!()
 }

--- a/crates/utils/secrets/Cargo.toml
+++ b/crates/utils/secrets/Cargo.toml
@@ -12,10 +12,12 @@ repository.workspace = true
 exclude = ["/proofs"]
 
 [dependencies]
-hax-lib.workspace = true
 
 [target.'cfg(valgrind_ct_test)'.dependencies]
 crabgrind.workspace = true
+
+[target.'cfg(hax)'.dependencies]
+hax-lib.workspace = true
 
 [features]
 check-secret-independence = []

--- a/crates/utils/secrets/src/int/classify_public.rs
+++ b/crates/utils/secrets/src/int/classify_public.rs
@@ -94,7 +94,7 @@ impl<T: Scalar, const N: usize, const M: usize> Declassify for [[T; N]; M] {
 }
 
 // Mutable references to scalars can be classified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar> ClassifyRefMut for &'a mut T {
     type ClassifiedRefMut = &'a mut T;
 
@@ -105,7 +105,7 @@ impl<'a, T: Scalar> ClassifyRefMut for &'a mut T {
 }
 
 // Mutable references to scalars can be declassified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar> DeclassifyRefMut for &'a mut T {
     type DeclassifiedRefMut = &'a mut T;
 
@@ -136,7 +136,7 @@ impl<'a, T: Scalar> DeclassifyRef for &'a [T] {
 }
 
 // Mutable references to slices can be classified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar> ClassifyRefMut for &'a mut [T] {
     type ClassifiedRefMut = &'a mut [T];
 
@@ -147,7 +147,7 @@ impl<'a, T: Scalar> ClassifyRefMut for &'a mut [T] {
 }
 
 // Mutable references to slices can be declassified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar> DeclassifyRefMut for &'a mut [T] {
     type DeclassifiedRefMut = &'a mut [T];
 
@@ -178,7 +178,7 @@ impl<'a, T: Scalar, const N: usize> DeclassifyRef for &'a [T; N] {
 }
 
 // Mutable references to arrays can be classified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar, const N: usize> ClassifyRefMut for &'a mut [T; N] {
     type ClassifiedRefMut = &'a mut [T; N];
 
@@ -189,7 +189,7 @@ impl<'a, T: Scalar, const N: usize> ClassifyRefMut for &'a mut [T; N] {
 }
 
 // Mutable references to arrays can be declassified
-#[hax_lib::exclude]
+#[cfg_attr(hax, hax_lib::exclude)]
 impl<'a, T: Scalar, const N: usize> DeclassifyRefMut for &'a mut [T; N] {
     type DeclassifiedRefMut = &'a mut [T; N];
 

--- a/libcrux-ml-dsa/Cargo.toml
+++ b/libcrux-ml-dsa/Cargo.toml
@@ -31,7 +31,6 @@ libcrux-intrinsics.workspace = true
 libcrux-platform.workspace = true
 libcrux-macros.workspace = true
 libcrux-secrets.workspace = true
-hax-lib.workspace = true
 tls_codec = { workspace = true, optional = true }
 
 [dev-dependencies]
@@ -49,6 +48,7 @@ pqcrypto-mldsa = { version = "0.1.0" } #, default-features = false
 
 [target.'cfg(hax)'.dependencies]
 core-models = { path = "../crates/utils/core-models", version = "0.0.7" }
+hax-lib.workspace = true
 
 [features]
 default = ["std", "mldsa44", "mldsa65", "mldsa87"]

--- a/libcrux-ml-dsa/src/arithmetic.rs
+++ b/libcrux-ml-dsa/src/arithmetic.rs
@@ -5,11 +5,11 @@ use crate::{
 };
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
         (forall i. forall j. Spec.Utils.is_i32b_array_opaque 
             (v ${crate::simd::traits::specs::FIELD_MAX}) 
-            (i0._super_i2.f_repr (Seq.index (Seq.index vector i).f_simd_units j)))"#))]
+            (i0._super_i2.f_repr (Seq.index (Seq.index vector i).f_simd_units j)))"#)))]
 /// CAUTION: This function must only be called with inputs for
 /// which it is safe to leak the index of a violating coefficient.
 ///
@@ -37,11 +37,11 @@ pub(crate) fn vector_infinity_norm_exceeds<SIMDUnit: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
         (forall i. forall j.
             v (Seq.index (i0._super_i2.f_repr (Seq.index re.f_simd_units i)) j) >= 0 /\
-            v (Seq.index (i0._super_i2.f_repr (Seq.index re.f_simd_units i)) j) <= 261631)"#))]
+            v (Seq.index (i0._super_i2.f_repr (Seq.index re.f_simd_units i)) j) <= 261631)"#)))]
 pub(crate) fn shift_left_then_reduce<SIMDUnit: Operations, const SHIFT_BY: i32>(
     re: &mut PolynomialRingElement<SIMDUnit>,
 ) {
@@ -49,6 +49,7 @@ pub(crate) fn shift_left_then_reduce<SIMDUnit: Operations, const SHIFT_BY: i32>(
     let old_re = re.clone();
 
     for i in 0..re.simd_units.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             forall j. j >= v i ==> Seq.index re.f_simd_units j == Seq.index old_re.f_simd_units j"#
@@ -59,12 +60,12 @@ pub(crate) fn shift_left_then_reduce<SIMDUnit: Operations, const SHIFT_BY: i32>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"${t.len()} == ${t1.len()} /\
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"${t.len()} == ${t1.len()} /\
     (forall i. forall j. 
         Spec.Utils.is_i32b_array_opaque 
         (v ${crate::simd::traits::specs::FIELD_MAX}) 
-        (i0._super_i2.f_repr (Seq.index (Seq.index t i).f_simd_units j)))"#))]
+        (i0._super_i2.f_repr (Seq.index (Seq.index t i).f_simd_units j)))"#)))]
 pub(crate) fn power2round_vector<SIMDUnit: Operations>(
     t: &mut [PolynomialRingElement<SIMDUnit>],
     t1: &mut [PolynomialRingElement<SIMDUnit>],
@@ -76,6 +77,7 @@ pub(crate) fn power2round_vector<SIMDUnit: Operations>(
     use hax_lib::prop::*;
 
     for i in 0..t.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| Prop::from(
             t.len() == old_t.len() && t1.len() == old_t1.len()
         )
@@ -85,6 +87,7 @@ pub(crate) fn power2round_vector<SIMDUnit: Operations>(
         ))));
 
         for j in 0..t[i].simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|j: usize| Prop::from(
                 t.len() == old_t.len() && t1.len() == old_t1.len()
             )
@@ -110,8 +113,8 @@ pub(crate) fn power2round_vector<SIMDUnit: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
          v $gamma2 == v ${crate::constants::GAMMA2_V95_232}) /\
          ${t.len()} == dimension /\ 
@@ -120,7 +123,7 @@ pub(crate) fn power2round_vector<SIMDUnit: Operations>(
          (forall i. forall j. 
             Spec.Utils.is_i32b_array_opaque 
             (v ${crate::simd::traits::specs::FIELD_MAX}) 
-            (i0._super_i2.f_repr (Seq.index (Seq.index t i).f_simd_units j)))"#))]
+            (i0._super_i2.f_repr (Seq.index (Seq.index t i).f_simd_units j)))"#)))]
 pub(crate) fn decompose_vector<SIMDUnit: Operations>(
     dimension: usize,
     gamma2: Gamma2,
@@ -129,9 +132,11 @@ pub(crate) fn decompose_vector<SIMDUnit: Operations>(
     high: &mut [PolynomialRingElement<SIMDUnit>],
 ) {
     for i in 0..dimension {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| low.len() == dimension && high.len() == dimension);
 
         for j in 0..low[0].simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| low.len() == dimension && high.len() == dimension);
 
             SIMDUnit::decompose(
@@ -145,13 +150,13 @@ pub(crate) fn decompose_vector<SIMDUnit: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
          v $gamma2 == v ${crate::constants::GAMMA2_V95_232}) /\
          ${low.len()} == ${high.len()} /\ 
          ${low.len()} == ${hint.len()} /\
-         v (${low.len()}) <= 8"#))]
+         v (${low.len()}) <= 8"#)))]
 pub(crate) fn make_hint<SIMDUnit: Operations>(
     low: &[PolynomialRingElement<SIMDUnit>],
     high: &[PolynomialRingElement<SIMDUnit>],
@@ -162,9 +167,11 @@ pub(crate) fn make_hint<SIMDUnit: Operations>(
     let mut hint_simd = PolynomialRingElement::<SIMDUnit>::zero();
 
     for i in 0..low.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| true_hints <= 256 * i && hint.len() == low.len());
 
         for j in 0..hint_simd.simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|j: usize| true_hints <= 256 * i + 8 * j);
 
             let one_hints_count = SIMDUnit::compute_hint(
@@ -184,8 +191,8 @@ pub(crate) fn make_hint<SIMDUnit: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
          v $gamma2 == v ${crate::constants::GAMMA2_V95_232}) /\
          ${hint.len()} == ${re_vector.len()} /\ 
@@ -196,7 +203,7 @@ pub(crate) fn make_hint<SIMDUnit: Operations>(
          (forall i. forall j. 
             Spec.Utils.is_i32b_array_opaque 
             (v ${crate::simd::traits::specs::FIELD_MAX}) 
-            (i0._super_i2.f_repr (Seq.index (Seq.index re_vector i).f_simd_units j)))"#))]
+            (i0._super_i2.f_repr (Seq.index (Seq.index re_vector i).f_simd_units j)))"#)))]
 pub(crate) fn use_hint<SIMDUnit: Operations>(
     gamma2: Gamma2,
     hint: &[[i32; COEFFICIENTS_IN_RING_ELEMENT]],
@@ -208,6 +215,7 @@ pub(crate) fn use_hint<SIMDUnit: Operations>(
     let old_re_vector = old_re_vector_vec.as_slice();
 
     for i in 0..re_vector.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             ${re_vector.len()} == ${hint.len()} /\
@@ -220,6 +228,7 @@ pub(crate) fn use_hint<SIMDUnit: Operations>(
         PolynomialRingElement::<SIMDUnit>::from_i32_array(&hint[i], &mut tmp);
 
         for j in 0..re_vector[0].simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|j: usize| fstar!(
                 r#"
                 ${re_vector.len()} == ${hint.len()} /\

--- a/libcrux-ml-dsa/src/constants.rs
+++ b/libcrux-ml-dsa/src/constants.rs
@@ -157,7 +157,7 @@ pub(crate) mod ml_dsa_87 {
     pub(crate) const COMMITMENT_HASH_SIZE: usize = 64;
 }
 
-#[hax_lib::requires(ones_in_verifier_challenge <= 60)]
+#[cfg_attr(hax, hax_lib::requires(ones_in_verifier_challenge <= 60))]
 pub(crate) const fn beta(ones_in_verifier_challenge: usize, eta: Eta) -> i32 {
     // [eurydice] can't handle conversion of enum into a usize
     let eta_val: usize = match eta {
@@ -167,22 +167,22 @@ pub(crate) const fn beta(ones_in_verifier_challenge: usize, eta: Eta) -> i32 {
     (ones_in_verifier_challenge * eta_val) as i32
 }
 
-#[hax_lib::requires(bits_per_error_coefficient <= 4)]
+#[cfg_attr(hax, hax_lib::requires(bits_per_error_coefficient <= 4))]
 pub(crate) const fn error_ring_element_size(bits_per_error_coefficient: usize) -> usize {
     (bits_per_error_coefficient * COEFFICIENTS_IN_RING_ELEMENT) / 8
 }
 
-#[hax_lib::requires(bits_per_gamma1_coefficient <= 20)]
+#[cfg_attr(hax, hax_lib::requires(bits_per_gamma1_coefficient <= 20))]
 pub(crate) const fn gamma1_ring_element_size(bits_per_gamma1_coefficient: usize) -> usize {
     (bits_per_gamma1_coefficient * COEFFICIENTS_IN_RING_ELEMENT) / 8
 }
 
-#[hax_lib::requires(bits_per_commitment_coefficient <= 6)]
+#[cfg_attr(hax, hax_lib::requires(bits_per_commitment_coefficient <= 6))]
 pub(crate) const fn commitment_ring_element_size(bits_per_commitment_coefficient: usize) -> usize {
     (bits_per_commitment_coefficient * COEFFICIENTS_IN_RING_ELEMENT) / 8
 }
 
-#[hax_lib::requires(bits_per_commitment_coefficient <= 6 && rows_in_a <= 8)]
+#[cfg_attr(hax, hax_lib::requires(bits_per_commitment_coefficient <= 6 && rows_in_a <= 8))]
 pub(crate) const fn commitment_vector_size(
     bits_per_commitment_coefficient: usize,
     rows_in_a: usize,
@@ -190,7 +190,7 @@ pub(crate) const fn commitment_vector_size(
     commitment_ring_element_size(bits_per_commitment_coefficient) * rows_in_a
 }
 
-#[hax_lib::requires(rows_in_a <= 8 && columns_in_a <= 7 && error_ring_element_size <= 128)]
+#[cfg_attr(hax, hax_lib::requires(rows_in_a <= 8 && columns_in_a <= 7 && error_ring_element_size <= 128))]
 pub(crate) const fn signing_key_size(
     rows_in_a: usize,
     columns_in_a: usize,
@@ -203,7 +203,7 @@ pub(crate) const fn signing_key_size(
         + rows_in_a * RING_ELEMENT_OF_T0S_SIZE
 }
 
-#[hax_lib::requires(rows_in_a <= 8)]
+#[cfg_attr(hax, hax_lib::requires(rows_in_a <= 8))]
 pub(crate) const fn verification_key_size(rows_in_a: usize) -> usize {
     SEED_FOR_A_SIZE
         + (COEFFICIENTS_IN_RING_ELEMENT
@@ -212,7 +212,7 @@ pub(crate) const fn verification_key_size(rows_in_a: usize) -> usize {
             / 8
 }
 
-#[hax_lib::requires(rows_in_a <= 8 && columns_in_a <= 7 && max_ones_in_hint <= 80 && commitment_hash_size <= 64 && bits_per_gamma1_coefficient <= 20)]
+#[cfg_attr(hax, hax_lib::requires(rows_in_a <= 8 && columns_in_a <= 7 && max_ones_in_hint <= 80 && commitment_hash_size <= 64 && bits_per_gamma1_coefficient <= 20))]
 pub(crate) const fn signature_size(
     rows_in_a: usize,
     columns_in_a: usize,

--- a/libcrux-ml-dsa/src/polynomial.rs
+++ b/libcrux-ml-dsa/src/polynomial.rs
@@ -3,12 +3,12 @@ use crate::simd::traits::specs::*;
 use crate::simd::traits::{Operations, COEFFICIENTS_IN_SIMD_UNIT, SIMD_UNITS_IN_RING_ELEMENT};
 
 #[derive(Clone, Copy)]
-#[hax_lib::fstar::after("open Libcrux_ml_dsa.Simd.Traits.Specs")]
+#[cfg_attr(hax, hax_lib::fstar::after("open Libcrux_ml_dsa.Simd.Traits.Specs"))]
 pub(crate) struct PolynomialRingElement<SIMDUnit: Operations> {
     pub(crate) simd_units: [SIMDUnit; SIMD_UNITS_IN_RING_ELEMENT],
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
     #[inline(always)]
     // Barrett reduce all coefficients.
@@ -48,7 +48,7 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
         result
     }
 
-    #[hax_lib::requires(array.len() == 256)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == 256))]
     pub(crate) fn from_i32_array(array: &[i32], result: &mut Self) {
         for i in 0..SIMD_UNITS_IN_RING_ELEMENT {
             SIMDUnit::from_coefficient_array(
@@ -66,10 +66,10 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
         (forall i. Spec.Utils.is_i32b_array_opaque 
             (v ${FIELD_MAX}) 
-            (i0._super_i2.f_repr (Seq.index self.f_simd_units i)))"#))]
+            (i0._super_i2.f_repr (Seq.index self.f_simd_units i)))"#)))]
     /// CAUTION: This function must only be called with inputs for
     /// which it is safe to leak the index of a violating coefficient.
     ///
@@ -102,14 +102,15 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(fstar!(r#"forall i. 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. 
         add_pre (i0._super_i2.f_repr (Seq.index self.f_simd_units i)) 
-                (i0._super_i2.f_repr (Seq.index rhs.f_simd_units i))"#))]
+                (i0._super_i2.f_repr (Seq.index rhs.f_simd_units i))"#)))]
     pub(crate) fn add(&mut self, rhs: &Self) {
         #[cfg(hax)]
         let old_self = self.clone();
 
         for i in 0..self.simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| fstar!(
                 r#"forall j. j >= v i ==> 
                             Seq.index self.f_simd_units j == 
@@ -121,14 +122,15 @@ impl<SIMDUnit: Operations> PolynomialRingElement<SIMDUnit> {
     }
 
     #[inline(always)]
-    #[hax_lib::requires(fstar!(r#"forall i. 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. 
         sub_pre (i0._super_i2.f_repr (Seq.index self.f_simd_units i)) 
-                (i0._super_i2.f_repr (Seq.index rhs.f_simd_units i))"#))]
+                (i0._super_i2.f_repr (Seq.index rhs.f_simd_units i))"#)))]
     pub(crate) fn subtract(&mut self, rhs: &Self) {
         #[cfg(hax)]
         let old_self = self.clone();
 
         for i in 0..self.simd_units.len() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| fstar!(
                 r#"forall j. j >= v i ==> 
                         Seq.index self.f_simd_units j == 

--- a/libcrux-ml-dsa/src/sample.rs
+++ b/libcrux-ml-dsa/src/sample.rs
@@ -444,6 +444,7 @@ fn inside_out_shuffle(
     let mut done = false;
 
     for i in 0..randomness.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"v ${out_index} <= 256 /\
                (${done} \/ v ${out_index} < 256)"#
@@ -492,7 +493,6 @@ pub(crate) fn sample_challenge_ring_element<SIMDUnit: Operations, Shake256: shak
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{
         constants::COEFFICIENTS_IN_RING_ELEMENT,
         hash_functions,

--- a/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/arithmetic.rs
@@ -6,33 +6,35 @@ use crate::{
 };
 
 #[inline]
-#[hax_lib::fstar::before(r#"open Spec.Intrinsics"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(true)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"open Spec.Intrinsics"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(true))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     forall i. if v (to_i32x8 $t i) < 0 
               then to_i32x8 $result i = to_i32x8 $t i +! $FIELD_MODULUS
               else to_i32x8 $result i = to_i32x8 $t i)) =
-"#))]
+"#)))]
 fn to_unsigned_representatives_ret(t: &Vec256) -> Vec256 {
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #i32_inttype)");
 
     let signs = mm256_srai_epi32::<31>(*t);
     let conditional_add_field_modulus = mm256_and_si256(signs, mm256_set1_epi32(FIELD_MODULUS));
 
+    #[cfg(hax)]
     hax_lib::fstar!(r"logand_lemma $FIELD_MODULUS (mk_i32 0)");
 
     mm256_add_epi32(*t, conditional_add_field_modulus)
 }
 
 #[inline]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(true)]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(true))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     forall i. if v (to_i32x8 $t i) < 0 
               then to_i32x8 tt_future i = to_i32x8 $t i +! $FIELD_MODULUS
               else to_i32x8 tt_future i = to_i32x8 $t i)) =
-"#))]
+"#)))]
 fn to_unsigned_representatives(t: &mut Vec256) {
     *t = to_unsigned_representatives_ret(t);
 }
@@ -49,12 +51,13 @@ pub(super) fn subtract(lhs: &mut Vec256, rhs: &Vec256) {
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     forall i. to_i32x8 ${result} i == 
               Spec.MLDSA.Math.mont_mul (to_i32x8 ${lhs} i) $constant
-"#))]
+"#)))]
 pub(super) fn montgomery_multiply_by_constant(lhs: Vec256, constant: i32) -> Vec256 {
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%Spec.MLDSA.Math.mont_mul) (Spec.MLDSA.Math.mont_mul)");
 
     let rhs = mm256_set1_epi32(constant);
@@ -82,24 +85,25 @@ pub(super) fn montgomery_multiply_by_constant(lhs: Vec256, constant: i32) -> Vec
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(
     hax_lib::eq(field_modulus, mm256_set1_epi32(FIELD_MODULUS)).and(hax_lib::eq(
         inverse_of_modulus_mod_montgomery_r,
         mm256_set1_epi32(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i32),
     ))
-)]
-#[hax_lib::ensures(|_| fstar!(r#"
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     forall i. to_i32x8 ${lhs}_future i ==
               Spec.MLDSA.Math.mont_mul (to_i32x8 ${lhs} i) (to_i32x8 ${rhs} i)
-"#))]
-#[hax_lib::fstar::verification_status(panic_free)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
 pub(super) fn montgomery_multiply_aux(
     field_modulus: Vec256,
     inverse_of_modulus_mod_montgomery_r: Vec256,
     lhs: &mut Vec256,
     rhs: &Vec256,
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%Spec.MLDSA.Math.mont_mul) (Spec.MLDSA.Math.mont_mul)");
 
     let prod02 = mm256_mul_epi32(*lhs, *rhs);
@@ -121,11 +125,11 @@ pub(super) fn montgomery_multiply_aux(
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     forall i. to_i32x8 ${lhs}_future i == 
               Spec.MLDSA.Math.mont_mul (to_i32x8 ${lhs} i) (to_i32x8 ${rhs} i)
-"#))]
+"#)))]
 pub(super) fn montgomery_multiply(lhs: &mut Vec256, rhs: &Vec256) {
     let field_modulus = mm256_set1_epi32(FIELD_MODULUS);
     let inverse_of_modulus_mod_montgomery_r =
@@ -135,12 +139,13 @@ pub(super) fn montgomery_multiply(lhs: &mut Vec256, rhs: &Vec256) {
 }
 
 #[inline]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     (forall i. to_i32x8 ${simd_unit}_future i ==
-        Spec.MLDSA.Math.barrett_red (shift_left_opaque (to_i32x8 ${simd_unit} i) v_SHIFT_BY))"#))]
+        Spec.MLDSA.Math.barrett_red (shift_left_opaque (to_i32x8 ${simd_unit} i) v_SHIFT_BY))"#)))]
 pub(super) fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Vec256) {
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%Spec.MLDSA.Math.barrett_red) (Spec.MLDSA.Math.barrett_red)");
 
     let mut shifted = mm256_slli_epi32::<SHIFT_BY>(*simd_unit);
@@ -150,11 +155,11 @@ pub(super) fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Vec256
 }
 
 #[inline]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     (forall i. to_i32x8 ${simd_unit}_future i ==
-        Spec.MLDSA.Math.barrett_red (to_i32x8 ${simd_unit} i))"#))]
-#[hax_lib::fstar::verification_status(panic_free)]
+        Spec.MLDSA.Math.barrett_red (to_i32x8 ${simd_unit} i))"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
 pub(super) fn barrett_reduce_simd_unit(simd_unit: &mut Vec256) {
     let quotient = mm256_add_epi32(*simd_unit, mm256_set1_epi32(1 << 22));
     let quotient = mm256_srai_epi32::<23>(quotient);
@@ -166,13 +171,13 @@ pub(super) fn barrett_reduce_simd_unit(simd_unit: &mut Vec256) {
 }
 
 #[inline]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 300")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
-    (forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 ${simd_unit} i))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
+    (forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 ${simd_unit} i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     $result == false <==> 
-        (forall i. Spec.Utils.is_i32b (v $bound - 1) (to_i32x8 ${simd_unit} i))"#))]
+        (forall i. Spec.Utils.is_i32b (v $bound - 1) (to_i32x8 ${simd_unit} i))"#)))]
 pub(super) fn infinity_norm_exceeds(simd_unit: &Vec256, bound: i32) -> bool {
     let absolute_values = mm256_abs_epi32(*simd_unit);
 
@@ -185,22 +190,24 @@ pub(super) fn infinity_norm_exceeds(simd_unit: &Vec256, bound: i32) -> bool {
     // If every lane of |result| is 0, all coefficients are <= bound - 1
     let result = mm256_testz_si256(compare_with_bound, compare_with_bound);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r"logand_lemma_forall #i32_inttype");
 
     result != 1
 }
 
 #[inline]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
-    forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 $r0 i)"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
+    forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 $r0 i)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     forall i. 
         let (t0, t1) = Spec.MLDSA.Math.power2round (v (to_i32x8 $r0 i)) in
         (to_i32x8 ${r0}_future i == mk_i32 t0 /\
          to_i32x8 ${r1}_future i == mk_i32 t1 /\
-         Spec.Utils.is_i32b (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) (to_i32x8 ${r0}_future i))"#))]
+         Spec.Utils.is_i32b (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) (to_i32x8 ${r0}_future i))"#)))]
 pub(super) fn power2round(r0: &mut Vec256, r1: &mut Vec256) {
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #i32_inttype");
 
     to_unsigned_representatives(r0);
@@ -217,14 +224,14 @@ pub(super) fn power2round(r0: &mut Vec256, r1: &mut Vec256) {
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
-    (forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 $r i))"#))]
-#[hax_lib::ensures(|(r0,r1)| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
+    (forall i. Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) (to_i32x8 $r i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|(r0,r1)| fstar!(r#"
     forall i.
     let (r0_s, r1_s) = Spec.MLDSA.Math.decompose_spec $gamma2 (to_i32x8 $r i) in
     to_i32x8 ${r0}_future i = r0_s /\ 
-    to_i32x8 ${r1}_future i = r1_s"#))]
+    to_i32x8 ${r1}_future i = r1_s"#)))]
 pub(super) fn decompose(gamma2: Gamma2, r: &Vec256, r0: &mut Vec256, r1: &mut Vec256) {
     let r = to_unsigned_representatives_ret(r);
 
@@ -281,8 +288,8 @@ pub(super) fn decompose(gamma2: Gamma2, r: &Vec256, r0: &mut Vec256, r1: &mut Ve
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(super) fn compute_hint(low: &Vec256, high: &Vec256, gamma2: i32, hint: &mut Vec256) -> usize {
     let minus_gamma2 = mm256_set1_epi32(-gamma2);
     let gamma2 = mm256_set1_epi32(gamma2);
@@ -308,8 +315,8 @@ pub(super) fn compute_hint(low: &Vec256, high: &Vec256, gamma2: i32, hint: &mut 
 
 // Not using inline always here regresses performance significantly.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(super) fn use_hint(gamma2: Gamma2, r: &Vec256, hint: &mut Vec256) {
     let (mut r0, mut r1) = (mm256_setzero_si256(), mm256_setzero_si256());
     decompose(gamma2, r, &mut r0, &mut r1);

--- a/libcrux-ml-dsa/src/simd/avx2/encoding/commitment.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/encoding/commitment.rs
@@ -1,14 +1,14 @@
 use libcrux_intrinsics::avx2::*;
 
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
       let open Spec.Intrinsics in
       forall (i: nat {i < 48}).
          (if i < 24 then result.(mk_int i) else result.(mk_int (128 + i - 24)))
       == (${simd_unit}.(mk_int ((i / 6) * 32 + i % 6)))
     "#
-    ))]
-#[hax_lib::fstar::options("--ifuel 0 --z3rlimit 380")]
-#[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+)))]
+#[cfg_attr(hax, hax_lib::fstar::options("--ifuel 0 --z3rlimit 380"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
 #[inline(always)]
 // This function is purely AVX2 operations, which makes the SMT proof with F* easy.
 fn serialize_6(simd_unit: &Vec256) -> Vec256 {
@@ -49,12 +49,12 @@ fn serialize_6(simd_unit: &Vec256) -> Vec256 {
     mm256_srlv_epi32(adjacent_3_combined, mm256_set_epi32(0, 0, 0, 4, 0, 0, 0, 4))
 }
 
-#[hax_lib::fstar::options("--ifuel 0 --z3rlimit 380")]
-#[hax_lib::ensures(|result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::options("--ifuel 0 --z3rlimit 380"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r"
         let open Spec.Intrinsics in
           forall (i: nat{i < 32}).
                 ${result}.(mk_int i) == simd_unit.(mk_int ((i / 4) * 32 + i % 4))
-    "))]
+    ")))]
 #[inline(always)]
 // This function is purely AVX2 operations, which makes the SMT proof with F* easy.
 fn serialize_4(simd_unit: &Vec256) -> Vec128 {
@@ -75,14 +75,14 @@ fn serialize_4(simd_unit: &Vec256) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(out.len() == 4 || out.len() == 6)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::requires(out.len() == 4 || out.len() == 6))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
   let open Spec.Intrinsics in
   let bytes = Seq.length out in
      Seq.length out_future == Seq.length out
   /\ (forall (i: nat {i < bytes * 8}). u8_to_bv out_future.[mk_usize (i / 8)] (mk_int (i % 8)) == simd_unit.(mk_int (i / bytes * 32 + i % bytes)))
-"))]
-#[hax_lib::fstar::verification_status(panic_free)]
+")))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
 pub(in crate::simd::avx2) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 19];
 

--- a/libcrux-ml-dsa/src/simd/avx2/encoding/error.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/encoding/error.rs
@@ -3,16 +3,19 @@ use libcrux_intrinsics::avx2::*;
 use crate::simd::avx2::Eta;
 
 #[inline(always)]
-#[hax_lib::fstar::before("open Spec.Intrinsics")]
-#[hax_lib::fstar::options(
-    "--fuel 0 --ifuel 0 --z3rlimit 5000 --z3smtopt '(set-option :smt.arith.nl false)'"
+#[cfg_attr(hax, hax_lib::fstar::before("open Spec.Intrinsics"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(
+        "--fuel 0 --ifuel 0 --z3rlimit 5000 --z3smtopt '(set-option :smt.arith.nl false)'"
+    )
 )]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(r"forall (i: nat {i < 256}). i % 32 >= 3 ==> ${simd_unit_shifted}.(mk_int i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero")
-)]
-#[hax_lib::ensures(|result| {
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result| {
     fstar!(r"forall (i:nat{i < 24}). ${result}.(mk_int i) == ${simd_unit_shifted}.(mk_int ((i / 3) * 32 + i % 3))")
-})]
+}))]
 // `serialize_when_eta_is_2_aux` contains the AVX2-only pure operations.
 // This split is required for the F* proof to go through.
 fn serialize_when_eta_is_2_aux(simd_unit_shifted: Vec256) -> Vec128 {
@@ -47,19 +50,21 @@ fn serialize_when_eta_is_2_aux(simd_unit_shifted: Vec256) -> Vec128 {
 const ETA_2: i32 = 2;
 
 #[inline(always)]
-#[hax_lib::requires(fstar!("forall i. let x = (v $ETA_2 - v (to_i32x8 simd_unit i)) in x >= 0 && x <= 7"))]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!("forall i. let x = (v $ETA_2 - v (to_i32x8 simd_unit i)) in x >= 0 && x <= 7")))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
      Seq.length ${out}_future == 3
   /\ (forall (i:nat{i < 24}). u8_to_bv (Seq.index ${out}_future (i / 8)) (mk_int (i % 8))
                    == i32_to_bv ($ETA_2 -! to_i32x8 $simd_unit (mk_int (i / 3))) (mk_int (i % 3)))
-"#))]
-#[hax_lib::fstar::verification_status(lax)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn serialize_when_eta_is_2(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 16];
 
     let simd_unit_shifted = mm256_sub_epi32(mm256_set1_epi32(ETA_2), *simd_unit);
 
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #I32");
+    #[cfg(hax)]
     hax_lib::fstar!("i32_lt_pow2_n_to_bit_zero_lemma 3 $simd_unit_shifted");
     let adjacent_6_combined = serialize_when_eta_is_2_aux(simd_unit_shifted);
 
@@ -70,12 +75,12 @@ fn serialize_when_eta_is_2(simd_unit: &Vec256, out: &mut [u8]) {
 #[inline(always)]
 // `serialize_when_eta_is_4_aux` contains the AVX2-only pure operations.
 // This split makes the F* proof much faster and stable (seconds versus about a minute).
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(r"forall (i: nat {i < 256}). i % 32 >= 4 ==> ${simd_unit_shifted}.(mk_int i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero")
-)]
-#[hax_lib::ensures(|result| {
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result| {
     fstar!(r"forall (i:nat{i < 32}). ${result}.(mk_int i) == ${simd_unit_shifted}.(mk_int ((i / 4) * 32 + i % 4))")
-})]
+}))]
 fn serialize_when_eta_is_4_aux(simd_unit_shifted: Vec256) -> Vec128 {
     let adjacent_2_combined = mm256_sllv_epi32(
         simd_unit_shifted,
@@ -99,23 +104,27 @@ fn serialize_when_eta_is_4_aux(simd_unit_shifted: Vec256) -> Vec128 {
 const ETA_4: i32 = 4;
 
 #[inline(always)]
-#[hax_lib::requires(fstar!("forall i. let x = (v $ETA_4 - v (to_i32x8 simd_unit i)) in x >= 0 && x <= 15"))]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!("forall i. let x = (v $ETA_4 - v (to_i32x8 simd_unit i)) in x >= 0 && x <= 15")))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
      Seq.length ${out}_future == 4
   /\ (forall (i:nat{i < 32}). u8_to_bv (Seq.index ${out}_future (i / 8)) (mk_int (i % 8))
                    == i32_to_bv ($ETA_4 -! to_i32x8 $simd_unit (mk_int (i / 4))) (mk_int (i % 4)))
-"#))]
-#[hax_lib::fstar::verification_status(lax)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn serialize_when_eta_is_4(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 16];
 
     let simd_unit_shifted = mm256_sub_epi32(mm256_set1_epi32(ETA_4), *simd_unit);
 
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #I32");
+    #[cfg(hax)]
     hax_lib::fstar!("i32_lt_pow2_n_to_bit_zero_lemma 4 $simd_unit_shifted");
     let adjacent_4_combined = serialize_when_eta_is_4_aux(simd_unit_shifted);
 
+    #[cfg(hax)]
     hax_lib::fstar!("assert(forall (i:nat{i < 32}). to_i32x8 $simd_unit_shifted (mk_int (i / 4)) == mk_int 4 `sub_mod` to_i32x8 $simd_unit (mk_int (i / 4)))");
+    #[cfg(hax)]
     hax_lib::fstar!("assert(forall i. mk_int 4 `sub_mod` to_i32x8 simd_unit i == mk_int 4 -! to_i32x8 simd_unit i)");
 
     mm_storeu_bytes_si128(&mut serialized[0..16], adjacent_4_combined);
@@ -123,10 +132,10 @@ fn serialize_when_eta_is_4(simd_unit: &Vec256, out: &mut [u8]) {
     out.copy_from_slice(&serialized[0..4])
 }
 
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     fstar!("forall i. let x = (v (${eta as u8}) - v (to_i32x8 simd_unit i)) in x >= 0 && x <= (pow2 (v (${eta as u8})) - 1)")
-)]
-#[hax_lib::ensures(|_result| {
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| {
     let bytes = match eta {
         Eta::Two => 3,
         Eta::Four => 4,
@@ -137,7 +146,7 @@ fn serialize_when_eta_is_4(simd_unit: &Vec256, out: &mut [u8]) {
               u8_to_bv (Seq.index ${serialized}_future (i / 8)) (mk_int (i % 8))
            == i32_to_bv ((${eta as i32}) -! to_i32x8 $simd_unit (mk_int (i / v $bytes))) (mk_int (i % v $bytes)))
     "#)
-})]
+}))]
 #[inline(always)]
 pub fn serialize(eta: Eta, simd_unit: &Vec256, serialized: &mut [u8]) {
     // [eurydice] injects an unused variable here in the C code for some reason.
@@ -148,11 +157,11 @@ pub fn serialize(eta: Eta, simd_unit: &Vec256, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(bytes.len() == 3)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 3))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
   (forall (i: nat {i <  24}). u8_to_bv ${bytes}.[mk_usize (i / 8)] (mk_int (i % 8)) == ${result}.(mk_int (i / 3 * 32 + i % 3)))
 /\ (forall (i: nat {i < 256}). i % 32 >= 3 ==> Libcrux_core_models.Abstractions.Bit.Bit_Zero? ${result}.(mk_int i))
-"#))]
+"#)))]
 fn deserialize_to_unsigned_when_eta_is_2(bytes: &[u8]) -> Vec256 {
     #[cfg(not(eurydice))]
     debug_assert!(bytes.len() == 3);
@@ -177,11 +186,11 @@ fn deserialize_to_unsigned_when_eta_is_2(bytes: &[u8]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(bytes.len() == 4)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 4))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
   (forall (i: nat {i <  32}). u8_to_bv ${bytes}.[mk_usize (i / 8)] (mk_int (i % 8)) == ${result}.(mk_int (i / 4 * 32 + i % 4)))
 /\ (forall (i: nat {i < 256}). i % 32 >= 4 ==> Libcrux_core_models.Abstractions.Bit.Bit_Zero? ${result}.(mk_int i))
-"#))]
+"#)))]
 fn deserialize_to_unsigned_when_eta_is_4(bytes: &[u8]) -> Vec256 {
     #[cfg(not(eurydice))]
     debug_assert!(bytes.len() == 4);
@@ -206,7 +215,7 @@ fn deserialize_to_unsigned_when_eta_is_4(bytes: &[u8]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
 let deserialize_to_unsigned_post
   (eta: Libcrux_ml_dsa.Constants.t_Eta)
   (serialized: t_Slice u8{Seq.length serialized == (match eta with | Libcrux_ml_dsa.Constants.Eta_Two  -> 3 | Libcrux_ml_dsa.Constants.Eta_Four -> 4)})
@@ -217,13 +226,13 @@ let deserialize_to_unsigned_post
        result.(mk_int ((i / bytes) * 32 + i % bytes))) /\
     (forall (i: nat{i < 256}).
        i % 32 >= bytes ==> Libcrux_core_models.Abstractions.Bit.Bit_Zero? result.(mk_int i))
-"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(serialized.len() == match eta {
+"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == match eta {
     Eta::Two => 3,
     Eta::Four => 4,
-})]
-#[hax_lib::ensures(|result| fstar!("deserialize_to_unsigned_post $eta $serialized $result"))]
+}))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("deserialize_to_unsigned_post $eta $serialized $result")))]
 pub(crate) fn deserialize_to_unsigned(eta: Eta, serialized: &[u8]) -> Vec256 {
     match eta {
         Eta::Two => deserialize_to_unsigned_when_eta_is_2(serialized),
@@ -232,7 +241,7 @@ pub(crate) fn deserialize_to_unsigned(eta: Eta, serialized: &[u8]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
 module C = Libcrux_ml_dsa.Constants
 let deserialize_post (eta: C.t_Eta)
          (serialized: t_Slice u8 {Seq.length serialized == (match eta with | C.Eta_Two  -> 3 | C.Eta_Four -> 4)})
@@ -242,12 +251,12 @@ let deserialize_post (eta: C.t_Eta)
       (forall i. v (to_i32x8 result i) > minint I32)
     /\ ( let out_reverted = mk_i32x8 (fun i -> neg (to_i32x8 result i) `add_mod` eta_i32) in
         deserialize_to_unsigned_post eta serialized out_reverted)
-"#)]
-#[hax_lib::requires(serialized.len() == match eta {
+"#))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == match eta {
     Eta::Two => 3,
     Eta::Four => 4,
-})]
-#[hax_lib::ensures(|result| fstar!("deserialize_post $eta $serialized ${out}_future"))]
+}))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("deserialize_post $eta $serialized ${out}_future")))]
 pub(crate) fn deserialize(eta: Eta, serialized: &[u8], out: &mut Vec256) {
     let unsigned = deserialize_to_unsigned(eta, serialized);
 
@@ -257,6 +266,7 @@ pub(crate) fn deserialize(eta: Eta, serialized: &[u8], out: &mut Vec256) {
         Eta::Four => 4,
     };
     *out = mm256_sub_epi32(mm256_set1_epi32(eta_v), unsigned);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r"
     i32_bit_zero_lemma_to_lt_pow2_n_weak 4 $unsigned;

--- a/libcrux-ml-dsa/src/simd/avx2/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/encoding/gamma1.rs
@@ -1,7 +1,7 @@
 use libcrux_intrinsics::avx2::*;
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
 open Spec.Intrinsics
 let lemma_mm256_add_epi64_lemma_weaker lhs rhs (i: u64 {v i < 256})
   : Lemma
@@ -10,15 +10,15 @@ let lemma_mm256_add_epi64_lemma_weaker lhs rhs (i: u64 {v i < 256})
            /\ (Libcrux_core_models.Abstractions.Bit.Bit_Zero? rhs.(i) ==> (Libcrux_intrinsics.Avx2.mm256_add_epi64 lhs rhs).(i) == lhs.(i)))
     [SMTPat (Libcrux_intrinsics.Avx2.mm256_add_epi64 lhs rhs).(i)]
     = Spec.Intrinsics.mm256_add_epi64_lemma lhs rhs i
-"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 18 ==> simd_unit_shifted.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 18 ==> simd_unit_shifted.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 forall (i: nat {i < 8}) (j: nat {j < 18}).
   let offset = if i >= 4 then 56 else 0 in
   ${result}.(mk_int (i * 18 + j + offset)) == ${simd_unit_shifted}.(mk_int (i * 32 + j))
-"#))]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 100")]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 100"))]
 // `serialize_when_gamma1_is_2_pow_17_aux` contains the AVX2-only pure operations.
 // This split is required for the F* proof to go through.
 fn serialize_when_gamma1_is_2_pow_17_aux(simd_unit_shifted: Vec256) -> Vec256 {
@@ -39,20 +39,25 @@ fn serialize_when_gamma1_is_2_pow_17_aux(simd_unit_shifted: Vec256) -> Vec256 {
 const GAMMA1_2_POW_17: i32 = 1 << 17;
 
 #[inline(always)]
-#[hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 140 --split_queries always"#)]
-#[hax_lib::requires(fstar!(r#"forall i. let x = (v ${GAMMA1_2_POW_17} - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 18"#))]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 140 --split_queries always"#)
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. let x = (v ${GAMMA1_2_POW_17} - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 18"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
       Seq.length ${out}_future == 18
     /\ (forall (i:nat{i < 144}).
       u8_to_bv (Seq.index ${out}_future (i / 8)) (mk_int (i % 8))
    == i32_to_bv (${GAMMA1_2_POW_17} `sub_mod` to_i32x8 $simd_unit (mk_int (i / 18))) (mk_int (i % 18)))
-"#))]
-#[hax_lib::fstar::verification_status(lax)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn serialize_when_gamma1_is_2_pow_17(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 32];
 
     let simd_unit_shifted = mm256_sub_epi32(mm256_set1_epi32(GAMMA1_2_POW_17), *simd_unit);
+    #[cfg(hax)]
     hax_lib::fstar!("i32_lt_pow2_n_to_bit_zero_lemma 18 $simd_unit_shifted");
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #I32");
     let adjacent_4_combined = serialize_when_gamma1_is_2_pow_17_aux(simd_unit_shifted);
 
@@ -66,13 +71,13 @@ fn serialize_when_gamma1_is_2_pow_17(simd_unit: &Vec256, out: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 20 ==> ${simd_unit_shifted}.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 20 ==> ${simd_unit_shifted}.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 forall (i: nat {i < 8}) (j: nat {j < 20}).
        ${result}.(mk_int ((if i >= 4 then 48 else 0) + i * 20 + j))
     == ${simd_unit_shifted}.(mk_int (i * 32 + j))
-"#))]
+"#)))]
 // `serialize_when_gamma1_is_2_pow_19_aux` contains the AVX2-only pure operations.
 // This split is required for the F* proof to go through.
 fn serialize_when_gamma1_is_2_pow_19_aux(simd_unit_shifted: Vec256) -> Vec256 {
@@ -94,20 +99,25 @@ fn serialize_when_gamma1_is_2_pow_19_aux(simd_unit_shifted: Vec256) -> Vec256 {
 
 const GAMMA1_2_POW_19: i32 = 1 << 19;
 #[inline(always)]
-#[hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 140 --split_queries always"#)]
-#[hax_lib::requires(fstar!(r#"forall i. let x = (v ${GAMMA1_2_POW_19} - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 20"#))]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 140 --split_queries always"#)
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. let x = (v ${GAMMA1_2_POW_19} - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 20"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
       Seq.length ${out}_future == 20
     /\ (forall (i:nat{i < 160}).
       u8_to_bv (Seq.index ${out}_future (i / 8)) (mk_int (i % 8))
    == i32_to_bv (${GAMMA1_2_POW_19} `sub_mod` to_i32x8 $simd_unit (mk_int (i / 20))) (mk_int (i % 20)))
-"#))]
-#[hax_lib::fstar::verification_status(lax)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 32];
 
     let simd_unit_shifted = mm256_sub_epi32(mm256_set1_epi32(GAMMA1_2_POW_19), *simd_unit);
+    #[cfg(hax)]
     hax_lib::fstar!("i32_lt_pow2_n_to_bit_zero_lemma 20 $simd_unit_shifted");
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #I32");
     let adjacent_4_combined = serialize_when_gamma1_is_2_pow_19_aux(simd_unit_shifted);
 
@@ -119,6 +129,7 @@ fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Vec256, out: &mut [u8]) {
     let upper_4 = mm256_extracti128_si256::<1>(adjacent_4_combined);
     mm_storeu_bytes_si128(&mut serialized[10..26], upper_4);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
   // Thunk the two proofs, so that Z3 check them in parallel, and the SMT context is not polluted
@@ -137,7 +148,7 @@ fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Vec256, out: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      (v $gamma1_exponent == 17 \/ v $gamma1_exponent == 19)
   /\ (Seq.length serialized == v $gamma1_exponent + 1)
   /\ (
@@ -147,9 +158,9 @@ fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Vec256, out: &mut [u8]) {
     in
     forall i. let x = (v gamma_pow - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 (v $gamma1_exponent + 1)
   )
-"#))
+"#)))
 ]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
     let gamma_pow = match v $gamma1_exponent with
     | 17 -> $GAMMA1_2_POW_17
     | 19 -> $GAMMA1_2_POW_19
@@ -159,7 +170,7 @@ fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Vec256, out: &mut [u8]) {
     /\ (forall (i:nat{i < n_bytes * 8}).
       u8_to_bv (Seq.index ${serialized}_future (i / 8)) (mk_int (i % 8))
    == i32_to_bv (gamma_pow -! to_i32x8 $simd_unit (mk_int (i / n_bytes))) (mk_int (i % n_bytes)))
-"#))]
+"#)))]
 pub(crate) fn serialize(simd_unit: &Vec256, serialized: &mut [u8], gamma1_exponent: usize) {
     match gamma1_exponent {
         17 => serialize_when_gamma1_is_2_pow_17(simd_unit, serialized),
@@ -175,8 +186,10 @@ const GAMMA1_19: i32 = 1 << 19;
 const GAMMA1_19_TIMES_2_MASK: i32 = (GAMMA1_19 << 1) - 1;
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 type gamma1_exp = g:usize {v g == 17 \/ v g == 19}
 unfold let serialized_len (g: gamma1_exp) = v g + 1
 unfold let gamma1_of_exp (g: gamma1_exp) = match v g with | 17 -> $GAMMA1_17 | 19 -> $GAMMA1_19
@@ -192,10 +205,11 @@ let deserialize_unsigned_post
     (forall (i: nat{i < 256}).
        i % 32 >= bytes ==> Libcrux_core_models.Abstractions.Bit.Bit_Zero? result.(mk_int i))
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(serialized.len() == 18)]
-#[hax_lib::ensures(|_result| fstar!("deserialize_unsigned_post (mk_int 17) $serialized ${out}_future"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 18))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!("deserialize_unsigned_post (mk_int 17) $serialized ${out}_future")))]
 fn deserialize_when_gamma1_is_2_pow_17_unsigned(serialized: &[u8], out: &mut Vec256) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 18);
@@ -216,6 +230,7 @@ fn deserialize_when_gamma1_is_2_pow_17_unsigned(serialized: &[u8], out: &mut Vec
 
     let coefficients = mm256_srlv_epi32(coefficients, mm256_set_epi32(6, 4, 2, 0, 6, 4, 2, 0));
     let coefficients = mm256_and_si256(coefficients, mm256_set1_epi32(GAMMA1_17_TIMES_2_MASK));
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"let (): squash (deserialize_unsigned_post (mk_int 17) $serialized $coefficients) =
              i32_to_bv_pow2_min_one_lemma_fa 18
@@ -225,9 +240,9 @@ fn deserialize_when_gamma1_is_2_pow_17_unsigned(serialized: &[u8], out: &mut Vec
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(serialized.len() == 20)]
-#[hax_lib::ensures(|result| fstar!("deserialize_unsigned_post (mk_int 19) $serialized ${out}_future"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 20))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("deserialize_unsigned_post (mk_int 19) $serialized ${out}_future")))]
 fn deserialize_when_gamma1_is_2_pow_19_unsigned(serialized: &[u8], out: &mut Vec256) {
     // Each set of 5 bytes deserializes to 2 coefficients, and since each Vec256
     // can hold 8 such coefficients, we process 5 * (8 / 2) = 20 bytes in this
@@ -250,12 +265,13 @@ fn deserialize_when_gamma1_is_2_pow_19_unsigned(serialized: &[u8], out: &mut Vec
 
     let coefficients = mm256_srlv_epi32(coefficients, mm256_set_epi32(4, 0, 4, 0, 4, 0, 4, 0));
     let coefficients = mm256_and_si256(coefficients, mm256_set1_epi32(GAMMA1_19_TIMES_2_MASK));
+    #[cfg(hax)]
     hax_lib::fstar!("i32_to_bv_pow2_min_one_lemma_fa 20");
     *out = coefficients
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
+#[cfg_attr(hax, hax_lib::fstar::before(
     r#"
 let deserialize_post (gamma1_exponent: gamma1_exp)
          (serialized: t_Slice u8 {Seq.length serialized == v gamma1_exponent + 1})
@@ -264,13 +280,13 @@ let deserialize_post (gamma1_exponent: gamma1_exp)
     /\ ( let out_reverted = mk_i32x8 (fun i -> neg (to_i32x8 result i) `add_mod` gamma1_of_exp gamma1_exponent) in
         deserialize_unsigned_post gamma1_exponent serialized out_reverted)
 "#
-)]
-#[hax_lib::requires( match gamma1_exponent {
+))]
+#[cfg_attr(hax, hax_lib::requires( match gamma1_exponent {
         17 => serialized.len() == 18,
         19 => serialized.len() == 20,
         _ => false,
-})]
-#[hax_lib::ensures(|result| fstar!("deserialize_post $gamma1_exponent $serialized ${out}_future"))]
+}))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("deserialize_post $gamma1_exponent $serialized ${out}_future")))]
 pub(crate) fn deserialize(serialized: &[u8], out: &mut Vec256, gamma1_exponent: usize) {
     match gamma1_exponent as u8 {
         17 => deserialize_when_gamma1_is_2_pow_17_unsigned(serialized, out),
@@ -289,6 +305,7 @@ pub(crate) fn deserialize(serialized: &[u8], out: &mut Vec256, gamma1_exponent: 
 
     *out = mm256_sub_epi32(mm256_set1_epi32(gamma1), *out);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
     i32_bit_zero_lemma_to_lt_pow2_n_weak (v $gamma1_exponent + 1) $unsigned;

--- a/libcrux-ml-dsa/src/simd/avx2/encoding/t0.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/encoding/t0.rs
@@ -12,8 +12,8 @@ fn change_interval(simd_unit: &Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before("open Spec.Intrinsics")]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::before("open Spec.Intrinsics"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
 let mm256_add_epi64_lemma_smtpat lhs rhs (i: u64 {v i < 256})
   : Lemma
     (requires
@@ -26,12 +26,12 @@ let mm256_add_epi64_lemma_smtpat lhs rhs (i: u64 {v i < 256})
     )
     [SMTPat (Libcrux_intrinsics.Avx2.mm256_add_epi64 lhs rhs).(i)]
     = mm256_add_epi64_lemma lhs rhs i
-"#)]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 500")]
-#[hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 13 ==> ${simd_unit}.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#))]
-#[hax_lib::ensures(|out|fstar!(r#"
-forall (i: nat {i < 8}) (j: nat {j < 13}). ${out}.(mk_int (i * 13 + j)) == ${simd_unit}.(mk_int (i * 32 + j))
 "#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 500"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. v i % 32 >= 13 ==> ${simd_unit}.(i) == Libcrux_core_models.Abstractions.Bit.Bit_Zero"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out|fstar!(r#"
+forall (i: nat {i < 8}) (j: nat {j < 13}). ${out}.(mk_int (i * 13 + j)) == ${simd_unit}.(mk_int (i * 32 + j))
+"#)))]
 // `serialize_aux` contains the AVX2-only pure operations.
 // This split is required for the F* proof to go through.
 pub(crate) fn serialize_aux(simd_unit: Vec256) -> Vec128 {
@@ -55,22 +55,27 @@ pub(crate) fn serialize_aux(simd_unit: Vec256) -> Vec128 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 340 --split_queries always"#)]
-#[hax_lib::requires(fstar!(r#"forall i. let x = (v $POW_2_BITS_IN_LOWER_PART_OF_T_MINUS_ONE - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 13"#))]
-#[hax_lib::ensures(|_result| fstar!(r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(r#"--ifuel 0 --z3rlimit 340 --split_queries always"#)
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. let x = (v $POW_2_BITS_IN_LOWER_PART_OF_T_MINUS_ONE - v (to_i32x8 $simd_unit i)) in x >= 0 && x < pow2 13"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r#"
       Seq.length ${out}_future == 13
     /\ (forall (i:nat{i < 8 * 13}).
       u8_to_bv (Seq.index ${out}_future (i / 8)) (mk_int (i % 8))
    == i32_to_bv (         $POW_2_BITS_IN_LOWER_PART_OF_T_MINUS_ONE
                 `sub_mod` to_i32x8 $simd_unit (mk_int (i / 13))) (mk_int (i % 13)))
-"#))]
-#[hax_lib::fstar::verification_status(lax)]
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
     let mut serialized = [0u8; 16];
 
     let simd_unit_changed = change_interval(simd_unit);
 
+    #[cfg(hax)]
     hax_lib::fstar!("i32_lt_pow2_n_to_bit_zero_lemma 13 $simd_unit_changed");
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque_arithmetic_ops #I32");
     let bits_sequential = serialize_aux(simd_unit_changed);
     mm_storeu_bytes_si128(&mut serialized, bits_sequential);
@@ -79,8 +84,10 @@ pub(crate) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let deserialize_unsigned_post
   (serialized: t_Slice u8{Seq.length serialized == 13})
   (result: bv256)
@@ -91,10 +98,11 @@ let deserialize_unsigned_post
     (forall (i: nat{i < 256}).
        i % 32 >= bytes ==> Libcrux_core_models.Abstractions.Bit.Bit_Zero? result.(mk_int i))
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(serialized.len() == 13)]
-#[hax_lib::ensures(|_result| fstar!("deserialize_unsigned_post $serialized ${out}_future"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 13))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!("deserialize_unsigned_post $serialized ${out}_future")))]
 fn deserialize_unsigned(serialized: &[u8], out: &mut Vec256) {
     const COEFFICIENT_MASK: i32 = (1 << 13) - 1;
 
@@ -115,12 +123,13 @@ fn deserialize_unsigned(serialized: &[u8], out: &mut Vec256) {
 
     let coefficients = mm256_srlv_epi32(coefficients, mm256_set_epi32(3, 6, 1, 4, 7, 2, 5, 0));
     let coefficients = mm256_and_si256(coefficients, mm256_set1_epi32(COEFFICIENT_MASK));
+    #[cfg(hax)]
     hax_lib::fstar!("i32_to_bv_pow2_min_one_lemma_fa 13");
     *out = coefficients
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
+#[cfg_attr(hax, hax_lib::fstar::before(
     r#"
 let deserialize_post
          (serialized: t_Slice u8 {Seq.length serialized == 13})
@@ -129,9 +138,9 @@ let deserialize_post
     /\ ( let out_reverted = mk_i32x8 (fun i -> neg (to_i32x8 result i) `add_mod` $POW_2_BITS_IN_LOWER_PART_OF_T_MINUS_ONE) in
         deserialize_unsigned_post serialized out_reverted)
 "#
-)]
-#[hax_lib::requires(serialized.len() == 13)]
-#[hax_lib::ensures(|result| fstar!("deserialize_post $serialized ${out}_future"))]
+))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 13))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("deserialize_post $serialized ${out}_future")))]
 pub(crate) fn deserialize(serialized: &[u8], out: &mut Vec256) {
     #[cfg(not(eurydice))]
     debug_assert_eq!(serialized.len(), 13);
@@ -139,6 +148,7 @@ pub(crate) fn deserialize(serialized: &[u8], out: &mut Vec256) {
     #[cfg(hax)]
     let unsigned = out.clone();
     *out = change_interval(out);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r"
     i32_bit_zero_lemma_to_lt_pow2_n_weak 13 $unsigned;

--- a/libcrux-ml-dsa/src/simd/avx2/encoding/t1.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/encoding/t1.rs
@@ -1,16 +1,16 @@
 use libcrux_intrinsics::avx2::*;
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800")]
-#[hax_lib::fstar::before("open Spec.Intrinsics")]
-#[hax_lib::requires(out.len() == 10)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800"))]
+#[cfg_attr(hax, hax_lib::fstar::before("open Spec.Intrinsics"))]
+#[cfg_attr(hax, hax_lib::requires(out.len() == 10))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
    Seq.length ${out}_future == 10 /\
    (forall (i:nat).
      i < 80 ==>
        ${simd_unit}.(mk_int (32*(i/10) + (i%10))) == (u8_to_bv (Seq.index ${out}_future (i/8)))(mk_int (i % 8)))
-"))]
-#[hax_lib::fstar::verification_status(panic_free)]
+")))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
 pub(crate) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
     #[cfg(not(eurydice))]
     debug_assert!(out.len() == 10);
@@ -41,10 +41,10 @@ pub(crate) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 1 --z3rlimit 300")]
-#[hax_lib::fstar::before("open Spec.Intrinsics")]
-#[hax_lib::requires(bytes.len() == 10)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 1 --z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::fstar::before("open Spec.Intrinsics"))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 10))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
   (forall (i:nat).
     i < 80 ==>
       (u8_to_bv (Seq.index $bytes (i/8)))(mk_int (i%8)) == ${out}_future.(mk_int (32*(i/10) + (i%10)))
@@ -53,7 +53,7 @@ pub(crate) fn serialize(simd_unit: &Vec256, out: &mut [u8]) {
     j < 256 ==>
     j % 32 > 10 ==>
        ${out}_future.(mk_int j) == Libcrux_core_models.Abstractions.Bit.Bit_Zero
-  )"))]
+  )")))]
 pub(crate) fn deserialize(bytes: &[u8], out: &mut Vec256) {
     #[cfg(not(eurydice))]
     debug_assert_eq!(bytes.len(), 10);

--- a/libcrux-ml-dsa/src/simd/avx2/invntt.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/invntt.rs
@@ -5,11 +5,11 @@ use crate::simd::{avx2::AVX2SIMDUnit, traits::COEFFICIENTS_IN_SIMD_UNIT};
 
 #[inline(always)]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn invert_ntt_montgomery(re: &mut AVX2RingElement) {
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
     #[allow(unsafe_code)]
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     unsafe fn inv_inner(re: &mut AVX2RingElement) {
         invert_ntt_at_layer_0(re);
         invert_ntt_at_layer_1(re);
@@ -35,11 +35,11 @@ pub(crate) fn invert_ntt_montgomery(re: &mut AVX2RingElement) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r"open Spec.MLDSA.Ntt")]
-#[hax_lib::fstar::before(r"open Spec.Intrinsics")]
-#[hax_lib::fstar::before(r"open Spec.Utils")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|(a, b)| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r"open Spec.MLDSA.Ntt"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r"open Spec.Intrinsics"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r"open Spec.Utils"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|(a, b)| fstar!(r#"
 let nre0, nre1 = ${a}.f_value, ${b}.f_value in
 let re0, re1 = ${simd_unit0}, ${simd_unit1} in
 (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 1)) ==
@@ -58,7 +58,7 @@ let re0, re1 = ${simd_unit0}, ${simd_unit1} in
  inv_ntt_step $zeta12 (to_i32x8 re1 (mk_u64 4), to_i32x8 re1 (mk_u64 5)) /\
 (to_i32x8 nre1 (mk_u64 6), to_i32x8 nre1 (mk_u64 7)) ==
  inv_ntt_step $zeta13 (to_i32x8 re1 (mk_u64 6), to_i32x8 re1 (mk_u64 7))
-"#))]
+"#)))]
 fn simd_unit_invert_ntt_at_layer_0(
     simd_unit0: Vec256,
     simd_unit1: Vec256,
@@ -102,8 +102,8 @@ fn simd_unit_invert_ntt_at_layer_0(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|(a, b)| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|(a, b)| fstar!(r#"
 let nre0, nre1 = ${a}.f_value, ${b}.f_value in
 let re0, re1 = ${simd_unit0}, ${simd_unit1} in
 (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 2)) ==
@@ -122,7 +122,7 @@ inv_ntt_step zeta10 (to_i32x8 re1 (mk_u64 1), to_i32x8 re1 (mk_u64 3)) /\
 inv_ntt_step zeta11 (to_i32x8 re1 (mk_u64 4), to_i32x8 re1 (mk_u64 6)) /\
 (to_i32x8 nre1 (mk_u64 5), to_i32x8 nre1 (mk_u64 7)) ==
 inv_ntt_step zeta11 (to_i32x8 re1 (mk_u64 5), to_i32x8 re1 (mk_u64 7))
-"#))]
+"#)))]
 fn simd_unit_invert_ntt_at_layer_1(
     simd_unit0: Vec256,
     simd_unit1: Vec256,
@@ -155,8 +155,8 @@ fn simd_unit_invert_ntt_at_layer_1(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|(a, b)| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|(a, b)| fstar!(r#"
 let nre0, nre1 = ${a}.f_value, ${b}.f_value in
 let re0, re1 = ${simd_unit0}, ${simd_unit1} in
 (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 4)) ==
@@ -175,7 +175,7 @@ let re0, re1 = ${simd_unit0}, ${simd_unit1} in
  inv_ntt_step zeta1 (to_i32x8 re1 (mk_u64 2), to_i32x8 re1 (mk_u64 6)) /\
 (to_i32x8 nre1 (mk_u64 3), to_i32x8 nre1 (mk_u64 7)) ==
  inv_ntt_step zeta1 (to_i32x8 re1 (mk_u64 3), to_i32x8 re1 (mk_u64 7))
-"#))]
+"#)))]
 fn simd_unit_invert_ntt_at_layer_2(
     simd_unit0: Vec256,
     simd_unit1: Vec256,
@@ -205,8 +205,8 @@ fn simd_unit_invert_ntt_at_layer_2(
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -226,18 +226,18 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_0(re: &mut AVX2RingElement) {
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(index < 31)]
-    #[hax_lib::ensures(|result| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(index < 31))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
       let r = ${re}_future in
          modifies2_32 $re r $index ($index +! mk_int 1)
       /\ ( let (a, b) = simd_unit_invert_ntt_at_layer_0_ (Seq.index re (v $index)).f_value (Seq.index re (v $index + 1)).f_value 
                             $zeta00 $zeta01 $zeta02 $zeta03 $zeta10 $zeta11 $zeta12 $zeta13 in
            Seq.index r (v $index) == a /\ Seq.index r (v $index + 1) == b)
-    "#))]
+    "#)))]
     fn round(
         re: &mut AVX2RingElement,
         index: usize,
@@ -316,8 +316,8 @@ unsafe fn invert_ntt_at_layer_0(re: &mut AVX2RingElement) {
 
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -340,17 +340,17 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_1(re: &mut AVX2RingElement) {
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(index < 31)]
-    #[hax_lib::ensures(|result| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(index < 31))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
       let r = ${re}_future in
          modifies2_32 re r $index ($index +! mk_int 1)
       /\ ( let (a, b) = simd_unit_invert_ntt_at_layer_1_ (Seq.index re (v $index)).f_value (Seq.index re (v $index + 1)).f_value $zeta_00 $zeta_01 $zeta_10 $zeta_11 in
            Seq.index r (v $index) == a /\ Seq.index r (v $index + 1) == b)
-    "#))]
+    "#)))]
     fn round(
         re: &mut AVX2RingElement,
         index: usize,
@@ -389,8 +389,8 @@ unsafe fn invert_ntt_at_layer_1(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -412,17 +412,17 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_2(re: &mut AVX2RingElement) {
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(index < 31)]
-    #[hax_lib::ensures(|result| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(index < 31))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
       let r = ${re}_future in
          modifies2_32 re r $index ($index +! mk_int 1)
       /\ ( let (a, b) = simd_unit_invert_ntt_at_layer_2_ (Seq.index re (v $index)).f_value (Seq.index re (v $index + 1)).f_value $zeta1 $zeta2 in
            Seq.index r (v $index) == a /\ Seq.index r (v $index + 1) == b)
-    "#))]
+    "#)))]
     fn round(re: &mut AVX2RingElement, index: usize, zeta1: i32, zeta2: i32) {
         (re[index], re[index + 1]) =
             simd_unit_invert_ntt_at_layer_2(re[index].value, re[index + 1].value, zeta1, zeta2);
@@ -447,7 +447,7 @@ unsafe fn invert_ntt_at_layer_2(re: &mut AVX2RingElement) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
+#[cfg_attr(hax, hax_lib::fstar::before(
     r#"
 unfold let (∈) (x: nat) ((l, r): (nat & nat)) = x >= l && x < r
 unfold let outer_3_plus_inv_pointwise  (offset: nat) (step_by: nat {offset + step_by * 2 <= 32}) (zeta: i32)
@@ -470,18 +470,19 @@ let outer_3_plus_inv
     (re nre: t_Array Libcrux_ml_dsa.Simd.Avx2.Vector_type.t_Vec256 (mk_usize 32))
 = forall j. outer_3_plus_inv_pointwise offset step_by zeta current_j re nre j
 "#
-)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!("v $OFFSET + v $STEP_BY * 2 <= 32"))]
-#[hax_lib::ensures(|result| fstar!(r#"
+))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!("v $OFFSET + v $STEP_BY * 2 <= 32")))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     outer_3_plus_inv (v $OFFSET) (v $STEP_BY) v_ZETA (v $OFFSET + v $STEP_BY) $re ${re}_future
-"#))]
+"#)))]
 fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     re: &mut AVX2RingElement,
 ) {
     #[cfg(hax)]
     let _re0 = re.clone();
     for j in OFFSET..OFFSET + STEP_BY {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|j: usize| fstar!(
             r#"outer_3_plus_inv (v $OFFSET) (v $STEP_BY) $ZETA (v $j) $_re0 $re"#
         ));
@@ -492,6 +493,7 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
         re[j + STEP_BY] = AVX2SIMDUnit {
             value: arithmetic::montgomery_multiply_by_constant(a_minus_b, ZETA),
         };
+        #[cfg(hax)]
         hax_lib::fstar!("assert (outer_3_plus_inv_pointwise (v $OFFSET) (v $STEP_BY) $ZETA (v $OFFSET + v $STEP_BY) ${_re0} ${re} (v j + v $STEP_BY))");
         ()
     }
@@ -499,7 +501,7 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
 let invert_ntt_outer_3_plus_spec
   (layer: nat {layer >= 3 && layer <= 7})
   (re nre: t_Array Libcrux_ml_dsa.Simd.Avx2.Vector_type.t_Vec256 (mk_usize 32))
@@ -516,12 +518,12 @@ let invert_ntt_outer_3_plus_spec
                     let nre_j'= (Seq.index nre (j + step_by)).f_value in
                     forall i. (to_i32x8 nre_j i, to_i32x8 nre_j' i) == inv_ntt_step zeta (to_i32x8 re_j i, to_i32x8 re_j' i)
                   end)
-"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
-norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 3 $re ${re}_future)
 "#))]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
+norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 3 $re ${re}_future)
+"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 unsafe fn invert_ntt_at_layer_3(re: &mut AVX2RingElement) {
     const STEP: usize = 8; // 1 << LAYER;
     const STEP_BY: usize = 1; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -546,10 +548,10 @@ unsafe fn invert_ntt_at_layer_3(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 4 $re ${re}_future)
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_4(re: &mut AVX2RingElement) {
     const STEP: usize = 16; // 1 << LAYER;
     const STEP_BY: usize = 2; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -566,10 +568,10 @@ unsafe fn invert_ntt_at_layer_4(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 5 $re ${re}_future)
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_5(re: &mut AVX2RingElement) {
     const STEP: usize = 32; // 1 << LAYER;
     const STEP_BY: usize = 4; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -582,10 +584,10 @@ unsafe fn invert_ntt_at_layer_5(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 6 $re ${re}_future)
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_6(re: &mut AVX2RingElement) {
     const STEP: usize = 64; // 1 << LAYER;
     const STEP_BY: usize = 8; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -596,10 +598,10 @@ unsafe fn invert_ntt_at_layer_6(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall32 ]] (invert_ntt_outer_3_plus_spec 7 $re ${re}_future)
-"#))]
+"#)))]
 unsafe fn invert_ntt_at_layer_7(re: &mut AVX2RingElement) {
     const STEP: usize = 128; // 1 << LAYER;
     const STEP_BY: usize = 16; // step / COEFFICIENTS_IN_SIMD_UNIT;

--- a/libcrux-ml-dsa/src/simd/avx2/ntt.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/ntt.rs
@@ -1,14 +1,16 @@
+use libcrux_intrinsics::avx2::*;
+
 use super::{arithmetic, AVX2RingElement, AVX2SIMDUnit};
 use crate::simd::traits::COEFFICIENTS_IN_SIMD_UNIT;
 
-use libcrux_intrinsics::avx2::*;
-
 // Compute (a,b) ↦ (a + ζb, a - ζb) at layer 0 for 2 SIMD Units in one go.
 #[inline(always)]
-#[hax_lib::fstar::before(r"open Spec.MLDSA.Ntt")]
-#[hax_lib::fstar::before(r"open Spec.Intrinsics")]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r"open Spec.MLDSA.Ntt"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r"open Spec.Intrinsics"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let butterfly_2_spec re0 re1 zeta_a0 zeta_a1 zeta_a2 zeta_a3 
                      zeta_b0 zeta_b1 zeta_b2 zeta_b3 nre0 nre1 =
     (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 1)) ==
@@ -28,17 +30,18 @@ let butterfly_2_spec re0 re1 zeta_a0 zeta_a1 zeta_a2 zeta_a3
     (to_i32x8 nre1 (mk_u64 6), to_i32x8 nre1 (mk_u64 7)) ==
      ntt_step zeta_b3 (to_i32x8 re1 (mk_u64 6), to_i32x8 re1 (mk_u64 7))
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(index < 31)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(index < 31))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
         butterfly_2_spec (Seq.index ${re} (v $index)).f_value
                          (Seq.index ${re} (v $index + 1)).f_value
                          $zeta_a0 $zeta_a1 $zeta_a2 $zeta_a3 $zeta_b0 $zeta_b1 $zeta_b2 $zeta_b3
                          (Seq.index ${re}_future (v $index)).f_value
                          (Seq.index ${re}_future (v $index + 1)).f_value /\
         Spec.Utils.modifies2_32 re ${re}_future $index ($index +! mk_int 1)
-"))]
+")))]
 fn butterfly_2(
     re: &mut AVX2RingElement,
     index: usize,
@@ -91,6 +94,7 @@ fn butterfly_2(
     let nre1 = mm256_shuffle_epi32::<SHUFFLE>(b_terms_shuffled);
 
     // This assert allows all the SMT Patterns to kick in and prove correctness
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (butterfly_2_spec 
                             $re0 $re1 $zeta_a0 $zeta_a1 $zeta_a2 $zeta_a3 
@@ -103,8 +107,10 @@ fn butterfly_2(
 
 // Compute (a,b) ↦ (a + ζb, a - ζb) at layer 1 for 2 SIMD Units in one go.
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let butterfly_4_spec re0 re1 zeta_a0 zeta_a1 zeta_b0 zeta_b1 nre0 nre1 =
     (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 2)) ==
     ntt_step zeta_a0 (to_i32x8 re0 (mk_u64 0), to_i32x8 re0 (mk_u64 2)) /\
@@ -123,17 +129,18 @@ let butterfly_4_spec re0 re1 zeta_a0 zeta_a1 zeta_b0 zeta_b1 nre0 nre1 =
     (to_i32x8 nre1 (mk_u64 5), to_i32x8 nre1 (mk_u64 7)) ==
     ntt_step zeta_b1 (to_i32x8 re1 (mk_u64 5), to_i32x8 re1 (mk_u64 7))
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(index < 31)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(index < 31))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
         butterfly_4_spec    (Seq.index ${re} (v $index)).f_value
                             (Seq.index ${re} (v $index + 1)).f_value
                             $zeta_a0 $zeta_a1 $zeta_b0 $zeta_b1
                             (Seq.index ${re}_future (v $index)).f_value
                             (Seq.index ${re}_future (v $index + 1)).f_value /\
         Spec.Utils.modifies2_32 $re ${re}_future $index ($index +! mk_int 1)
-"))]
+")))]
 fn butterfly_4(
     re: &mut AVX2RingElement,
     index: usize,
@@ -162,6 +169,7 @@ fn butterfly_4(
     let nre1 = mm256_unpackhi_epi64(add_terms, sub_terms);
 
     // This assert allows all the SMT Patterns to kick in and prove correctness
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (butterfly_4_spec 
         $re0 $re1 $zeta_a0 $zeta_a1 $zeta_b0 $zeta_b1 $nre0 $nre1)"#
@@ -173,8 +181,10 @@ fn butterfly_4(
 
 // Compute (a,b) ↦ (a + ζb, a - ζb) at layer 2 for 2 SIMD Units in one go.
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let butterfly_8_spec re0 re1 zeta0 zeta1 nre0 nre1 =
     (to_i32x8 nre0 (mk_u64 0), to_i32x8 nre0 (mk_u64 4)) ==
      ntt_step zeta0 (to_i32x8 re0 (mk_u64 0), to_i32x8 re0 (mk_u64 4)) /\
@@ -193,17 +203,18 @@ let butterfly_8_spec re0 re1 zeta0 zeta1 nre0 nre1 =
     (to_i32x8 nre1 (mk_u64 3), to_i32x8 nre1 (mk_u64 7)) ==
      ntt_step zeta1 (to_i32x8 re1 (mk_u64 3), to_i32x8 re1 (mk_u64 7))
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(index < 31)]
-#[hax_lib::ensures(|_result| fstar!(r"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(index < 31))]
+#[cfg_attr(hax, hax_lib::ensures(|_result| fstar!(r"
         butterfly_8_spec    (Seq.index ${re} (v $index)).f_value
                             (Seq.index ${re} (v $index + 1)).f_value
                             $zeta0 $zeta1
                             (Seq.index ${re}_future (v $index)).f_value
                             (Seq.index ${re}_future (v $index + 1)).f_value /\
         Spec.Utils.modifies2_32 $re ${re}_future $index ($index +! mk_int 1)
-"))]
+")))]
 fn butterfly_8(re: &mut AVX2RingElement, index: usize, zeta0: i32, zeta1: i32) {
     let re0 = re[index].value;
     let re1 = re[index + 1].value;
@@ -224,6 +235,7 @@ fn butterfly_8(re: &mut AVX2RingElement, index: usize, zeta0: i32, zeta1: i32) {
     let nre1 = mm256_permute2x128_si256::<0b0001_0011>(sub_terms, add_terms);
 
     // This assert allows all the SMT Patterns to kick in and prove correctness
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (butterfly_8_spec 
          $re0 $re1 $zeta0 $zeta1 $nre0 $nre1)"#
@@ -235,8 +247,8 @@ fn butterfly_8(re: &mut AVX2RingElement, index: usize, zeta0: i32, zeta1: i32) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -256,7 +268,7 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn ntt_at_layer_0(re: &mut AVX2RingElement) {
     butterfly_2(
         re, 0, 2091667, 3407706, 2316500, 3817976, -3342478, 2244091, -2446433, -3562462,
@@ -310,8 +322,8 @@ unsafe fn ntt_at_layer_0(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -334,7 +346,7 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn ntt_at_layer_1(re: &mut AVX2RingElement) {
     butterfly_4(re, 0, -3930395, -1528703, -3677745, -3041255);
     butterfly_4(re, 2, -1452451, 3475950, 2176455, -1585221);
@@ -356,8 +368,8 @@ unsafe fn ntt_at_layer_1(re: &mut AVX2RingElement) {
 
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Utils.forall16 ]] (
    Spec.Utils.forall16 (fun i ->
      let  nre = ${re}_future in
@@ -379,7 +391,7 @@ norm [primops; iota; delta_namespace [ `%zeta_r; `%Spec.Utils.forall4; `%Spec.Ut
      )
    )
 )
-"#))]
+"#)))]
 unsafe fn ntt_at_layer_2(re: &mut AVX2RingElement) {
     butterfly_8(re, 0, 2706023, 95776);
     butterfly_8(re, 2, 3077325, 3530437);
@@ -405,24 +417,24 @@ unsafe fn ntt_at_layer_2(re: &mut AVX2RingElement) {
 /// This is the same as in pqclean. The only difference is locality of registers.
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::options(r#"--fuel 0 --ifuel 0 --z3rlimit 200"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::options(r#"--fuel 0 --ifuel 0 --z3rlimit 200"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 unsafe fn ntt_at_layer_7_and_6(re: &mut AVX2RingElement) {
     let field_modulus = mm256_set1_epi32(crate::simd::traits::FIELD_MODULUS);
     let inverse_of_modulus_mod_montgomery_r =
         mm256_set1_epi32(crate::simd::traits::INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i32);
 
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires({
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires({
         use crate::constants::FIELD_MODULUS;
         use crate::simd::traits::INVERSE_OF_MODULUS_MOD_MONTGOMERY_R;
         use hax_lib::int::{ToInt, int};
         hax_lib::eq(field_modulus, mm256_set1_epi32(FIELD_MODULUS)).and(
             hax_lib::eq(inverse_of_modulus_mod_montgomery_r, mm256_set1_epi32(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i32))
         ).and(index.to_int() + step_by.to_int() < int!(32)).and(step_by > 0)
-    })]
-    #[hax_lib::ensures(|result| fstar!(r#"
+    }))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
         let re0 = (Seq.index $re (v $index)).f_value in
         let re1 = (Seq.index $re (v $index + v $step_by)).f_value in
         let nre0 = (Seq.index ${re}_future (v $index)).f_value in
@@ -432,7 +444,7 @@ unsafe fn ntt_at_layer_7_and_6(re: &mut AVX2RingElement) {
            (to_i32x8 nre0 (mk_u64 i), to_i32x8 nre1 (mk_u64 i)) ==
            ntt_step (to_i32x8 zeta (mk_int i)) (to_i32x8 re0 (mk_u64 i), to_i32x8 re1 (mk_u64 i))
         )
-    "#))]
+    "#)))]
     fn mul(
         re: &mut AVX2RingElement,
         index: usize,
@@ -515,12 +527,12 @@ unsafe fn ntt_at_layer_7_and_6(re: &mut AVX2RingElement) {
 /// pqclean does 4 * 4 on each layer -> 48 total | plus 4 * 4 shuffles every time (48)
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
 #[allow(unsafe_code)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 unsafe fn ntt_at_layer_5_to_3(re: &mut AVX2RingElement) {
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         (STEP == 8 || STEP == 16 || STEP == 32) && STEP_BY == STEP / COEFFICIENTS_IN_SIMD_UNIT && index < 128 / STEP
-    )]
+    ))]
     fn round<const STEP: usize, const STEP_BY: usize>(
         re: &mut AVX2RingElement,
         index: usize,
@@ -606,7 +618,7 @@ unsafe fn ntt_at_layer_5_to_3(re: &mut AVX2RingElement) {
 
 #[allow(unsafe_code)]
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
 pub(crate) fn ntt(re: &mut AVX2RingElement) {
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
     unsafe fn avx2_ntt(re: &mut AVX2RingElement) {

--- a/libcrux-ml-dsa/src/simd/avx2/vector_type.rs
+++ b/libcrux-ml-dsa/src/simd/avx2/vector_type.rs
@@ -1,5 +1,5 @@
 /// The vector type
-#[hax_lib::fstar::before("noeq")]
+#[cfg_attr(hax, hax_lib::fstar::before("noeq"))]
 #[derive(Clone, Copy)]
 #[repr(transparent)]
 pub(crate) struct Vec256 {

--- a/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
+++ b/libcrux-ml-dsa/src/simd/portable/arithmetic.rs
@@ -11,17 +11,20 @@ use crate::{
 pub(crate) const MONTGOMERY_SHIFT: u8 = 32;
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(add_pre(&lhs.values, &rhs.values))]
-#[hax_lib::ensures(|result| add_post(&lhs.values, &rhs.values, &(future(lhs).values)))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(add_pre(&lhs.values, &rhs.values)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| add_post(&lhs.values, &rhs.values, &(future(lhs).values))))]
 pub fn add(lhs: &mut Coefficients, rhs: &Coefficients) {
     #[cfg(hax)]
     let _lhs0 = lhs.clone();
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%$add_pre) ($add_pre)");
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%$add_post) ($add_post)");
 
     for i in 0..lhs.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             hax_lib::forall(|j: usize| {
                 hax_lib::implies(j < i, lhs.values[j] == _lhs0.values[j] + rhs.values[j])
@@ -38,17 +41,20 @@ pub fn add(lhs: &mut Coefficients, rhs: &Coefficients) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(sub_pre(&lhs.values, &rhs.values))]
-#[hax_lib::ensures(|result| sub_post(&lhs.values, &rhs.values, &(future(lhs).values)))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(sub_pre(&lhs.values, &rhs.values)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| sub_post(&lhs.values, &rhs.values, &(future(lhs).values))))]
 pub fn subtract(lhs: &mut Coefficients, rhs: &Coefficients) {
     #[cfg(hax)]
     let _lhs0 = lhs.clone();
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%$sub_pre) ($sub_pre)");
+    #[cfg(hax)]
     hax_lib::fstar!("reveal_opaque (`%$sub_post) ($sub_post)");
 
     for i in 0..lhs.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             hax_lib::forall(|j: usize| {
                 hax_lib::implies(j < i, lhs.values[j] == _lhs0.values[j] - rhs.values[j])
@@ -65,13 +71,14 @@ pub fn subtract(lhs: &mut Coefficients, rhs: &Coefficients) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(n <= 32)]
-#[hax_lib::ensures(|result| fstar!(r#"v result == v value % pow2(v n)"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(n <= 32))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"v result == v value % pow2(v n)"#)))]
 pub(crate) fn get_n_least_significant_bits(n: u8, value: u64) -> u64 {
     let res = value & ((1 << n) - 1);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "calc (==) {
             v res;
@@ -92,20 +99,22 @@ pub(crate) fn get_n_least_significant_bits(n: u8, value: u64) -> u64 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 900 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i64b (8380416 * pow2 32) value "#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b (8380416 + 4190209) result /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 900 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i64b (8380416 * pow2 32) value "#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b (8380416 + 4190209) result /\
                 (Spec.Utils.is_i64b (8380416 * pow2 31) value ==> Spec.Utils.is_i32b 8380416 result) /\
-                Spec.MLDSA.Math.(mod_q (v result) == mod_q (v value * 8265825))"#))]
+                Spec.MLDSA.Math.(mod_q (v result) == mod_q (v value * 8265825))"#)))]
 pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgomeryR {
     let t = get_n_least_significant_bits(MONTGOMERY_SHIFT, value as u64)
         * INVERSE_OF_MODULUS_MOD_MONTGOMERY_R;
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $t == (v $value % pow2 32) * 58728449)"#);
 
     let k = get_n_least_significant_bits(MONTGOMERY_SHIFT, t) as i32;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $k == v $t @% pow2 32);
         assert(v (cast ($k <: i32) <: i64) == v $k);
@@ -116,6 +125,7 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
 
     let k_times_modulus = (k as i64) * (FIELD_MODULUS as i64);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_mul_i32b (pow2 31) (8380417) $k $FIELD_MODULUS;
         assert (Spec.Utils.is_i64b (pow2 31 * 8380417) $k_times_modulus)"#
@@ -123,6 +133,7 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
 
     let c = (k_times_modulus >> MONTGOMERY_SHIFT) as i32;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $k_times_modulus < pow2 63);
         assert (v $k_times_modulus / pow2 32 < pow2 31);
@@ -133,6 +144,7 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
 
     let value_high = (value >> MONTGOMERY_SHIFT) as i32;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $value < pow2 63);
         assert (v $value / pow2 32 < pow2 31);
@@ -145,10 +157,12 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
 
     let res = value_high - c;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(Spec.Utils.is_i32b (8380416 + 4190209) $res);
         assert(Spec.Utils.is_i64b (8380416 * pow2 31) $value ==> Spec.Utils.is_i32b 58728448 $res)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"calc ( == ) {
             v $k_times_modulus % pow2 32;
@@ -168,6 +182,7 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
         Math.Lemmas.modulo_add (pow2 32) (- (v $k_times_modulus)) (v $value) (v $k_times_modulus);
         assert ((v $value - v $k_times_modulus) % pow2 32 == 0)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"calc ( == ) {
             v $res % 8380417;
@@ -189,42 +204,46 @@ pub(crate) fn montgomery_reduce_element(value: i64) -> FieldElementTimesMontgome
             (v $value * 8265825) % 8380417;
         }"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLDSA.Math.mod_q) (Spec.MLDSA.Math.mod_q)"#);
     res
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 4190208 fer"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b 8380416 $result /\
-    Spec.MLDSA.Math.(mod_q (v result) == mod_q (v fe * v fer * 8265825))"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 4190208 fer"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b 8380416 $result /\
+    Spec.MLDSA.Math.(mod_q (v result) == mod_q (v fe * v fer * 8265825))"#)))]
 pub(crate) fn montgomery_multiply_fe_by_fer(
     fe: FieldElement,
     fer: FieldElementTimesMontgomeryR,
 ) -> FieldElement {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i32b (pow2 31) (4190208) fe fer"#);
 
     montgomery_reduce_element((fe as i64) * (fer as i64))
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 4190208 $c"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 4190208 $c"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     Spec.Utils.is_i32b_array_opaque 8380416 ${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values /\
     Spec.MLDSA.Math.(forall i. i < 8 ==> 
         mod_q (v (Seq.index ${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) == 
-        mod_q (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * v $c * 8265825))"#))]
+        mod_q (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * v $c * 8265825))"#)))]
 pub(crate) fn montgomery_multiply_by_constant(simd_unit: &mut Coefficients, c: i32) {
     #[cfg(hax)]
     let _simd_unit0 = simd_unit.clone();
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..simd_unit.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -235,6 +254,7 @@ pub(crate) fn montgomery_multiply_by_constant(simd_unit: &mut Coefficients, c: i
               (forall j. j >= v $i ==> (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j) == (Seq.index ${_simd_unit0}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j))"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.Utils.lemma_mul_i32b (pow2 31) (4190208) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values.[ $i ] $c"#
         );
@@ -244,22 +264,24 @@ pub(crate) fn montgomery_multiply_by_constant(simd_unit: &mut Coefficients, c: i
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque 8380416 ${rhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque 8380416 ${rhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     Spec.Utils.is_i32b_array_opaque 8380416 ${lhs}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values /\
     Spec.MLDSA.Math.(forall i. i < 8 ==> 
         mod_q (v (Seq.index ${lhs}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) == 
-        mod_q (v (Seq.index ${lhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * v (Seq.index ${rhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * 8265825))"#))]
+        mod_q (v (Seq.index ${lhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * v (Seq.index ${rhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) * 8265825))"#)))]
 pub(crate) fn montgomery_multiply(lhs: &mut Coefficients, rhs: &Coefficients) {
     #[cfg(hax)]
     let _lhs0 = lhs.clone();
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..lhs.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -270,6 +292,7 @@ pub(crate) fn montgomery_multiply(lhs: &mut Coefficients, rhs: &Coefficients) {
               (forall j. j >= v $i ==> (Seq.index ${lhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j) == (Seq.index ${_lhs0}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j))"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.Utils.lemma_mul_i32b (pow2 31) (8380416) ${lhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values.[ $i ] ${rhs}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values.[ $i ]"#
         );
@@ -287,12 +310,16 @@ pub(crate) fn montgomery_multiply(lhs: &mut Coefficients, rhs: &Coefficients) {
 // We assume the input t is in the signed representative range and convert it
 // to the standard unsigned range.
 #[inline(always)]
-#[hax_lib::fstar::options("--ext context_pruning --z3refresh --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) $t"#))]
-#[hax_lib::ensures(|(t0,t1)| fstar!(r#"let (t0_s, t1_s) = Spec.MLDSA.Math.power2round (v $t) in
-    v $t0 == t0_s /\ v $t1 == t1_s /\ Spec.Utils.is_intb_bt (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) (v $t0)"#))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --z3refresh --split_queries always")
+)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) $t"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|(t0,t1)| fstar!(r#"let (t0_s, t1_s) = Spec.MLDSA.Math.power2round (v $t) in
+    v $t0 == t0_s /\ v $t1 == t1_s /\ Spec.Utils.is_intb_bt (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) (v $t0)"#)))]
 fn power2round_element(t: i32) -> (i32, i32) {
+    #[cfg(hax)]
     hax_lib::fstar!("logand_lemma $FIELD_MODULUS (t >>! mk_i32 31)");
     #[cfg(hax)]
     let _t = t;
@@ -300,6 +327,7 @@ fn power2round_element(t: i32) -> (i32, i32) {
     // Convert the signed representative to the standard unsigned one.
     let t = t + ((t >> 31) & FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!("assert (v $t == v $_t % v $FIELD_MODULUS)");
 
     // t0 = t - (2^{BITS_IN_LOWER_PART_OF_T} * t1)
@@ -309,6 +337,7 @@ fn power2round_element(t: i32) -> (i32, i32) {
     // on what these compute.
     let t1 = (t - 1 + (1 << (BITS_IN_LOWER_PART_OF_T - 1))) >> BITS_IN_LOWER_PART_OF_T;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v $t1 == (v $t - 1 + pow2 12) / pow2 13);
         assert ((v $t - (Spec.Utils.mod_p (v $t) (pow2 13))) / pow2 13 ==
@@ -326,6 +355,7 @@ fn power2round_element(t: i32) -> (i32, i32) {
 
     let t0 = t - (t1 << BITS_IN_LOWER_PART_OF_T);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v $t0 == v $t - ((v $t - (Spec.Utils.mod_p (v $t) (pow2 13))) / pow2 13) * pow2 13);
         assert (v $t0 == v $t - (v $t - (Spec.Utils.mod_p (v $t) (pow2 13))));
@@ -335,22 +365,24 @@ fn power2round_element(t: i32) -> (i32, i32) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${t0}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${t0}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     forall i. i < 8 ==>
         (let t0_v = v (Seq.index ${t0}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) in
         let (t0_s, t1_s) = Spec.MLDSA.Math.power2round (v (Seq.index ${t0}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) in
         t0_v == t0_s /\ v (Seq.index ${t1}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) == t1_s /\
-        Spec.Utils.is_intb_bt (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) t0_v)"#))]
+        Spec.Utils.is_intb_bt (pow2 (v $BITS_IN_LOWER_PART_OF_T - 1)) t0_v)"#)))]
 pub(super) fn power2round(t0: &mut Coefficients, t1: &mut Coefficients) {
     #[cfg(hax)]
     let _t0: Coefficients = t0.clone();
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..t0.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -370,13 +402,14 @@ pub(super) fn power2round(t0: &mut Coefficients, t1: &mut Coefficients) {
 // TODO: Revisit this function when doing the range analysis and testing
 // additional KATs.
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
-        Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
+        Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     $result == false ==> 
-        Spec.Utils.is_i32b_array_opaque (v $bound - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#))]
+        Spec.Utils.is_i32b_array_opaque (v $bound - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#)))]
 pub(super) fn infinity_norm_exceeds(simd_unit: &Coefficients, bound: i32) -> bool {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
@@ -386,6 +419,7 @@ pub(super) fn infinity_norm_exceeds(simd_unit: &Coefficients, bound: i32) -> boo
     // the probability for each coefficient is independent of secret
     // data but we must not leak the sign of the centralized representative.
     for i in 0..simd_unit.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -404,10 +438,12 @@ pub(super) fn infinity_norm_exceeds(simd_unit: &Coefficients, bound: i32) -> boo
         // don't convert it into a different representation.
         let sign = coefficient >> 31;
 
+        #[cfg(hax)]
         hax_lib::fstar!("logand_lemma (mk_i32 2 *! $coefficient) $sign");
 
         let normalized = coefficient - (sign & (2 * coefficient));
 
+        #[cfg(hax)]
         hax_lib::fstar!("assert (v $normalized == abs (v $coefficient))");
 
         // FIXME: return
@@ -419,14 +455,15 @@ pub(super) fn infinity_norm_exceeds(simd_unit: &Coefficients, bound: i32) -> boo
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 2143289343 $fe"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b 8380416 $result /\
-    Spec.MLDSA.Math.mod_q (v $result) == Spec.MLDSA.Math.mod_q (v $fe)"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b 2143289343 $fe"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i32b 8380416 $result /\
+    Spec.MLDSA.Math.mod_q (v $result) == Spec.MLDSA.Math.mod_q (v $fe)"#)))]
 fn barrett_reduce_element(fe: FieldElement) -> FieldElement {
     let quotient = (fe + (1 << 22)) >> 23;
     let result = fe - (quotient * FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "calc (==) {
         v $result % 8380417;
@@ -441,25 +478,27 @@ fn barrett_reduce_element(fe: FieldElement) -> FieldElement {
     }"
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLDSA.Math.mod_q) (Spec.MLDSA.Math.mod_q)"#);
     result
 }
 
 #[inline]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque 2143289343 (${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values)"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b_array_opaque 2143289343 (${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array_opaque 8380416 (${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) /\
     (forall i. i < 8 ==> Spec.MLDSA.Math.(
         mod_q (v (Seq.index ${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) ==
-        mod_q (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)))))"#))
+        mod_q (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)))))"#)))
 ]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn barrett_reduce_simd_unit(simd_unit: &mut Coefficients) {
     #[cfg(hax)]
     let _simd_unit0 = simd_unit.clone();
 
     for i in 0..simd_unit.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
                 (forall j. j < v i ==> (Spec.Utils.is_i32b 8380416 (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j) /\
@@ -472,23 +511,25 @@ pub(crate) fn barrett_reduce_simd_unit(simd_unit: &mut Coefficients) {
     }
 }
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
     (forall i. i < 8 ==> v (Seq.index (${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) i) >= 0 /\
-        v (Seq.index (${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) i) <= 261631)"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+        v (Seq.index (${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) i) <= 261631)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array_opaque 8380416 (${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) /\
     (forall i. i < 8 ==> Spec.MLDSA.Math.(
         mod_q (v (Seq.index ${simd_unit}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) ==
-        mod_q (v ((Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) <<! v_SHIFT_BY))))"#))]
+        mod_q (v ((Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) <<! v_SHIFT_BY))))"#)))]
 pub(super) fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Coefficients) {
     #[cfg(hax)]
     let _simd_unit0 = simd_unit.clone();
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..simd_unit.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
                 (forall j. j < v i ==> Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values j == 
@@ -503,9 +544,9 @@ pub(super) fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Coeffi
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232"#))]
-#[hax_lib::ensures(|result| fstar!(r#"v $result = Spec.MLDSA.Math.compute_one_hint (v $low) (v $high) (v $gamma2)"#))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"v $result = Spec.MLDSA.Math.compute_one_hint (v $low) (v $high) (v $gamma2)"#)))]
 fn compute_one_hint(low: i32, high: i32, gamma2: i32) -> i32 {
     if (low > gamma2) || (low < -gamma2) || (low == -gamma2 && high != 0) {
         1
@@ -515,14 +556,14 @@ fn compute_one_hint(low: i32, high: i32, gamma2: i32) -> i32 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     (forall i. i < 8 ==> (v (Seq.index ${hint}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) =
         Spec.MLDSA.Math.compute_one_hint (v (Seq.index ${low}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i))
             (v (Seq.index ${high}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) (v $gamma2))) /\
     v $result == Spec.MLDSA.Math.compute_hint ${hint}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#
-))]
+)))]
 pub(super) fn compute_hint(
     low: &Coefficients,
     high: &Coefficients,
@@ -531,11 +572,13 @@ pub(super) fn compute_hint(
 ) -> usize {
     let mut one_hints_count = 0;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.eq_repeati0 (sz 0) (Spec.MLDSA.Math.hint_counter ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) (0)"#
     );
 
     for i in 0..hint.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -553,6 +596,7 @@ pub(super) fn compute_hint(
 
         hint.values[i] = compute_one_hint(low.values[i], high.values[i], gamma2);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.MLDSA.Math.hint_counter_loop ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values $_hint_values (v i);
             Spec.Utils.unfold_repeati ($i +! sz 1) (Spec.MLDSA.Math.hint_counter ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values) (0) ($i)"#
@@ -579,34 +623,40 @@ pub(super) fn compute_hint(
 //
 // Note that 0 ≤ r₁ < (q-1)/α.
 #[inline(always)]
-#[hax_lib::fstar::options(
-    "--fuel 3 --z3rlimit 1500 --ext context_pruning --z3refresh --split_queries always"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(
+        "--fuel 3 --z3rlimit 1500 --ext context_pruning --z3refresh --split_queries always"
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
-    Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) $r"#))]
-#[hax_lib::ensures(|(r0,r1)| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
+    Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) $r"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|(r0,r1)| fstar!(r#"
     let (r0_s, r1_s, cond) = Spec.MLDSA.Math.decompose (v $gamma2) (v $r) in
     v $r0 = r0_s /\ v $r1 = r1_s /\
     (if cond then
         (v $r0 >= -(v $gamma2) /\ v $r0 < 0)
     else
         (v $r0 > -(v $gamma2) /\ v $r0 <= v $gamma2)) /\
-    (v $r1 >= 0 /\ v $r1 < (v $FIELD_MODULUS - 1) / (v $gamma2 * 2))"#))]
+    (v $r1 >= 0 /\ v $r1 < (v $FIELD_MODULUS - 1) / (v $gamma2 * 2))"#)))]
 fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
     #[cfg(hax)]
     let _r = r;
+    #[cfg(hax)]
     hax_lib::fstar!(r#"logand_lemma $FIELD_MODULUS ($r >>! mk_i32 31)"#);
 
     // Convert the signed representative to the standard unsigned one.
     let r = r + ((r >> 31) & FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $r == v $_r % v $FIELD_MODULUS)"#);
 
     let r1 = {
         // Compute ⌈r / 128⌉
         let ceil_of_r_by_128 = (r + 127) >> 7;
 
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (v $ceil_of_r_by_128 == (v $r + 127) / 128)"#);
 
         match gamma2 {
@@ -615,6 +665,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
                 // ⌊2²⁴ / 1488⌋ / 2²⁴ = 11,275 / 2²⁴
                 let result = ((ceil_of_r_by_128 * 11_275) + (1 << 23)) >> 24;
 
+                #[cfg(hax)]
                 hax_lib::fstar!(
                     r#"assert (v $result == ((v $ceil_of_r_by_128 * 11275) + pow2 23) / pow2 24);
                     assert (v $result == ((((v $r + 127) / 128) * 11275) + pow2 23) / pow2 24);
@@ -622,6 +673,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
                     assert (v $result == (v $r - (Spec.Utils.mod_p (v $r) 190464)) / 190464);
                     assert (v $result >= 0 /\ v $result <= 44)"#
                 );
+                #[cfg(hax)]
                 hax_lib::fstar!(
                     r#"logxor_lemma $result ((mk_i32 43 -! $result) >>! mk_i32 31);
                     lognot_lemma $result;
@@ -631,6 +683,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
                 // For the corner-case a₁ = (q-1)/α = 44, we have to set a₁=0.
                 let result_0 = (result ^ (43 - result) >> 31) & result;
 
+                #[cfg(hax)]
                 hax_lib::fstar!(
                     r#"assert (v $result == 44 ==> v $result_0 == 0);
                     assert (v $result < 44 ==> v $result_0 == v $result)"#
@@ -643,6 +696,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
                 // ⌊2²² / 4092⌋ / 2²² = 1025 / 2²²
                 let result = (ceil_of_r_by_128 * 1025 + (1 << 21)) >> 22;
 
+                #[cfg(hax)]
                 hax_lib::fstar!(
                     r#"assert (v $result == ((v $ceil_of_r_by_128 * 1025) + pow2 21) / pow2 22);
                     assert (v $result == ((((v $r + 127) / 128) * 1025) + pow2 21) / pow2 22);
@@ -650,11 +704,13 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
                     assert (v $result == (v $r - (Spec.Utils.mod_p (v $r) 523776)) / 523776);
                     assert (v $result >= 0 /\ v $result <= 16)"#
                 );
+                #[cfg(hax)]
                 hax_lib::fstar!(r#"logand_mask_lemma $result 4"#);
 
                 // For the corner-case a₁ = (q-1)/α = 16, we have to set a₁=0.
                 let result_0 = result & 15;
 
+                #[cfg(hax)]
                 hax_lib::fstar!(
                     r#"assert (v $result == 16 ==> v $result_0 == 0);
                     assert (v $result < 16 ==> v $result_0 == v $result)"#
@@ -672,6 +728,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
     #[cfg(hax)]
     let _r0 = r0;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"logand_lemma (((($FIELD_MODULUS -! mk_i32 1) /! mk_i32 2) -! $r0) >>! mk_i32 31)
             $FIELD_MODULUS"#
@@ -682,6 +739,7 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
     // return a₀ + q, that comes down to adding q if a₀ < (q-1)/2.
     r0 -= (((FIELD_MODULUS - 1) / 2 - r0) >> 31) & FIELD_MODULUS;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $_r0 > 4190208 ==> v $r0 == v $_r0 - 8380417);
         assert (v $_r0 <= 4190208 ==> v $r0 == v $_r0);
@@ -700,12 +758,15 @@ fn decompose_element(gamma2: Gamma2, r: i32) -> (i32, i32) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--ext context_pruning --z3refresh --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --z3refresh --split_queries always")
+)]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
     Spec.Utils.is_i32b (v $FIELD_MODULUS - 1) $r /\
-    (v $hint == 0 \/ v $hint == 1)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"v $result == Spec.MLDSA.Math.use_one_hint (v $gamma2) (v $r) (v $hint)"#))]
+    (v $hint == 0 \/ v $hint == 1)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"v $result == Spec.MLDSA.Math.use_one_hint (v $gamma2) (v $r) (v $hint)"#)))]
 pub(crate) fn use_one_hint(gamma2: Gamma2, r: i32, hint: i32) -> i32 {
     let (r0, r1) = decompose_element(gamma2, r);
     if hint == 0 {
@@ -728,6 +789,7 @@ pub(crate) fn use_one_hint(gamma2: Gamma2, r: i32, hint: i32) -> i32 {
         }
 
         GAMMA2_V261_888 => {
+            #[cfg(hax)]
             hax_lib::fstar!(
                 r#"logand_mask_lemma ($r1 +! $hint) 4;
                 logand_mask_lemma ($r1 -! $hint) 4"#
@@ -745,10 +807,10 @@ pub(crate) fn use_one_hint(gamma2: Gamma2, r: i32, hint: i32) -> i32 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
-    Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#))]
-#[hax_lib::ensures(|_| fstar!(r#"forall i. i < 8 ==>
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
+    Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"forall i. i < 8 ==>
     (let r = v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) in
     let r0 = v (Seq.index ${low}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) in
     let r1 = v (Seq.index ${high}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) in
@@ -758,18 +820,20 @@ pub(crate) fn use_one_hint(gamma2: Gamma2, r: i32, hint: i32) -> i32 {
         (r0 >= -(v $gamma2) /\ r0 < 0)
     else
         (r0 > -(v $gamma2) /\ r0 <= v $gamma2)) /\
-    (r1 >= 0 /\ r1 < (v $FIELD_MODULUS - 1) / (v $gamma2 * 2)))"#))]
+    (r1 >= 0 /\ r1 < (v $FIELD_MODULUS - 1) / (v $gamma2 * 2)))"#)))]
 pub fn decompose(
     gamma2: Gamma2,
     simd_unit: &Coefficients,
     low: &mut Coefficients,
     high: &mut Coefficients,
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..low.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -791,22 +855,24 @@ pub fn decompose(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $gamma2 == v $GAMMA2_V261_888 \/ v $gamma2 == v $GAMMA2_V95_232) /\
     Spec.Utils.is_i32b_array_opaque (v $FIELD_MODULUS - 1) ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values /\
-    (forall i. i < 8 ==> v (Seq.index ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) == 0 \/ v (Seq.index ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) == 1)"#))]
-#[hax_lib::ensures(|_| fstar!(r#"forall i. i < 8 ==>
+    (forall i. i < 8 ==> v (Seq.index ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) == 0 \/ v (Seq.index ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) == 1)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"forall i. i < 8 ==>
     (let h = Seq.index ${hint}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i in
     let result = Seq.index ${hint}_future.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i in
-    v result = Spec.MLDSA.Math.use_one_hint (v $gamma2) (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) (v h))"#))]
+    v result = Spec.MLDSA.Math.use_one_hint (v $gamma2) (v (Seq.index ${simd_unit}.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i)) (v h))"#)))]
 pub fn use_hint(gamma2: Gamma2, simd_unit: &Coefficients, hint: &mut Coefficients) {
     #[cfg(hax)]
     let _hint0 = hint.clone();
+    #[cfg(hax)]
     hax_lib::fstar!(
         "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
     );
 
     for i in 0..hint.values.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"

--- a/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/commitment.rs
@@ -1,8 +1,8 @@
 use crate::simd::portable::vector_type::Coefficients;
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r"Seq.length ${serialized} == 4 /\ (forall i. bounded (Seq.index ${simd_unit.values} i) 4)"))]
-#[hax_lib::ensures(|out| {
+#[cfg_attr(hax, hax_lib::requires(fstar!(r"Seq.length ${serialized} == 4 /\ (forall i. bounded (Seq.index ${simd_unit.values} i) 4)")))]
+#[cfg_attr(hax, hax_lib::ensures(|out| {
     let serialized_future = future(serialized);
     fstar!(r"
 Seq.length ${serialized_future} == Seq.length ${serialized} /\
@@ -10,7 +10,7 @@ Seq.length ${serialized_future} == Seq.length ${serialized} /\
  let out = bit_vec_of_int_t_array #U8  #(mk_usize 4) ${serialized_future} 8 in
  forall (i: nat {i < 8 * 4}). inp i == out i)
 ")
-})]
+}))]
 fn serialize_4(simd_unit: &Coefficients, serialized: &mut [u8]) {
     let coefficient0 = simd_unit.values[0] as u8;
     let coefficient1 = simd_unit.values[1] as u8;
@@ -33,9 +33,9 @@ fn serialize_4(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r"Seq.length ${serialized} == 6 /\ (forall i. bounded (Seq.index ${simd_unit.values} i) 6)"))]
-#[hax_lib::ensures(|out| {
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r"Seq.length ${serialized} == 6 /\ (forall i. bounded (Seq.index ${simd_unit.values} i) 6)")))]
+#[cfg_attr(hax, hax_lib::ensures(|out| {
     let serialized_future = future(serialized);
     fstar!(r"
 Seq.length ${serialized_future} == Seq.length ${serialized} /\
@@ -43,7 +43,7 @@ Seq.length ${serialized_future} == Seq.length ${serialized} /\
  let out = bit_vec_of_int_t_array #U8  #(mk_usize 6) ${serialized_future} 8 in
  forall (i: nat {i < 8 * 6}). inp i == out i)
 ")
-})]
+}))]
 pub fn serialize_6(simd_unit: &Coefficients, serialized: &mut [u8]) {
     // The commitment has coefficients in [0,43] => each coefficient occupies
     // 6 bits.
@@ -73,14 +73,14 @@ pub fn serialize_6(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(r"
         let d = Seq.length $serialized in
            (d == 4 \/ d == 6)
         /\ (forall i. bounded (Seq.index ${simd_unit.values} i) d)
     ")
-)]
-#[hax_lib::ensures(|out| {
+))]
+#[cfg_attr(hax, hax_lib::ensures(|out| {
     let serialized_future = future(serialized);
     fstar!(r"
 let d = Seq.length ${serialized} in
@@ -89,7 +89,7 @@ let d = Seq.length ${serialized} in
    let out = bit_vec_of_int_t_array #U8  #(mk_usize d) ${serialized_future} 8 in
    forall (i: nat {i < 8 * d}). inp i == out i))
 ")
-})]
+}))]
 pub(in crate::simd::portable) fn serialize(simd_unit: &Coefficients, serialized: &mut [u8]) {
     match serialized.len() as u8 {
         4 => serialize_4(simd_unit, serialized),

--- a/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/error.rs
@@ -1,7 +1,7 @@
 use crate::{constants::Eta, helper::cloop, simd::portable::vector_type::Coefficients};
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 2) /\ Seq.length $serialized == 3"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 2) /\ Seq.length $serialized == 3"#)))]
 fn serialize_when_eta_is_2(simd_unit: &Coefficients, serialized: &mut [u8]) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 3);
@@ -24,12 +24,13 @@ fn serialize_when_eta_is_2(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 4) /\ Seq.length $serialized == 4"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 4) /\ Seq.length $serialized == 4"#)))]
 fn serialize_when_eta_is_4(simd_unit: &Coefficients, serialized: &mut [u8]) {
     const ETA: i32 = 4;
 
     cloop! {
         for (i, coefficients) in simd_unit.values.chunks_exact(2).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 4);
             let coefficient0 = (ETA - coefficients[0]) as u8;
             let coefficient1 = (ETA - coefficients[1]) as u8;
@@ -40,10 +41,10 @@ fn serialize_when_eta_is_4(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Seq.length serialized == (match eta with | Libcrux_ml_dsa.Constants.Eta_Two -> 3 | Libcrux_ml_dsa.Constants.Eta_Four -> 4)
  /\ (forall i. bounded (Seq.index simd_unit.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) (match eta with | Libcrux_ml_dsa.Constants.Eta_Two -> 2 | Libcrux_ml_dsa.Constants.Eta_Four -> 4))
-"#))]
+"#)))]
 pub(crate) fn serialize(eta: Eta, simd_unit: &Coefficients, serialized: &mut [u8]) {
     // [eurydice] injects an unused variable here in the C code for some reason.
     match eta {
@@ -53,7 +54,7 @@ pub(crate) fn serialize(eta: Eta, simd_unit: &Coefficients, serialized: &mut [u8
 }
 
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == 3)]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 3))]
 fn deserialize_when_eta_is_2(serialized: &[u8], simd_unit: &mut Coefficients) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 3);
@@ -64,6 +65,7 @@ fn deserialize_when_eta_is_2(serialized: &[u8], simd_unit: &mut Coefficients) {
     let byte1 = serialized[1] as i32;
     let byte2 = serialized[2] as i32;
 
+    #[cfg(hax)]
     hax_lib::fstar!("let (): squash (forall (x: int_t I32). get_bit x (mk_int 31) == 0 ==> v x >= 0) = reveal_opaque (`%get_bit) (get_bit #I32) in ()");
 
     simd_unit.values[0] = ETA - (byte0 & 7);
@@ -77,7 +79,7 @@ fn deserialize_when_eta_is_2(serialized: &[u8], simd_unit: &mut Coefficients) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == 4)]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 4))]
 fn deserialize_when_eta_is_4(serialized: &[u8], simd_units: &mut Coefficients) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 4);
@@ -86,6 +88,7 @@ fn deserialize_when_eta_is_4(serialized: &[u8], simd_units: &mut Coefficients) {
 
     cloop! {
         for (i, byte) in serialized.iter().enumerate() {
+            #[cfg(hax)]
             hax_lib::fstar!("let (): squash (forall (x: int_t I32). get_bit x (mk_int 31) == 0 ==> v x >= 0) = reveal_opaque (`%get_bit) (get_bit #I32) in ()");
 
             simd_units.values[2 * i] = ETA - ((byte & 0xF) as i32);
@@ -94,7 +97,7 @@ fn deserialize_when_eta_is_4(serialized: &[u8], simd_units: &mut Coefficients) {
     }
 }
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == (match eta { Eta::Two => 3, Eta::Four => 4 }))]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == (match eta { Eta::Two => 3, Eta::Four => 4 })))]
 pub(crate) fn deserialize(eta: Eta, serialized: &[u8], out: &mut Coefficients) {
     // [eurydice] injects an unused variable here in the C code for some reason.
     //            That's why we don't match here.

--- a/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/gamma1.rs
@@ -1,12 +1,13 @@
 use crate::{helper::cloop, simd::portable::vector_type::Coefficients};
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 17) /\ Seq.length $serialized == 18"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 17) /\ Seq.length $serialized == 18"#)))]
 fn serialize_when_gamma1_is_2_pow_17(simd_unit: &Coefficients, serialized: &mut [u8]) {
     const GAMMA1: i32 = 1 << 17;
 
     cloop! {
         for (i, coefficients) in simd_unit.values.chunks_exact(4).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 18);
 
             let coefficient0 = GAMMA1 - coefficients[0];
@@ -37,12 +38,13 @@ fn serialize_when_gamma1_is_2_pow_17(simd_unit: &Coefficients, serialized: &mut 
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 19) /\ Seq.length $serialized == 20"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(forall i. bounded (Seq.index ${simd_unit.values} i) 19) /\ Seq.length $serialized == 20"#)))]
 fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Coefficients, serialized: &mut [u8]) {
     const GAMMA1: i32 = 1 << 19;
 
     cloop! {
         for (i, coefficients) in simd_unit.values.chunks_exact(2).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 20);
 
             let coefficient0 = GAMMA1 - coefficients[0];
@@ -61,11 +63,11 @@ fn serialize_when_gamma1_is_2_pow_19(simd_unit: &Coefficients, serialized: &mut 
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
        (v $gamma1_exponent == 17 \/ v $gamma1_exponent == 19)
     /\ (forall i. bounded (Seq.index ${simd_unit.values} i) (v $gamma1_exponent))
     /\ Seq.length $serialized == (1 + v $gamma1_exponent)
-"#))]
+"#)))]
 pub(crate) fn serialize(simd_unit: &Coefficients, serialized: &mut [u8], gamma1_exponent: usize) {
     match gamma1_exponent {
         17 => serialize_when_gamma1_is_2_pow_17(simd_unit, serialized),
@@ -75,7 +77,7 @@ pub(crate) fn serialize(simd_unit: &Coefficients, serialized: &mut [u8], gamma1_
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length $serialized == 18"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length $serialized == 18"#)))]
 fn deserialize_when_gamma1_is_2_pow_17(serialized: &[u8], simd_unit: &mut Coefficients) {
     // Each set of 9 bytes deserializes to 4 elements, and since each PortableSIMDUnit
     // can hold 8, we process 18 bytes in this function.
@@ -87,6 +89,7 @@ fn deserialize_when_gamma1_is_2_pow_17(serialized: &[u8], simd_unit: &mut Coeffi
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(9).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 18);
 
             let mut coefficient0 = bytes[0] as i32;
@@ -109,6 +112,7 @@ fn deserialize_when_gamma1_is_2_pow_17(serialized: &[u8], simd_unit: &mut Coeffi
             coefficient3 |= (bytes[8] as i32) << 10;
             coefficient3 &= GAMMA1_TIMES_2_BITMASK;
 
+            #[cfg(hax)]
             hax_lib::fstar!("let (): squash (forall (x: int_t I32). get_bit x (mk_int 31) == 0 ==> v x >= 0) = reveal_opaque (`%get_bit) (get_bit #I32) in ()");
 
             simd_unit.values[4 * i] = GAMMA1 - coefficient0;
@@ -120,7 +124,7 @@ fn deserialize_when_gamma1_is_2_pow_17(serialized: &[u8], simd_unit: &mut Coeffi
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length $serialized == 20"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length $serialized == 20"#)))]
 fn deserialize_when_gamma1_is_2_pow_19(serialized: &[u8], simd_unit: &mut Coefficients) {
     // Each set of 5 bytes deserializes to 2 elements, and since each PortableSIMDUnit
     // can hold 8, we process 5 * (8 / 2) = 20 bytes in this function.
@@ -141,6 +145,7 @@ fn deserialize_when_gamma1_is_2_pow_19(serialized: &[u8], simd_unit: &mut Coeffi
             coefficient1 |= (bytes[3] as i32) << 4;
             coefficient1 |= (bytes[4] as i32) << 12;
 
+            #[cfg(hax)]
             hax_lib::fstar!("let (): squash (forall (x: int_t I32). get_bit x (mk_int 31) == 0 ==> v x >= 0) = reveal_opaque (`%get_bit) (get_bit #I32) in ()");
 
             simd_unit.values[2 * i] = GAMMA1 - coefficient0;
@@ -150,7 +155,7 @@ fn deserialize_when_gamma1_is_2_pow_19(serialized: &[u8], simd_unit: &mut Coeffi
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length $serialized == 1 + v $gamma1_exponent"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length $serialized == 1 + v $gamma1_exponent"#)))]
 pub(crate) fn deserialize(serialized: &[u8], out: &mut Coefficients, gamma1_exponent: usize) {
     match gamma1_exponent {
         17 => deserialize_when_gamma1_is_2_pow_17(serialized, out),

--- a/libcrux-ml-dsa/src/simd/portable/encoding/t0.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/t0.rs
@@ -3,16 +3,16 @@ use crate::{constants::BITS_IN_LOWER_PART_OF_T, simd::portable::vector_type::Coe
 // If t0 is a signed representative, change it to an unsigned one and
 // vice versa.
 #[inline(always)]
-#[hax_lib::requires(t0 > i32::MIN + 4096)]
+#[cfg_attr(hax, hax_lib::requires(t0 > i32::MIN + 4096))]
 fn change_t0_interval(t0: i32) -> i32 {
     (1 << (BITS_IN_LOWER_PART_OF_T - 1)) - t0
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     (forall i. bounded (Seq.index simd_unit.Libcrux_ml_dsa.Simd.Portable.Vector_type.f_values i) 13)
  /\ (Seq.length $serialized == 13)
-"#))]
+"#)))]
 pub fn serialize(simd_unit: &Coefficients, serialized: &mut [u8]) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 13);
@@ -42,7 +42,7 @@ pub fn serialize(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == 13)]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 13))]
 pub fn deserialize(serialized: &[u8], simd_unit: &mut Coefficients) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 13);
@@ -99,6 +99,7 @@ pub fn deserialize(serialized: &[u8], simd_unit: &mut Coefficients) {
     coefficient7 |= byte12 << 5;
     coefficient7 &= BITS_IN_LOWER_PART_OF_T_MASK;
 
+    #[cfg(hax)]
     hax_lib::fstar!("let (): squash (forall (x: int_t I32). get_bit x (mk_int 31) == 0 ==> v x >= 0) = reveal_opaque (`%get_bit) (get_bit #I32) in ()");
 
     simd_unit.values[0] = change_t0_interval(coefficient0);

--- a/libcrux-ml-dsa/src/simd/portable/encoding/t1.rs
+++ b/libcrux-ml-dsa/src/simd/portable/encoding/t1.rs
@@ -3,13 +3,14 @@ use crate::{
 };
 
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == 10)]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 10))]
 pub fn serialize(simd_unit: &Coefficients, serialized: &mut [u8]) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 10);
 
     cloop! {
         for (i, coefficients) in simd_unit.values.chunks_exact(4).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 10);
 
             serialized[5 * i] = (coefficients[0] & 0xFF) as u8;
@@ -25,7 +26,7 @@ pub fn serialize(simd_unit: &Coefficients, serialized: &mut [u8]) {
 }
 
 #[inline(always)]
-#[hax_lib::requires(serialized.len() == 10)]
+#[cfg_attr(hax, hax_lib::requires(serialized.len() == 10))]
 pub fn deserialize(serialized: &[u8], simd_unit: &mut Coefficients) {
     #[cfg(not(eurydice))]
     debug_assert!(serialized.len() == 10);
@@ -34,6 +35,7 @@ pub fn deserialize(serialized: &[u8], simd_unit: &mut Coefficients) {
 
     cloop! {
         for (i, bytes) in serialized.chunks_exact(5).enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|_i: usize| serialized.len() == 10);
 
             let byte0 = bytes[0] as i32;

--- a/libcrux-ml-dsa/src/simd/portable/invntt.rs
+++ b/libcrux-ml-dsa/src/simd/portable/invntt.rs
@@ -7,9 +7,11 @@ use crate::simd::traits::specs::*;
 use crate::simd::traits::{COEFFICIENTS_IN_SIMD_UNIT, SIMD_UNITS_IN_RING_ELEMENT};
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let simd_layer_factor (step:usize) =
     match step with
     | MkInt 1 -> 1
@@ -17,23 +19,24 @@ let simd_layer_factor (step:usize) =
     | MkInt 4 -> 4
     | _ -> 5
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     v $step <= 4 /\ v $index + v $step < 8 /\    
     Spec.Utils.is_i32b (simd_layer_factor $step * v $FIELD_MAX)
                     (Seq.index ${simd_unit}.f_values (v $index)) /\
     Spec.Utils.is_i32b (simd_layer_factor $step * v $FIELD_MAX)
                     (Seq.index ${simd_unit}.f_values (v $index + v $step)) /\
     Spec.Utils.is_i32b 4190208 $zeta 
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.modifies2_8 ${simd_unit}.f_values ${simd_unit}_future.f_values index (index +! step) /\
     Spec.Utils.is_i32b (2 * (simd_layer_factor $step)  * v $FIELD_MAX)
                     (Seq.index ${simd_unit}_future.f_values (v $index)) /\
     Spec.Utils.is_i32b (2 * (simd_layer_factor $step)  * v $FIELD_MAX)
                     (Seq.index ${simd_unit}_future.f_values (v $index + v $step))
-"#) )]
+"#) ))]
 fn simd_unit_inv_ntt_step(simd_unit: &mut Coefficients, zeta: i32, index: usize, step: usize) {
     let a_minus_b = simd_unit.values[index + step] - simd_unit.values[index];
     simd_unit.values[index] = simd_unit.values[index] + simd_unit.values[index + step];
@@ -41,18 +44,18 @@ fn simd_unit_inv_ntt_step(simd_unit: &mut Coefficients, zeta: i32, index: usize,
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta0 /\
     Spec.Utils.is_i32b 4190208 $zeta1 /\
     Spec.Utils.is_i32b 4190208 $zeta2 /\
     Spec.Utils.is_i32b 4190208 $zeta3
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (2 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_invert_ntt_at_layer_0(
     simd_unit: &mut Coefficients,
     zeta0: i32,
@@ -67,16 +70,16 @@ pub fn simd_unit_invert_ntt_at_layer_0(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (2 * v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta0 /\
     Spec.Utils.is_i32b 4190208 $zeta1
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (4 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_invert_ntt_at_layer_1(simd_unit: &mut Coefficients, zeta0: i32, zeta1: i32) {
     simd_unit_inv_ntt_step(simd_unit, zeta0, 0, 2);
     simd_unit_inv_ntt_step(simd_unit, zeta0, 1, 2);
@@ -85,15 +88,15 @@ pub fn simd_unit_invert_ntt_at_layer_1(simd_unit: &mut Coefficients, zeta0: i32,
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (4 * v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (8 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_invert_ntt_at_layer_2(simd_unit: &mut Coefficients, zeta: i32) {
     simd_unit_inv_ntt_step(simd_unit, zeta, 0, 4);
     simd_unit_inv_ntt_step(simd_unit, zeta, 1, 4);
@@ -102,19 +105,19 @@ pub fn simd_unit_invert_ntt_at_layer_2(simd_unit: &mut Coefficients, zeta: i32) 
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (2 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 100")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (v $FIELD_MAX) 
             (Seq.index ${re} (v index)).f_values /\
@@ -122,12 +125,12 @@ fn invert_ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
         Spec.Utils.is_i32b 4190208 $zeta1 /\
         Spec.Utils.is_i32b 4190208 $zeta2 /\
         Spec.Utils.is_i32b 4190208 $zeta3
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (2* v $FIELD_MAX)
             (Seq.index ${re}_future (v index)).f_values
-     "#))]
+     "#)))]
     fn round(
         re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
         index: usize,
@@ -136,6 +139,7 @@ fn invert_ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
         zeta2: i32,
         zeta3: i32,
     ) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -177,36 +181,37 @@ fn invert_ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (2 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (4 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_1(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 100")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (2 * v $FIELD_MAX) 
             (Seq.index ${re} (v index)).f_values /\
         Spec.Utils.is_i32b 4190208 $zeta_00 /\
         Spec.Utils.is_i32b 4190208 $zeta_01
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (4 * v $FIELD_MAX)
             (Seq.index ${re}_future (v $index)).f_values
-     "#))]
+     "#)))]
     fn round(
         re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
         index: usize,
         zeta_00: i32,
         zeta_01: i32,
     ) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -248,30 +253,31 @@ fn invert_ntt_at_layer_1(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (4 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (8 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 100")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (4 * v $FIELD_MAX) 
             (Seq.index ${re} (v index)).f_values /\
         Spec.Utils.is_i32b 4190208 $zeta1
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (8 * v $FIELD_MAX)
             (Seq.index ${re}_future (v $index)).f_values
-     "#))]
+     "#)))]
     fn round(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT], index: usize, zeta1: i32) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -313,8 +319,10 @@ fn invert_ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let layer_bound_factor (step_by:usize) : n:nat{n <= 128} =
     match step_by with
     | MkInt 1 -> 8
@@ -323,10 +331,11 @@ let layer_bound_factor (step_by:usize) : n:nat{n <= 128} =
     | MkInt 8 -> 64
     | MkInt 16 -> 128
     | _ -> 128"#
+    )
 )]
-#[hax_lib::fstar::options("--z3rlimit 600 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 600 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     (v $STEP_BY > 0) /\
     (v $OFFSET + v $STEP_BY < v $SIMD_UNITS_IN_RING_ELEMENT) /\
     (v $OFFSET + 2 * v $STEP_BY <= v $SIMD_UNITS_IN_RING_ELEMENT) /\
@@ -335,14 +344,14 @@ let layer_bound_factor (step_by:usize) : n:nat{n <= 128} =
                 ((layer_bound_factor $STEP_BY) * v $FIELD_MAX)
                 (Seq.index ${re} i).f_values)) /\
     Spec.Utils.is_i32b 4190208 $ZETA
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.modifies_range_32 ${re} ${re}_future $OFFSET (${OFFSET + STEP_BY + STEP_BY}) /\
     (Spec.Utils.forall32 (fun i -> (i >= v $OFFSET /\ i < (v $OFFSET + 2 * v $STEP_BY)) ==>
               Spec.Utils.is_i32b_array_opaque 
                 (2 * (layer_bound_factor $STEP_BY) * v $FIELD_MAX)
                 (Seq.index ${re}_future i).f_values))
-"#))]
+"#)))]
 fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
 ) {
@@ -350,6 +359,7 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     let orig_re = re.clone();
 
     for j in OFFSET..OFFSET + STEP_BY {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|j: usize| fstar!(
             r#"
             (Spec.Utils.modifies_range2_32 $orig_re $re 
@@ -368,20 +378,21 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
         arithmetic::subtract(&mut re[j + STEP_BY], &rej);
         arithmetic::montgomery_multiply_by_constant(&mut re[j + STEP_BY], ZETA);
 
+        #[cfg(hax)]
         hax_lib::fstar!("Spec.Utils.is_i32b_array_larger 
             (v $FIELD_MAX) (2 * (layer_bound_factor $STEP_BY) * v $FIELD_MAX) (Seq.index re (v j + v v_STEP_BY)).f_values");
     }
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (8 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (16 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_3(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 8; // 1 << LAYER;
     const STEP_BY: usize = 1; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -405,14 +416,14 @@ fn invert_ntt_at_layer_3(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (16 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (32 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_4(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 16; // 1 << LAYER;
     const STEP_BY: usize = 2; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -428,14 +439,14 @@ fn invert_ntt_at_layer_4(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (32 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (64 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_5(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 32; // 1 << LAYER;
     const STEP_BY: usize = 4; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -447,14 +458,14 @@ fn invert_ntt_at_layer_5(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (64 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (128 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_6(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 64; // 1 << LAYER;
     const STEP_BY: usize = 8; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -464,14 +475,14 @@ fn invert_ntt_at_layer_6(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (128 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (256 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn invert_ntt_at_layer_7(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 128; // 1 << LAYER;
     const STEP_BY: usize = 16; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -480,14 +491,14 @@ fn invert_ntt_at_layer_7(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Libcrux_ml_dsa.Simd.Portable.Ntt.is_i32b_polynomial (v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 pub(crate) fn invert_ntt_montgomery(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     invert_ntt_at_layer_0(re);
     invert_ntt_at_layer_1(re);
@@ -499,6 +510,7 @@ pub(crate) fn invert_ntt_montgomery(re: &mut [Coefficients; SIMD_UNITS_IN_RING_E
     invert_ntt_at_layer_7(re);
 
     for i in 0..re.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             (forall (k:nat).

--- a/libcrux-ml-dsa/src/simd/portable/ntt.rs
+++ b/libcrux-ml-dsa/src/simd/portable/ntt.rs
@@ -1,14 +1,17 @@
-use super::arithmetic::{self, montgomery_multiply_by_constant, montgomery_multiply_fe_by_fer};
-use super::vector_type::Coefficients;
-use crate::simd::traits::{COEFFICIENTS_IN_SIMD_UNIT, SIMD_UNITS_IN_RING_ELEMENT};
-
+use super::{
+    arithmetic::{self, montgomery_multiply_by_constant, montgomery_multiply_fe_by_fer},
+    vector_type::Coefficients,
+};
 #[cfg(hax)]
 use crate::simd::traits::specs::*;
+use crate::simd::traits::{COEFFICIENTS_IN_SIMD_UNIT, SIMD_UNITS_IN_RING_ELEMENT};
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let simd_layer_factor (step:usize) =
     match step with
     | MkInt 1 -> 7
@@ -16,9 +19,10 @@ let simd_layer_factor (step:usize) =
     | MkInt 4 -> 5
     | _ -> 5
 "#
+    )
 )]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     v step <= 4 /\ v index + v step < 8 /\    
     Spec.Utils.is_i32b 
         (v $NTT_BASE_BOUND + (simd_layer_factor $step * v $FIELD_MAX))
@@ -27,8 +31,8 @@ let simd_layer_factor (step:usize) =
         (v $NTT_BASE_BOUND + (simd_layer_factor $step * v $FIELD_MAX))
         (Seq.index ${simd_unit}.f_values (v $index + v $step)) /\
     Spec.Utils.is_i32b 4190208 $zeta 
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.modifies2_8 ${simd_unit}.f_values ${simd_unit}_future.f_values index (index +! step) /\
     Spec.Utils.is_i32b 
         (v $NTT_BASE_BOUND + ((simd_layer_factor $step + 1)  * v $FIELD_MAX))
@@ -36,7 +40,7 @@ let simd_layer_factor (step:usize) =
     Spec.Utils.is_i32b 
         (v $NTT_BASE_BOUND + ((simd_layer_factor $step + 1)  * v $FIELD_MAX))
         (Seq.index ${simd_unit}_future.f_values (v $index + v $step))
-"#) )]
+"#) ))]
 fn simd_unit_ntt_step(simd_unit: &mut Coefficients, zeta: i32, index: usize, step: usize) {
     let t = montgomery_multiply_fe_by_fer(simd_unit.values[index + step], zeta);
     simd_unit.values[index + step] = simd_unit.values[index] - t;
@@ -44,18 +48,18 @@ fn simd_unit_ntt_step(simd_unit: &mut Coefficients, zeta: i32, index: usize, ste
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta0 /\
     Spec.Utils.is_i32b 4190208 $zeta1 /\
     Spec.Utils.is_i32b 4190208 $zeta2 /\
     Spec.Utils.is_i32b 4190208 $zeta3
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 8 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_ntt_at_layer_0(
     simd_unit: &mut Coefficients,
     zeta0: i32,
@@ -70,16 +74,16 @@ pub fn simd_unit_ntt_at_layer_0(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta1 /\
     Spec.Utils.is_i32b 4190208 $zeta2
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_ntt_at_layer_1(simd_unit: &mut Coefficients, zeta1: i32, zeta2: i32) {
     simd_unit_ntt_step(simd_unit, zeta1, 0, 2);
     simd_unit_ntt_step(simd_unit, zeta1, 1, 2);
@@ -88,15 +92,15 @@ pub fn simd_unit_ntt_at_layer_1(simd_unit: &mut Coefficients, zeta1: i32, zeta2:
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 5 * v $FIELD_MAX) ${simd_unit}.f_values /\
     Spec.Utils.is_i32b 4190208 $zeta
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.is_i32b_array (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX) ${simd_unit}_future.f_values
-"#) )]
+"#) ))]
 pub fn simd_unit_ntt_at_layer_2(simd_unit: &mut Coefficients, zeta: i32) {
     simd_unit_ntt_step(simd_unit, zeta, 0, 4);
     simd_unit_ntt_step(simd_unit, zeta, 1, 4);
@@ -105,23 +109,23 @@ pub fn simd_unit_ntt_at_layer_2(simd_unit: &mut Coefficients, zeta: i32) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"
     let is_i32b_polynomial (b:nat) (re:t_Array Libcrux_ml_dsa.Simd.Portable.Vector_type.t_Coefficients (sz 32)) =
         Spec.Utils.forall32 (fun x -> Spec.Utils.is_i32b_array_opaque b (Seq.index re x).f_values)
-"#)]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
-    is_i32b_polynomial (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) ${re}
 "#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
+    is_i32b_polynomial (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) ${re}
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 8 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 100")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) 
             (Seq.index ${re} (v index)).f_values /\
@@ -129,12 +133,12 @@ fn ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
         Spec.Utils.is_i32b 4190208 $zeta_1 /\
         Spec.Utils.is_i32b 4190208 $zeta_2 /\
         Spec.Utils.is_i32b 4190208 $zeta_3
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 8 * v $FIELD_MAX)
             (Seq.index ${re}_future (v index)).f_values
-     "#))]
+     "#)))]
     fn round(
         re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
         index: usize,
@@ -143,6 +147,7 @@ fn ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
         zeta_2: i32,
         zeta_3: i32,
     ) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -185,36 +190,37 @@ fn ntt_at_layer_0(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_1(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 100")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX) 
                                  (Seq.index ${re} (v index)).f_values /\
         Spec.Utils.is_i32b 4190208 $zeta_0 /\
         Spec.Utils.is_i32b 4190208 $zeta_1
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 7 * v $FIELD_MAX)
             (Seq.index ${re}_future (v index)).f_values
-     "#))]
+     "#)))]
     fn round(
         re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
         index: usize,
         zeta_0: i32,
         zeta_1: i32,
     ) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -257,30 +263,31 @@ fn ntt_at_layer_1(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 5 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 200")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v index < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 5 * v $FIELD_MAX) 
                                         (Seq.index ${re} (v index)).f_values /\
         Spec.Utils.is_i32b 4190208 $zeta
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies1_32 ${re} ${re}_future $index /\
         Spec.Utils.is_i32b_array_opaque (v $NTT_BASE_BOUND + 6 * v $FIELD_MAX)
             (Seq.index ${re}_future (v index)).f_values
-    "#))]
+    "#)))]
     fn round(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT], index: usize, zeta: i32) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -323,9 +330,9 @@ fn ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 600 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 600 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     (v $STEP_BY > 0) /\
     (v $OFFSET + v $STEP_BY < v $SIMD_UNITS_IN_RING_ELEMENT) /\
     (v $OFFSET + 2 * v $STEP_BY <= v $SIMD_UNITS_IN_RING_ELEMENT) /\
@@ -334,22 +341,24 @@ fn ntt_at_layer_2(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
                 (v $NTT_BASE_BOUND + ((layer_bound_factor $STEP_BY) * v $FIELD_MAX)) 
                 (Seq.index ${re} i).f_values)) /\
     Spec.Utils.is_i32b 4190208 $ZETA
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     Spec.Utils.modifies_range_32 ${re} ${re}_future $OFFSET (${OFFSET + STEP_BY + STEP_BY}) /\
     (Spec.Utils.forall32 (fun i -> (i >= v $OFFSET /\ i < (v $OFFSET + 2 * v $STEP_BY)) ==>
               Spec.Utils.is_i32b_array_opaque 
                 (v $NTT_BASE_BOUND + ((layer_bound_factor $STEP_BY + 1) * v $FIELD_MAX)) 
                 (Seq.index ${re}_future i).f_values))
-"#))]
+"#)))]
 fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
 ) {
     // Refactoring the code to have the loop body separately verified is good for proof performance.
     // So we factor out the loop body in a `round` function similarly to the other NTT layers.
     #[inline(always)]
-    #[hax_lib::fstar::before(
-        r#"
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::before(
+            r#"
     let layer_bound_factor (step_by:usize) : n:nat{n <= 4} =
         match step_by with
         | MkInt 1 -> 4
@@ -359,10 +368,11 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
         | MkInt 16 -> 0
         | _ -> 0
     "#
+        )
     )]
-    #[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-    #[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         v $step_by > 0 /\
         v $index + v $step_by < v $SIMD_UNITS_IN_RING_ELEMENT /\
         Spec.Utils.is_i32b_array_opaque 
@@ -372,8 +382,8 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
                     (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by) * v $FIELD_MAX)) 
                     (Seq.index ${re} (v $index + v $step_by)).f_values /\
         Spec.Utils.is_i32b 4190208 $zeta
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         Spec.Utils.modifies2_32 ${re} ${re}_future $index (${index + step_by}) /\
         Spec.Utils.is_i32b_array_opaque 
                     (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by + 1) * v $FIELD_MAX)) 
@@ -381,13 +391,14 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
         Spec.Utils.is_i32b_array_opaque 
                     (v $NTT_BASE_BOUND + ((layer_bound_factor $step_by + 1) * v $FIELD_MAX)) 
                     (Seq.index ${re}_future (v $index + v step_by)).f_values
-    "#))]
+    "#)))]
     fn round(
         re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT],
         index: usize,
         step_by: usize,
         zeta: i32,
     ) {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i32b_array_opaque) (Spec.Utils.is_i32b_array_opaque)"
         );
@@ -404,6 +415,7 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
     let orig_re = re.clone();
 
     for j in OFFSET..OFFSET + STEP_BY {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|j: usize| fstar!(
             r#"
             (Spec.Utils.modifies_range2_32 $orig_re $re 
@@ -420,14 +432,14 @@ fn outer_3_plus<const OFFSET: usize, const STEP_BY: usize, const ZETA: i32>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 4 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 5 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_3(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 8; // 1 << LAYER;
     const STEP_BY: usize = 1; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -451,14 +463,14 @@ fn ntt_at_layer_3(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 3 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 4 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_4(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 16; // 1 << LAYER;
     const STEP_BY: usize = 2; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -474,14 +486,14 @@ fn ntt_at_layer_4(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 2 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 3 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_5(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 32; // 1 << LAYER;
     const STEP_BY: usize = 4; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -493,14 +505,14 @@ fn ntt_at_layer_5(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 1 * v $FIELD_MAX) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 2 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_6(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 64; // 1 << LAYER;
     const STEP_BY: usize = 8; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -510,14 +522,14 @@ fn ntt_at_layer_6(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND) $re
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 1 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 fn ntt_at_layer_7(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     const STEP: usize = 128; // 1 << LAYER;
     const STEP_BY: usize = 16; // step / COEFFICIENTS_IN_SIMD_UNIT;
@@ -526,14 +538,14 @@ fn ntt_at_layer_7(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND) ${re}
-"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
     is_i32b_polynomial (v $NTT_BASE_BOUND + 8 * v $FIELD_MAX) ${re}_future
-"#) )]
+"#) ))]
 pub(crate) fn ntt(re: &mut [Coefficients; SIMD_UNITS_IN_RING_ELEMENT]) {
     ntt_at_layer_7(re);
     ntt_at_layer_6(re);

--- a/libcrux-ml-dsa/src/simd/portable/sample.rs
+++ b/libcrux-ml-dsa/src/simd/portable/sample.rs
@@ -5,18 +5,23 @@ use crate::constants::FIELD_MODULUS;
 use crate::specs::simd::portable::sample::*;
 
 #[inline(always)]
-#[hax_lib::requires(rejection_sample_less_than_field_modulus_pre(randomness, out))]
-#[hax_lib::ensures(|r| rejection_sample_less_than_field_modulus_post(randomness, future(out), r))]
+#[cfg_attr(
+    hax,
+    hax_lib::requires(rejection_sample_less_than_field_modulus_pre(randomness, out))
+)]
+#[cfg_attr(hax, hax_lib::ensures(|r| rejection_sample_less_than_field_modulus_post(randomness, future(out), r)))]
 pub fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i32]) -> usize {
     let mut sampled = 0;
 
     #[cfg(hax)]
     let _out_len = out.len();
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.eq_repeati0 (sz 0) (Spec.MLDSA.Math.rejection_sample_field_modulus_inner $randomness) Seq.empty"#
     );
 
     for i in 0..randomness.len() / 3 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -34,6 +39,7 @@ pub fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i3
         let b2 = randomness[i * 3 + 2] as i32;
         let coefficient = ((b2 << 16) | (b1 << 8) | b0) & 0x00_7F_FF_FF;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.MLDSA.Math.rejection_sample_coefficient_lemma $randomness ($i);
             Spec.Utils.unfold_repeati ($i +! sz 1) 
@@ -45,6 +51,7 @@ pub fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i3
             sampled += 1;
         }
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"let samples = Spec.Utils.repeati ($i +! sz 1)
                 (Spec.MLDSA.Math.rejection_sample_field_modulus_inner $randomness) Seq.empty in
@@ -56,19 +63,27 @@ pub fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i3
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning --z3refresh")]
-#[hax_lib::requires(rejection_sample_less_than_eta_equals_2_pre(randomness, out))]
-#[hax_lib::ensures(|r| rejection_sample_less_than_eta_equals_2_post(randomness, future(out), r))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning --z3refresh")
+)]
+#[cfg_attr(
+    hax,
+    hax_lib::requires(rejection_sample_less_than_eta_equals_2_pre(randomness, out))
+)]
+#[cfg_attr(hax, hax_lib::ensures(|r| rejection_sample_less_than_eta_equals_2_post(randomness, future(out), r)))]
 pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32]) -> usize {
     let mut sampled = 0;
 
     #[cfg(hax)]
     let _out_len = out.len();
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.eq_repeati0 (sz 0) (Spec.MLDSA.Math.rejection_sample_eta_2_inner $randomness) Seq.empty"#
     );
 
     for i in 0..randomness.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -86,6 +101,7 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
         let try_0 = byte & 0xF;
         let try_1 = byte >> 4;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.Utils.unfold_repeati ($i +! sz 1) 
                 (Spec.MLDSA.Math.rejection_sample_eta_2_inner $randomness) Seq.empty ($i)"#
@@ -127,6 +143,7 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
             // (try_0 * 26) >> 7 computes ⌊try_0 / 5⌋
             let try_0_mod_5 = try_0 - ((try_0 * 26) >> 7) * 5;
 
+            #[cfg(hax)]
             hax_lib::fstar!(
                 r#"assert ($try_0_mod_5 == ($try_0 %! mk_i32 5));
                 assert ((mk_i32 2 -. $try_0_mod_5) == (mk_i32 2 -! $try_0_mod_5))"#
@@ -168,6 +185,7 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
             let try_1 = try_1 as i32;
             let try_1_mod_5 = try_1 - ((try_1 * 26) >> 7) * 5;
 
+            #[cfg(hax)]
             hax_lib::fstar!(
                 r#"assert ($try_1_mod_5 == ($try_1 %! mk_i32 5));
                 assert ((mk_i32 2 -. $try_1_mod_5) == (mk_i32 2 -! $try_1_mod_5))"#
@@ -177,6 +195,7 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
             sampled += 1;
         }
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"let samples = Spec.Utils.repeati ($i +! sz 1)
                 (Spec.MLDSA.Math.rejection_sample_eta_2_inner $randomness) Seq.empty in
@@ -188,19 +207,24 @@ pub fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--ext context_pruning --z3refresh")]
-#[hax_lib::requires(rejection_sample_less_than_eta_equals_4_pre(randomness, out))]
-#[hax_lib::ensures(|r| rejection_sample_less_than_eta_equals_4_post(randomness, future(out), r))]
+#[cfg_attr(hax, hax_lib::fstar::options("--ext context_pruning --z3refresh"))]
+#[cfg_attr(
+    hax,
+    hax_lib::requires(rejection_sample_less_than_eta_equals_4_pre(randomness, out))
+)]
+#[cfg_attr(hax, hax_lib::ensures(|r| rejection_sample_less_than_eta_equals_4_post(randomness, future(out), r)))]
 pub fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32]) -> usize {
     let mut sampled = 0;
 
     #[cfg(hax)]
     let _out_len = out.len();
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.eq_repeati0 (sz 0) (Spec.MLDSA.Math.rejection_sample_eta_4_inner $randomness) Seq.empty"#
     );
 
     for i in 0..randomness.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -218,6 +242,7 @@ pub fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32
         let try_0 = byte & 0xF;
         let try_1 = byte >> 4;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"Spec.Utils.unfold_repeati ($i +! sz 1) 
                 (Spec.MLDSA.Math.rejection_sample_eta_4_inner $randomness) Seq.empty ($i)"#
@@ -292,6 +317,7 @@ pub fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32
             sampled += 1;
         }
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"let samples = Spec.Utils.repeati ($i +! sz 1)
                 (Spec.MLDSA.Math.rejection_sample_eta_4_inner $randomness) Seq.empty in

--- a/libcrux-ml-dsa/src/simd/portable/vector_type.rs
+++ b/libcrux-ml-dsa/src/simd/portable/vector_type.rs
@@ -17,14 +17,14 @@ pub(crate) fn zero() -> Coefficients {
 }
 
 #[inline(always)]
-#[hax_lib::requires(array.len() == COEFFICIENTS_IN_SIMD_UNIT)]
+#[cfg_attr(hax, hax_lib::requires(array.len() == COEFFICIENTS_IN_SIMD_UNIT))]
 pub(crate) fn from_coefficient_array(array: &[i32], out: &mut Coefficients) {
     out.values
         .copy_from_slice(&array[0..COEFFICIENTS_IN_SIMD_UNIT])
 }
 
 #[inline(always)]
-#[hax_lib::requires(out.len() == COEFFICIENTS_IN_SIMD_UNIT)]
+#[cfg_attr(hax, hax_lib::requires(out.len() == COEFFICIENTS_IN_SIMD_UNIT))]
 pub(crate) fn to_coefficient_array(
     value: &Coefficients,
     out: &mut [i32], // len: COEFFICIENTS_IN_SIMD_UNIT

--- a/libcrux-ml-dsa/src/simd/traits.rs
+++ b/libcrux-ml-dsa/src/simd/traits.rs
@@ -22,7 +22,7 @@ pub const INVERSE_OF_MODULUS_MOD_MONTGOMERY_R: u64 = 58_728_449;
 pub(crate) type FieldElementTimesMontgomeryR = i32;
 
 #[cfg(hax)]
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Repr: Copy + Clone {
     #[cfg(hax)]
     #[requires(true)]
@@ -32,70 +32,70 @@ pub(crate) trait Repr: Copy + Clone {
 #[cfg(not(hax))]
 pub trait Repr {}
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Operations: Copy + Clone + Repr {
-    #[hax_lib::requires(true)]
-    #[hax_lib::ensures(|result| result.repr() == [0i32; COEFFICIENTS_IN_SIMD_UNIT])]
+    #[cfg_attr(hax, hax_lib::requires(true))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result.repr() == [0i32; COEFFICIENTS_IN_SIMD_UNIT]))]
     fn zero() -> Self;
 
-    #[hax_lib::requires(array.len() == COEFFICIENTS_IN_SIMD_UNIT)]
-    #[hax_lib::ensures(|result| future(out).repr() == array)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == COEFFICIENTS_IN_SIMD_UNIT))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| future(out).repr() == array))]
     fn from_coefficient_array(array: &[i32], out: &mut Self);
 
-    #[hax_lib::requires(out.len() == COEFFICIENTS_IN_SIMD_UNIT)]
-    #[hax_lib::ensures(|result| future(out) == value.repr())]
+    #[cfg_attr(hax, hax_lib::requires(out.len() == COEFFICIENTS_IN_SIMD_UNIT))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| future(out) == value.repr()))]
     fn to_coefficient_array(value: &Self, out: &mut [i32]);
 
     // Arithmetic
-    #[hax_lib::requires(specs::add_pre(&lhs.repr(), &rhs.repr()))]
-    #[hax_lib::ensures(|_| specs::add_post(&lhs.repr(), &rhs.repr(), &future(lhs).repr()))]
+    #[cfg_attr(hax, hax_lib::requires(specs::add_pre(&lhs.repr(), &rhs.repr())))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| specs::add_post(&lhs.repr(), &rhs.repr(), &future(lhs).repr())))]
     fn add(lhs: &mut Self, rhs: &Self);
 
-    #[hax_lib::requires(specs::sub_pre(&lhs.repr(), &rhs.repr()))]
-    #[hax_lib::ensures(|_| specs::sub_post(&lhs.repr(), &rhs.repr(), &future(lhs).repr()))]
+    #[cfg_attr(hax, hax_lib::requires(specs::sub_pre(&lhs.repr(), &rhs.repr())))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| specs::sub_post(&lhs.repr(), &rhs.repr(), &future(lhs).repr())))]
     fn subtract(lhs: &mut Self, rhs: &Self);
 
-    #[hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
-        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $bound > 0 /\ 
+        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#)))]
     fn infinity_norm_exceeds(simd_unit: &Self, bound: i32) -> bool;
 
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
          v $gamma2 == v ${crate::constants::GAMMA2_V95_232}) /\
-        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#))]
+        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#)))]
     fn decompose(gamma2: Gamma2, simd_unit: &Self, low: &mut Self, high: &mut Self);
 
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
-         v $gamma2 == v ${crate::constants::GAMMA2_V95_232})"#))]
-    #[hax_lib::ensures(|result| result <= 8)]
+         v $gamma2 == v ${crate::constants::GAMMA2_V95_232})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result <= 8))]
     fn compute_hint(low: &Self, high: &Self, gamma2: i32, hint: &mut Self) -> usize;
 
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (v $gamma2 == v ${crate::constants::GAMMA2_V261_888} \/ 
          v $gamma2 == v ${crate::constants::GAMMA2_V95_232}) /\
-        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#))]
+        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${simd_unit})"#)))]
     fn use_hint(gamma2: Gamma2, simd_unit: &Self, hint: &mut Self);
 
     // Modular operations
-    #[hax_lib::requires(fstar!(r#"
-        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (${rhs.repr()})"#))]
-    #[hax_lib::ensures(|result| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
+        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (${rhs.repr()})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
         Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${lhs}_future) /\
         Spec.MLDSA.Math.(forall i. i < 8 ==> 
             mod_q (v (Seq.index (f_repr ${lhs}_future) i)) == 
-            mod_q (v (Seq.index (${lhs.repr()}) i) * v (Seq.index (${rhs.repr()}) i) * 8265825))"#))]
+            mod_q (v (Seq.index (${lhs.repr()}) i) * v (Seq.index (${rhs.repr()}) i) * 8265825))"#)))]
     fn montgomery_multiply(lhs: &mut Self, rhs: &Self);
 
     // 261631 is the largest x such that x * pow2 13 <= 2143289343 (the barrett reduce input bound)
-    #[hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $SHIFT_BY == 13 /\ 
         (forall i. i < 8 ==> v (Seq.index (f_repr ${simd_unit}) i) >= 0 /\
-            v (Seq.index (f_repr ${simd_unit}) i) <= 261631)"#))]
+            v (Seq.index (f_repr ${simd_unit}) i) <= 261631)"#)))]
     fn shift_left_then_reduce<const SHIFT_BY: i32>(simd_unit: &mut Self);
 
     // Decomposition operations
-    #[hax_lib::requires(fstar!(r#"
-        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${t0})"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
+        Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) (f_repr ${t0})"#)))]
     fn power2round(t0: &mut Self, t1: &mut Self);
 
     // Sampling
@@ -105,70 +105,70 @@ pub(crate) trait Operations: Copy + Clone + Repr {
 
     // Since each coefficient could potentially be sampled with 3 bytes, we expect
     // `randomness` to hold 24 bytes.
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn rejection_sample_less_than_field_modulus(randomness: &[u8], out: &mut [i32]) -> usize;
 
     // Since each coefficient could potentially be sampled with half a byte,
     // we expect `randomness` to hold 4 bytes.
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn rejection_sample_less_than_eta_equals_2(randomness: &[u8], out: &mut [i32]) -> usize;
 
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn rejection_sample_less_than_eta_equals_4(randomness: &[u8], out: &mut [i32]) -> usize;
 
     // Encoding operations
 
     // Gamma1
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn gamma1_serialize(simd_unit: &Self, serialized: &mut [u8], gamma1_exponent: usize);
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn gamma1_deserialize(serialized: &[u8], out: &mut Self, gamma1_exponent: usize);
 
     // Commitment
-    #[hax_lib::requires(serialized.len() == 4 || serialized.len() == 6)]
-    #[hax_lib::ensures(|_| future(serialized).len() == serialized.len())]
+    #[cfg_attr(hax, hax_lib::requires(serialized.len() == 4 || serialized.len() == 6))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(serialized).len() == serialized.len()))]
     fn commitment_serialize(simd_unit: &Self, serialized: &mut [u8]);
 
     // Error
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn error_serialize(eta: Eta, simd_unit: &Self, serialized: &mut [u8]);
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn error_deserialize(eta: Eta, serialized: &[u8], out: &mut Self);
 
     // t0
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn t0_serialize(simd_unit: &Self, out: &mut [u8]); // out len 13
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn t0_deserialize(serialized: &[u8], out: &mut Self);
 
     // t1
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn t1_serialize(simd_unit: &Self, out: &mut [u8]); // out len 10
-    #[hax_lib::requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn t1_deserialize(serialized: &[u8], out: &mut Self);
 
     // NTT
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (forall (i:nat). i < 32 ==> 
             Spec.Utils.is_i32b_array_opaque 
             (v ${specs::NTT_BASE_BOUND})
             (f_repr (Seq.index ${simd_units} i)))
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         (forall (i:nat). i < 32 ==> Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) 
             (f_repr (Seq.index ${simd_units}_future i)))
-    "#))]
+    "#)))]
     fn ntt(simd_units: &mut [Self; SIMD_UNITS_IN_RING_ELEMENT]);
 
     // invert NTT and convert to standard domain
-    #[hax_lib::requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         (forall (i:nat). i < 32 ==> Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) 
             (f_repr (Seq.index ${simd_units} i)))
-    "#))]
-    #[hax_lib::ensures(|_| fstar!(r#"
+    "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         (forall (i:nat). i < 32 ==> Spec.Utils.is_i32b_array_opaque (v ${specs::FIELD_MAX}) 
             (f_repr (Seq.index ${simd_units}_future i)))
-    "#))]
+    "#)))]
     fn invert_ntt_montgomery(simd_units: &mut [Self; SIMD_UNITS_IN_RING_ELEMENT]);
 
     // Barrett reduce all coefficients

--- a/libcrux-ml-dsa/src/simd/traits/specs.rs
+++ b/libcrux-ml-dsa/src/simd/traits/specs.rs
@@ -18,8 +18,8 @@ pub(crate) fn int_is_i32(i: Int) -> bool {
     i <= i32::MAX.to_int() && i >= i32::MIN.to_int()
 }
 
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::after(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::after(r#"
     let bounded_add_pre (a b: t_Array i32 (sz 8)) (b1:nat) (b2:nat):
         Lemma (requires (Spec.Utils.is_i32b_array_opaque b1 a /\ Spec.Utils.is_i32b_array_opaque b2 b /\ b1 + b2 <= 4294967295))
                 (ensures (Libcrux_ml_dsa.Simd.Traits.Specs.add_pre a b))
@@ -27,7 +27,7 @@ pub(crate) fn int_is_i32(i: Int) -> bool {
                 SMTPat (Spec.Utils.is_i32b_array_opaque b1 a);
                 SMTPat (Spec.Utils.is_i32b_array_opaque b2 b)] = 
         reveal_opaque (`%$add_pre) ($add_pre)
-    "#)]
+    "#))]
 pub(crate) fn add_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
     forall(|i: usize| {
         implies(
@@ -37,8 +37,8 @@ pub(crate) fn add_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
     })
 }
 
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::after(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::after(r#"
     let bounded_add_post (a b a_future: t_Array i32 (sz 8)) (b1 b2 b3:nat):
         Lemma (requires (Spec.Utils.is_i32b_array_opaque b1 a /\ Spec.Utils.is_i32b_array_opaque b2 b /\
                     b1 + b2 <= b3 /\ Libcrux_ml_dsa.Simd.Traits.Specs.add_post a b a_future))
@@ -48,7 +48,7 @@ pub(crate) fn add_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
             SMTPat (Spec.Utils.is_i32b_array_opaque b2 b);
             SMTPat (Spec.Utils.is_i32b_array_opaque b3 a_future)] = 
         reveal_opaque (`%$add_post) ($add_post)
-    "#)]
+    "#))]
 pub(crate) fn add_post(lhs: &SIMDContent, rhs: &SIMDContent, future_lhs: &SIMDContent) -> Prop {
     forall(|i: usize| {
         implies(
@@ -58,8 +58,8 @@ pub(crate) fn add_post(lhs: &SIMDContent, rhs: &SIMDContent, future_lhs: &SIMDCo
     })
 }
 
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::after(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::after(r#"
     let bounded_sub_pre (a b: t_Array i32 (sz 8)) (b1:nat) (b2:nat):
         Lemma (requires (Spec.Utils.is_i32b_array_opaque b1 a /\ Spec.Utils.is_i32b_array_opaque b2 b /\ b1 + b2 <= 4294967295))
               (ensures (Libcrux_ml_dsa.Simd.Traits.Specs.sub_pre a b))
@@ -67,7 +67,7 @@ pub(crate) fn add_post(lhs: &SIMDContent, rhs: &SIMDContent, future_lhs: &SIMDCo
                SMTPat (Spec.Utils.is_i32b_array_opaque b1 a);
                SMTPat (Spec.Utils.is_i32b_array_opaque b2 b)] = 
         reveal_opaque (`%$sub_pre) ($sub_pre)
-    "#)]
+    "#))]
 pub(crate) fn sub_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
     forall(|i: usize| {
         implies(
@@ -77,8 +77,8 @@ pub(crate) fn sub_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
     })
 }
 
-#[hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::after(r#"
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::after(r#"
     let bounded_sub_post (a b a_future: t_Array i32 (sz 8)) (b1 b2 b3:nat):
         Lemma (requires (Spec.Utils.is_i32b_array_opaque b1 a /\ Spec.Utils.is_i32b_array_opaque b2 b /\
                         b1 + b2 <= b3 /\ Libcrux_ml_dsa.Simd.Traits.Specs.sub_post a b a_future))
@@ -88,7 +88,7 @@ pub(crate) fn sub_pre(lhs: &SIMDContent, rhs: &SIMDContent) -> Prop {
                 SMTPat (Spec.Utils.is_i32b_array_opaque b2 b);
                 SMTPat (Spec.Utils.is_i32b_array_opaque b3 a_future)] = 
                 reveal_opaque (`%$sub_post) ($sub_post)
-    "#)]
+    "#))]
 pub(crate) fn sub_post(lhs: &SIMDContent, rhs: &SIMDContent, future_lhs: &SIMDContent) -> Prop {
     forall(|i: usize| {
         implies(

--- a/libcrux-ml-kem/Cargo.toml
+++ b/libcrux-ml-kem/Cargo.toml
@@ -28,8 +28,10 @@ libcrux-sha3.workspace = true
 libcrux-intrinsics.workspace = true
 libcrux-secrets.workspace = true
 libcrux-traits.workspace = true
-hax-lib.workspace = true
 tls_codec = { workspace = true, optional = true }
+
+[target.'cfg(hax)'.dependencies]
+hax-lib.workspace = true
 
 [features]
 # By default all variants and std are enabled.

--- a/libcrux-ml-kem/TOOLS.md
+++ b/libcrux-ml-kem/TOOLS.md
@@ -251,7 +251,7 @@ way, but you can replace it with a different implementation, e.g.:
 
 ```rust
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1})]
+#[cfg_attr(hax, hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1}))]
 fn inz2(value: u8) -> u8 {
     let value = value as i32;
     let result = ((-value) as u32) >> 31;

--- a/libcrux-ml-kem/src/constant_time_ops.rs
+++ b/libcrux-ml-kem/src/constant_time_ops.rs
@@ -12,7 +12,7 @@ use crate::constants::SHARED_SECRET_SIZE;
 
 /// Return 1 if `value` is not zero and 0 otherwise.
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1})]
+#[cfg_attr(hax, hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1}))]
 fn inz(value: u8) -> u8 {
     #[cfg(hax)]
     let _orig_value = value; // copy original value for proofs
@@ -21,6 +21,7 @@ fn inz(value: u8) -> u8 {
     let result = ((!value).wrapping_add(1) >> 8) as u8;
     let res = result & 1;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"lognot_lemma $value;
            logand_lemma (mk_u8 1) $result"#
@@ -29,7 +30,7 @@ fn inz(value: u8) -> u8 {
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1})]
+#[cfg_attr(hax, hax_lib::ensures(|result| if value == 0 {result == 0} else {result == 1}))]
 fn is_non_zero(value: u8) -> u8 {
     #[cfg(eurydice)]
     return inz(value);
@@ -41,11 +42,12 @@ fn is_non_zero(value: u8) -> u8 {
 /// Return 1 if the bytes of `lhs` and `rhs` do not exactly
 /// match and 0 otherwise.
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::requires(lhs.len() == rhs.len())]
-#[hax_lib::ensures(|result| if lhs == rhs {result == 0} else {result == 1})]
+#[cfg_attr(hax, hax_lib::requires(lhs.len() == rhs.len()))]
+#[cfg_attr(hax, hax_lib::ensures(|result| if lhs == rhs {result == 0} else {result == 1}))]
 fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
     let mut r: u8 = 0;
     for i in 0..lhs.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i <= Seq.length $lhs /\
@@ -57,6 +59,7 @@ fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
 
         let nr = r | (lhs[i] ^ rhs[i]);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"if $r =. (mk_u8 0) then (
             if (Seq.index $lhs (v $i) = Seq.index $rhs (v $i)) then (
@@ -95,8 +98,8 @@ fn compare(lhs: &[u8], rhs: &[u8]) -> u8 {
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::requires(lhs.len() == rhs.len())]
-#[hax_lib::ensures(|result| if lhs == rhs {result == 0} else {result == 1})]
+#[cfg_attr(hax, hax_lib::requires(lhs.len() == rhs.len()))]
+#[cfg_attr(hax, hax_lib::ensures(|result| if lhs == rhs {result == 0} else {result == 1}))]
 pub(crate) fn compare_ciphertexts_in_constant_time(lhs: &[u8], rhs: &[u8]) -> u8 {
     #[cfg(eurydice)]
     return compare(lhs, rhs);
@@ -108,14 +111,15 @@ pub(crate) fn compare_ciphertexts_in_constant_time(lhs: &[u8], rhs: &[u8]) -> u8
 /// If `selector` is not zero, return the bytes in `rhs`; return the bytes in
 /// `lhs` otherwise.
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::fstar::options("--ifuel 0 --z3rlimit 50")]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::options("--ifuel 0 --z3rlimit 50"))]
+#[cfg_attr(hax, hax_lib::requires(
     lhs.len() == rhs.len() &&
     lhs.len() == SHARED_SECRET_SIZE
-)]
-#[hax_lib::ensures(|result| if selector == 0 {result == lhs} else {result == rhs})]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result| if selector == 0 {result == lhs} else {result == rhs}))]
 fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
     let mask = is_non_zero(selector).wrapping_sub(1);
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (if $selector = (mk_u8 0) then $mask = ones else $mask = zero);
         lognot_lemma $mask;
@@ -124,6 +128,7 @@ fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
     let mut out = [0u8; SHARED_SECRET_SIZE];
 
     for i in 0..SHARED_SECRET_SIZE {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i <= v $SHARED_SECRET_SIZE /\
@@ -131,8 +136,10 @@ fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
             (forall j. j >= v $i ==> Seq.index $out j == (mk_u8 0))"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert ((${out}.[ $i ] <: u8) = (mk_u8 0))"#);
         let outi = (lhs[i] & mask) | (rhs[i] & !mask);
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"if ($selector = (mk_u8 0)) then (
             logand_lemma (${lhs}.[ $i ] <: u8) $mask;
@@ -161,6 +168,7 @@ fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
         out[i] = outi;
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "if ($selector =. (mk_u8 0)) then (
             eq_intro $out $lhs
@@ -173,11 +181,11 @@ fn select_ct(lhs: &[u8], rhs: &[u8], selector: u8) -> [u8; SHARED_SECRET_SIZE] {
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     lhs.len() == rhs.len() &&
     lhs.len() == SHARED_SECRET_SIZE
-)]
-#[hax_lib::ensures(|result| if selector == 0 {result == lhs} else {result == rhs})]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result| if selector == 0 {result == lhs} else {result == rhs}))]
 pub(crate) fn select_shared_secret_in_constant_time(
     lhs: &[u8],
     rhs: &[u8],
@@ -191,12 +199,12 @@ pub(crate) fn select_shared_secret_in_constant_time(
 }
 
 #[inline(never)] // Don't inline this to avoid that the compiler optimizes this out.
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     lhs_c.len() == rhs_c.len() &&
     lhs_s.len() == rhs_s.len() &&
     lhs_s.len() == SHARED_SECRET_SIZE
-)]
-#[hax_lib::ensures(|result| if lhs_c == rhs_c {result == lhs_s} else {result == rhs_s})]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result| if lhs_c == rhs_c {result == lhs_s} else {result == rhs_s}))]
 pub(crate) fn compare_ciphertexts_select_shared_secret_in_constant_time(
     lhs_c: &[u8],
     rhs_c: &[u8],

--- a/libcrux-ml-kem/src/constants.rs
+++ b/libcrux-ml-kem/src/constants.rs
@@ -38,8 +38,8 @@ pub(crate) const G_DIGEST_SIZE: usize = 64;
 ///
 /// [eurydice] Note that we can't use const generics here because that breaks
 ///            C extraction with eurydice.
-#[hax_lib::requires(rank <= 4)]
-#[hax_lib::ensures(|result| result == rank * BITS_PER_RING_ELEMENT / 8)]
+#[cfg_attr(hax, hax_lib::requires(rank <= 4))]
+#[cfg_attr(hax, hax_lib::ensures(|result| result == rank * BITS_PER_RING_ELEMENT / 8))]
 pub(crate) const fn ranked_bytes_per_ring_element(rank: usize) -> usize {
     rank * BITS_PER_RING_ELEMENT / 8
 }

--- a/libcrux-ml-kem/src/hash_functions.rs
+++ b/libcrux-ml-kem/src/hash_functions.rs
@@ -23,56 +23,57 @@ pub(crate) const THREE_BLOCKS: usize = BLOCK_SIZE * 3;
 /// - AVX2
 /// - NEON
 /// - Portable
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Hash<const K: usize> {
     /// G aka SHA3 512
-    #[requires(true)]
-    #[ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_G $input"#))
+    #[cfg_attr(hax, hax_lib::requires(true))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_G $input"#)))
     ]
     fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE];
 
     /// H aka SHA3 256
-    #[requires(true)]
-    #[ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_H $input"#))
+    #[cfg_attr(hax, hax_lib::requires(true))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_H $input"#)))
     ]
     fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE];
 
     /// PRF aka SHAKE256
-    #[requires(fstar!(r#"v $LEN < pow2 32"#))]
-    #[ensures(|result|
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-        fstar!(r#"v $LEN < pow2 32 ==> $result == Spec.Utils.v_PRF $LEN $input"#))
+        fstar!(r#"v $LEN < pow2 32 ==> $result == Spec.Utils.v_PRF $LEN $input"#)))
     ]
     fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN];
 
     /// PRFxN aka N SHAKE256
-    #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[ensures(|result|
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
         fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-            $result == Spec.Utils.v_PRFxN $K $LEN $input"#))
+            $result == Spec.Utils.v_PRFxN $K $LEN $input"#)))
     ]
     fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K];
 
     /// Create a SHAKE128 state and absorb the input.
-    #[requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn shake128_init_absorb_final(input: &[[u8; 34]; K]) -> Self;
 
     /// Squeeze 3 blocks out of the SHAKE128 state.
-    #[requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn shake128_squeeze_first_three_blocks(&mut self) -> [[u8; THREE_BLOCKS]; K];
 
     /// Squeeze 1 block out of the SHAKE128 state.
-    #[requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn shake128_squeeze_next_block(&mut self) -> [[u8; BLOCK_SIZE]; K];
 }
 
 /// A portable implementation of [`Hash`]
 pub(crate) mod portable {
-    use super::*;
     use libcrux_sha3::portable::{self, incremental, KeccakState};
+
+    use super::*;
 
     /// The state.
     ///
@@ -83,8 +84,8 @@ pub(crate) mod portable {
         shake128_state: [KeccakState; K],
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_G $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_G $input"#)))
     ]
     #[inline]
     fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
@@ -93,8 +94,8 @@ pub(crate) mod portable {
         digest
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_H $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_H $input"#)))
     ]
     #[inline]
     fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
@@ -103,9 +104,9 @@ pub(crate) mod portable {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#)))
     ]
     #[inline]
     fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
@@ -114,9 +115,9 @@ pub(crate) mod portable {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#)))
     ]
     #[inline]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
@@ -172,38 +173,38 @@ pub(crate) mod portable {
         out
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     impl<const K: usize> Hash<K> for PortableHash<K> {
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_G $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_G $input"#)))
         ]
         #[inline]
         fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
             G(input)
         }
 
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_H $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_H $input"#)))
         ]
         #[inline]
         fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
             H(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32"#))]
-        #[ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
+            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#)))
         ]
         #[inline]
         fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
             PRF::<LEN>(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-        #[ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-                $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"#)))
         ]
         #[inline]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
@@ -230,11 +231,12 @@ pub(crate) mod portable {
 /// A SIMD256 implementation of [`Hash`] for AVX2
 #[cfg(feature = "simd256")]
 pub(crate) mod avx2 {
-    use super::*;
     use libcrux_sha3::{
         avx2::x4::{self, incremental::KeccakState},
         portable,
     };
+
+    use super::*;
 
     /// The state.
     ///
@@ -245,8 +247,8 @@ pub(crate) mod avx2 {
         shake128_state: KeccakState,
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_G $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_G $input"#)))
     ]
     #[inline(always)]
     fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
@@ -255,8 +257,8 @@ pub(crate) mod avx2 {
         digest
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_H $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_H $input"#)))
     ]
     #[inline(always)]
     fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
@@ -265,9 +267,9 @@ pub(crate) mod avx2 {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#)))
     ]
     #[inline(always)]
     fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
@@ -276,9 +278,9 @@ pub(crate) mod avx2 {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#)))
     ]
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
@@ -437,38 +439,38 @@ pub(crate) mod avx2 {
         out
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     impl<const K: usize> Hash<K> for Simd256Hash {
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_G $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_G $input"#)))
         ]
         #[inline(always)]
         fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
             G(input)
         }
 
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_H $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_H $input"#)))
         ]
         #[inline(always)]
         fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
             H(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32"#))]
-        #[hax_lib::ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
+            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#)))
         ]
         #[inline(always)]
         fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
             PRF::<LEN>(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-        #[ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-                $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"#)))
         ]
         #[inline(always)]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
@@ -495,8 +497,9 @@ pub(crate) mod avx2 {
 /// A SIMD128 implementation of [`Hash`] for NEON
 #[cfg(feature = "simd128")]
 pub(crate) mod neon {
-    use super::*;
     use libcrux_sha3::neon::x2::{self, incremental::KeccakState};
+
+    use super::*;
 
     /// The state.
     ///
@@ -507,8 +510,8 @@ pub(crate) mod neon {
         shake128_state: [KeccakState; 2],
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_G $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_G $input"#)))
     ]
     #[inline(always)]
     fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
@@ -517,8 +520,8 @@ pub(crate) mod neon {
         digest
     }
 
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_H $input"#))
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_H $input"#)))
     ]
     #[inline(always)]
     fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
@@ -527,9 +530,9 @@ pub(crate) mod neon {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRF $LEN $input"#)))
     ]
     #[inline(always)]
     fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
@@ -539,9 +542,9 @@ pub(crate) mod neon {
         digest
     }
 
-    #[hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-    #[hax_lib::ensures(|result|
-        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#))
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
+        fstar!(r#"$result == Spec.Utils.v_PRFxN $K $LEN $input"#)))
     ]
     #[inline(always)]
     fn PRFxN<const K: usize, const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {
@@ -715,39 +718,39 @@ pub(crate) mod neon {
         out
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     impl<const K: usize> Hash<K> for Simd128Hash {
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_G $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_G $input"#)))
         ]
         #[inline(always)]
         fn G(input: &[u8]) -> [u8; G_DIGEST_SIZE] {
             G(input)
         }
 
-        #[ensures(|out|
-            fstar!(r#"$out == Spec.Utils.v_H $input"#))
+        #[cfg_attr(hax, hax_lib::ensures(|out|
+            fstar!(r#"$out == Spec.Utils.v_H $input"#)))
         ]
         #[inline(always)]
         fn H(input: &[u8]) -> [u8; H_DIGEST_SIZE] {
             H(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32"#))]
-        #[ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
-            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#))
+            fstar!(r#"v $LEN < pow2 32 ==> $out == Spec.Utils.v_PRF $LEN $input"#)))
         ]
         #[inline(always)]
         fn PRF<const LEN: usize>(input: &[u8]) -> [u8; LEN] {
             PRF::<LEN>(input)
         }
 
-        #[requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#))]
-        #[ensures(|out|
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|out|
             // We need to repeat the pre-condition here because of https://github.com/hacspec/hax/issues/784
             fstar!(r#"(v $LEN < pow2 32 /\ (v $K == 2 \/ v $K == 3 \/ v $K == 4)) ==>
-                $out == Spec.Utils.v_PRFxN $K $LEN $input"#))
+                $out == Spec.Utils.v_PRFxN $K $LEN $input"#)))
         ]
         #[inline(always)]
         fn PRFxN<const LEN: usize>(input: &[[u8; 33]; K]) -> [[u8; LEN]; K] {

--- a/libcrux-ml-kem/src/ind_cca.rs
+++ b/libcrux-ml-kem/src/ind_cca.rs
@@ -43,16 +43,16 @@ pub(crate) mod incremental;
 /// Serialize the secret key.
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SERIALIZED_KEY_LEN == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     ${private_key.len()} == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     ${public_key.len()} == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-    ${implicit_rejection_value.len()} == Spec.MLKEM.v_SHARED_SECRET_SIZE"#))]
-#[hax_lib::ensures(|result| fstar!(r#"${serialized}_future == Seq.append $private_key (
+    ${implicit_rejection_value.len()} == Spec.MLKEM.v_SHARED_SECRET_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${serialized}_future == Seq.append $private_key (
                                               Seq.append $public_key (
                                               Seq.append (Spec.Utils.v_H $public_key) 
-                                                  $implicit_rejection_value))"#))]
+                                                  $implicit_rejection_value))"#)))]
 fn serialize_kem_secret_key_mut<
     const K: usize,
     const SERIALIZED_KEY_LEN: usize,
@@ -73,6 +73,7 @@ fn serialize_kem_secret_key_mut<
     serialized[pointer..pointer + implicit_rejection_value.len()]
         .copy_from_slice(implicit_rejection_value);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
    "let open Spec.Utils in
     assert (Seq.slice serialized 0 (v #usize_inttype (Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K)) `Seq.equal` $private_key);
@@ -97,16 +98,16 @@ fn serialize_kem_secret_key_mut<
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SERIALIZED_KEY_LEN == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     ${private_key.len()} == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     ${public_key.len()} == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
-    ${implicit_rejection_value.len()} == Spec.MLKEM.v_SHARED_SECRET_SIZE"#))]
-#[hax_lib::ensures(|result| fstar!(r#"$result == Seq.append $private_key (
+    ${implicit_rejection_value.len()} == Spec.MLKEM.v_SHARED_SECRET_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"$result == Seq.append $private_key (
                                               Seq.append $public_key (
                                               Seq.append (Spec.Utils.v_H $public_key) 
-                                                  $implicit_rejection_value))"#))]
+                                                  $implicit_rejection_value))"#)))]
 fn serialize_kem_secret_key<const K: usize, const SERIALIZED_KEY_LEN: usize, Hasher: Hash<K>>(
     private_key: &[u8],
     public_key: &[u8],
@@ -129,8 +130,8 @@ fn serialize_kem_secret_key<const K: usize, const SERIALIZED_KEY_LEN: usize, Has
 /// Note that the size check in 7.2 1 is covered by the `PUBLIC_KEY_SIZE` in the
 /// `public_key` type.
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#)))]
 pub(crate) fn validate_public_key<
     const K: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -155,10 +156,10 @@ pub(crate) fn validate_public_key<
 /// Note that the size checks in 7.2 1 and 2 are covered by the `SECRET_KEY_SIZE`
 /// and `CIPHERTEXT_SIZE` in the `private_key` and `ciphertext` types.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
-    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
 pub(crate) fn validate_private_key<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -175,9 +176,9 @@ pub(crate) fn validate_private_key<
 ///
 /// This implements the Hash check in 7.3 3.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#)))]
 pub(crate) fn validate_private_key_only<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -199,15 +200,15 @@ pub(crate) fn validate_private_key_only<
 ///
 /// Depending on the `Vector` and `Hasher` used, this requires different hardware
 /// features
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
-#[hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_generate_keypair $K $randomness in
-                                    valid ==> (${result}.f_sk.f_value, ${result}.f_pk.f_value) == expected"#))]
+    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_generate_keypair $K $randomness in
+                                    valid ==> (${result}.f_sk.f_value, ${result}.f_pk.f_value) == expected"#)))]
 #[inline(always)]
 pub(crate) fn generate_keypair<
     const K: usize,
@@ -247,8 +248,8 @@ pub(crate) fn generate_keypair<
     MlKemKeyPair::from(private_key, MlKemPublicKey::from(public_key))
 }
 
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -260,9 +261,9 @@ pub(crate) fn generate_keypair<
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
-#[hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_encapsulate $K ${public_key}.f_value $randomness in
-                                    valid ==> (${result}._1.f_value, ${result}._2) == expected"#))]
+    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_encapsulate $K ${public_key}.f_value $randomness in
+                                    valid ==> (${result}._1.f_value, ${result}._2) == expected"#)))]
 #[inline(always)]
 pub(crate) fn encapsulate<
     const K: usize,
@@ -288,9 +289,11 @@ pub(crate) fn encapsulate<
     let randomness = Scheme::entropy_preprocess::<K, Hasher>(randomness);
     let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(&randomness);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $randomness"#);
     to_hash[H_DIGEST_SIZE..].copy_from_slice(&Hasher::H(public_key.as_slice()));
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (Seq.slice to_hash 0 (v $H_DIGEST_SIZE) == $randomness);
         lemma_slice_append $to_hash $randomness (Spec.Utils.v_H ${public_key}.f_value);
@@ -323,9 +326,9 @@ pub(crate) fn encapsulate<
 }
 
 /// This code verifies on some machines, runs out of memory on others
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::fstar::options("--z3rlimit 500")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -340,9 +343,9 @@ pub(crate) fn encapsulate<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
-#[hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_decapsulate $K ${private_key}.f_value ${ciphertext}.f_value in
-                                    valid ==> $result == expected"#))]
+    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cca_decapsulate $K ${private_key}.f_value ${ciphertext}.f_value in
+                                    valid ==> $result == expected"#)))]
 #[inline(always)]
 pub(crate) fn decapsulate<
     const K: usize,
@@ -368,12 +371,14 @@ pub(crate) fn decapsulate<
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
     ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
 ) -> MlKemSharedSecret {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $CIPHERTEXT_SIZE == v $IMPLICIT_REJECTION_HASH_INPUT_SIZE - v $SHARED_SECRET_SIZE)"#
     );
     let (ind_cpa_secret_key, ind_cpa_public_key, ind_cpa_public_key_hash, implicit_rejection_value) =
         unpack_private_key::<CPA_SECRET_KEY_SIZE, PUBLIC_KEY_SIZE>(&private_key.value);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert ($ind_cpa_secret_key == slice ${private_key}.f_value (sz 0) $CPA_SECRET_KEY_SIZE);
         assert ($ind_cpa_public_key == slice ${private_key}.f_value $CPA_SECRET_KEY_SIZE ($CPA_SECRET_KEY_SIZE +! $PUBLIC_KEY_SIZE));
@@ -392,9 +397,11 @@ pub(crate) fn decapsulate<
     >(ind_cpa_secret_key, &ciphertext.value);
 
     let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $decrypted"#);
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(ind_cpa_public_key_hash);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"lemma_slice_append to_hash $decrypted $ind_cpa_public_key_hash;
         assert ($decrypted == Spec.MLKEM.ind_cpa_decrypt $K $ind_cpa_secret_key ${ciphertext}.f_value);
@@ -403,6 +410,7 @@ pub(crate) fn decapsulate<
     let hashed = Hasher::G(&to_hash);
     let (shared_secret, pseudorandomness) = hashed.split_at(SHARED_SECRET_SIZE);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (($shared_secret , $pseudorandomness) == split $hashed $SHARED_SECRET_SIZE);
         assert (length $implicit_rejection_value = $SECRET_KEY_SIZE -! $CPA_SECRET_KEY_SIZE -! $PUBLIC_KEY_SIZE -! $H_DIGEST_SIZE);
@@ -411,8 +419,10 @@ pub(crate) fn decapsulate<
     );
     let mut to_hash: [u8; IMPLICIT_REJECTION_HASH_INPUT_SIZE] =
         into_padded_array(implicit_rejection_value);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $implicit_rejection_value"#);
     to_hash[SHARED_SECRET_SIZE..].copy_from_slice(ciphertext.as_ref());
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert_norm (pow2 32 == 0x100000000);
         assert (v (sz 32) < pow2 32);
@@ -421,6 +431,7 @@ pub(crate) fn decapsulate<
     );
     let implicit_rejection_shared_secret: [u8; SHARED_SECRET_SIZE] = Hasher::PRF(&to_hash);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert ($implicit_rejection_shared_secret == Spec.Utils.v_PRF (sz 32) $to_hash);
         assert (Seq.length $ind_cpa_public_key == v $PUBLIC_KEY_SIZE)"
@@ -494,19 +505,19 @@ pub(crate) mod unpacked {
     }
 
     /// Generate an unpacked key from a serialized key.
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         fstar!(r#"Spec.MLKEM.is_rank $K /\
         $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
         $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K"#)
-    )]
-    #[hax_lib::ensures(|result| {
+    ))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| {
         let unpacked_public_key_future = future(unpacked_public_key);
         {fstar!(r#"let (public_key_hash, (seed, (deserialized_pk, (matrix_A, valid)))) =
             Spec.MLKEM.ind_cca_unpack_public_key $K ${public_key}.f_value in (valid ==>
             Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${unpacked_public_key_future.ind_cpa_public_key.A} == matrix_A) /\
         Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${unpacked_public_key_future.ind_cpa_public_key.t_as_ntt} == deserialized_pk /\
         ${unpacked_public_key_future.ind_cpa_public_key.seed_for_A} == seed /\
-        ${unpacked_public_key_future.public_key_hash} == public_key_hash"#)}})
+        ${unpacked_public_key_future.public_key_hash} == public_key_hash"#)}}))
     ]
     #[inline(always)]
     pub(crate) fn unpack_public_key<
@@ -523,6 +534,7 @@ pub(crate) mod unpacked {
             &public_key.value[..T_AS_NTT_ENCODED_SIZE],
             &mut unpacked_public_key.ind_cpa_public_key.t_as_ntt,
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"let (_, seed) = split ${public_key}.f_value (Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K) in
             eq_intro (Libcrux_ml_kem.Utils.into_padded_array (sz 32) seed) seed;
@@ -538,24 +550,24 @@ pub(crate) mod unpacked {
         unpacked_public_key.public_key_hash = Hasher::H(public_key.as_slice());
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     impl<const K: usize, Vector: Operations> MlKemPublicKeyUnpacked<K, Vector> {
         /// Get the serialized public key.
         #[inline(always)]
-        #[requires(fstar!(r#"let ${self_} = self in
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"let ${self_} = self in
         Spec.MLKEM.is_rank $K /\
             $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
             (forall (i:nat). i < v $K ==>
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                    ${self_.ind_cpa_public_key.t_as_ntt} i))"#))]
-        #[ensures(|_|
+                    ${self_.ind_cpa_public_key.t_as_ntt} i))"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|_|
             fstar!(r#"let ${self_} = self in            
             ${serialized}_future.f_value == 
                 Seq.append (Spec.MLKEM.vector_encode_12 #$K
                     (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector
                         ${self_.ind_cpa_public_key.t_as_ntt}))
                 ${self_.ind_cpa_public_key.seed_for_A})"#)
-        )]
+        ))]
         pub fn serialized_mut<const PUBLIC_KEY_SIZE: usize>(
             &self,
             serialized: &mut MlKemPublicKey<PUBLIC_KEY_SIZE>,
@@ -569,19 +581,19 @@ pub(crate) mod unpacked {
 
         /// Get the serialized public key.
         #[inline(always)]
-        #[requires(fstar!(r#"let ${self_} = self in
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"let ${self_} = self in
         Spec.MLKEM.is_rank $K /\
             $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
             (forall (i:nat). i < v $K ==>
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index
-                    ${self_.ind_cpa_public_key.t_as_ntt} i))"#))]
-        #[ensures(|res|
+                    ${self_.ind_cpa_public_key.t_as_ntt} i))"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|res|
             fstar!(r#"let ${self_} = self in
             ${res.value} == Seq.append (Spec.MLKEM.vector_encode_12 #$K
                             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector
                                 ${self_.ind_cpa_public_key.t_as_ntt}))
                         ${self_.ind_cpa_public_key.seed_for_A})"#)
-        )]
+        ))]
         pub fn serialized<const PUBLIC_KEY_SIZE: usize>(&self) -> MlKemPublicKey<PUBLIC_KEY_SIZE> {
             MlKemPublicKey::from(serialize_public_key::<K, PUBLIC_KEY_SIZE, Vector>(
                 &self.ind_cpa_public_key.t_as_ntt,
@@ -602,11 +614,11 @@ pub(crate) mod unpacked {
 
     /// Take a serialized private key and generate an unpacked key pair from it.
     #[inline(always)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
            v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
            v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
            v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-           v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
+           v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#)))]
     pub fn keys_from_private_key<
         const K: usize,
         const SECRET_KEY_SIZE: usize,
@@ -648,7 +660,7 @@ pub(crate) mod unpacked {
             .copy_from_slice(&ind_cpa_public_key[T_AS_NTT_ENCODED_SIZE..]);
     }
 
-    #[hax_lib::attributes]
+    #[cfg_attr(hax, hax_lib::attributes)]
     impl<const K: usize, Vector: Operations> MlKemKeyPairUnpacked<K, Vector> {
         /// Create a new empty unpacked key pair.
         #[inline(always)]
@@ -658,11 +670,11 @@ pub(crate) mod unpacked {
 
         /// Take a serialized private key and generate an unpacked key pair from it.
         #[inline(always)]
-        #[requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
            v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
            v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
            v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-           v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K)"#))]
+           v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K)"#)))]
         pub fn from_private_key<
             const SECRET_KEY_SIZE: usize,
             const CPA_SECRET_KEY_SIZE: usize,
@@ -685,20 +697,20 @@ pub(crate) mod unpacked {
 
         /// Get the serialized public key.
         #[inline(always)]
-        #[requires(fstar!(r#"let ${self_} = self in
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"let ${self_} = self in
         Spec.MLKEM.is_rank $K /\
             $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
             (forall (i:nat). i < v $K ==>
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                    ${self_.public_key.ind_cpa_public_key.t_as_ntt} i))"#))]
-        #[ensures(|_|
+                    ${self_.public_key.ind_cpa_public_key.t_as_ntt} i))"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|_|
             fstar!(r#"let ${self_} = self in
             ${serialized}_future.f_value == 
                 Seq.append (Spec.MLKEM.vector_encode_12 #$K
                     (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector
                         ${self_.public_key.ind_cpa_public_key.t_as_ntt}))
                 ${self_.public_key.ind_cpa_public_key.seed_for_A})"#)
-        )]
+        ))]
         pub fn serialized_public_key_mut<const PUBLIC_KEY_SIZE: usize>(
             &self,
             serialized: &mut MlKemPublicKey<PUBLIC_KEY_SIZE>,
@@ -709,19 +721,19 @@ pub(crate) mod unpacked {
 
         /// Get the serialized public key.
         #[inline(always)]
-        #[requires(fstar!(r#"let ${self_} = self in
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"let ${self_} = self in
         Spec.MLKEM.is_rank $K /\
             $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
             (forall (i:nat). i < v $K ==>
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index
-                    ${self_.public_key.ind_cpa_public_key.t_as_ntt} i))"#))]
-        #[ensures(|res|
+                    ${self_.public_key.ind_cpa_public_key.t_as_ntt} i))"#)))]
+        #[cfg_attr(hax, hax_lib::ensures(|res|
             fstar!(r#"let ${self_} = self in
             ${res}.f_value == Seq.append (Spec.MLKEM.vector_encode_12 #$K
                             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector
                                 ${self_.public_key.ind_cpa_public_key.t_as_ntt}))
                         ${self_.public_key.ind_cpa_public_key.seed_for_A})"#)
-        )]
+        ))]
         pub fn serialized_public_key<const PUBLIC_KEY_SIZE: usize>(
             &self,
         ) -> MlKemPublicKey<PUBLIC_KEY_SIZE> {
@@ -742,10 +754,10 @@ pub(crate) mod unpacked {
 
         /// Get the serialized private key.
         #[inline(always)]
-        #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
             $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
             $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
-            $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
+            $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
         pub fn serialized_private_key_mut<
             const CPA_PRIVATE_KEY_SIZE: usize,
             const PRIVATE_KEY_SIZE: usize,
@@ -774,10 +786,10 @@ pub(crate) mod unpacked {
 
         /// Get the serialized private key.
         #[inline(always)]
-        #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+        #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
             $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
             $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
-            $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
+            $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
         pub fn serialized_private_key<
             const CPA_PRIVATE_KEY_SIZE: usize,
             const PRIVATE_KEY_SIZE: usize,
@@ -804,13 +816,13 @@ pub(crate) mod unpacked {
         }
     }
 
-    #[hax_lib::fstar::options("--z3rlimit 200")]
-    #[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
-    #[hax_lib::ensures(|result|
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"forall (i: nat). i < v $K ==>
             (forall (j: nat). j < v $K ==>
                 Seq.index (Seq.index $result i) j ==
-                    Seq.index (Seq.index $ind_cpa_a j) i)"#))
+                    Seq.index (Seq.index $ind_cpa_a j) i)"#)))
     ]
     fn transpose_a<const K: usize, Vector: Operations>(
         ind_cpa_a: [[PolynomialRingElement<Vector>; K]; K],
@@ -826,6 +838,7 @@ pub(crate) mod unpacked {
         #[allow(non_snake_case)]
         let mut A = from_fn(|_i| from_fn(|_j| PolynomialRingElement::<Vector>::ZERO()));
         for i in 0..K {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| {
                 fstar!(
                     r#"forall (j: nat). j < v $i ==>
@@ -836,6 +849,7 @@ pub(crate) mod unpacked {
             });
             let _a_i = A;
             for j in 0..K {
+                #[cfg(hax)]
                 hax_lib::loop_invariant!(|j: usize| {
                     fstar!(
                         r#"(forall (k: nat). k < v $i ==>
@@ -853,20 +867,23 @@ pub(crate) mod unpacked {
 
     /// Generate Unpacked Keys
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 300 --ext context_pruning --split_queries always")]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::options("--z3rlimit 300 --ext context_pruning --split_queries always")
+    )]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
-    #[hax_lib::ensures(|result|
+        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"let ((m_A, public_key_hash), implicit_rejection_value), valid =
             Spec.MLKEM.ind_cca_unpack_generate_keypair $K $randomness in
         valid ==> Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector
             ${out}_future.f_public_key.f_ind_cpa_public_key.f_A == m_A /\
         ${out}_future.f_public_key.f_public_key_hash == public_key_hash /\
-        ${out}_future.f_private_key.f_implicit_rejection_value == implicit_rejection_value"#))
+        ${out}_future.f_private_key.f_implicit_rejection_value == implicit_rejection_value"#)))
     ]
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub(crate) fn generate_keypair<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
@@ -892,6 +909,7 @@ pub(crate) mod unpacked {
 
         #[allow(non_snake_case)]
         let A = transpose_a::<K, Vector>(out.public_key.ind_cpa_public_key.A);
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"let (ind_cpa_keypair_randomness, _) = split $randomness Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE in
         let ((((_, _), matrix_A_as_ntt), _), sufficient_randomness) =
@@ -924,7 +942,7 @@ pub(crate) mod unpacked {
 
     // Encapsulate with Unpacked Public Key
     #[inline(always)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -934,15 +952,15 @@ pub(crate) mod unpacked {
         $VECTOR_U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $VECTOR_U_BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
-        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
-    #[hax_lib::ensures(|(ciphertext_result, shared_secret_array)|
+        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|(ciphertext_result, shared_secret_array)|
         fstar!(r#"let (ciphertext, shared_secret) =
             Spec.MLKEM.ind_cca_unpack_encapsulate $K ${public_key}.f_public_key_hash
             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${public_key.ind_cpa_public_key.t_as_ntt})
             (Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${public_key.ind_cpa_public_key.A})
             $randomness in
         ${ciphertext_result}.f_value == ciphertext /\
-        $shared_secret_array == shared_secret"#))
+        $shared_secret_array == shared_secret"#)))
     ]
     pub(crate) fn encapsulate<
         const K: usize,
@@ -992,18 +1010,20 @@ pub(crate) mod unpacked {
         (MlKemCiphertext::from(ciphertext), shared_secret_array)
     }
 
-    #[hax_lib::requires(randomness.len() == 32 && pk_hash.len() == 32)]
-    #[hax_lib::ensures(|result| fstar!("result == Spec.Utils.v_G (concat randomness pk_hash)"))]
+    #[cfg_attr(hax, hax_lib::requires(randomness.len() == 32 && pk_hash.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!("result == Spec.Utils.v_G (concat randomness pk_hash)")))]
     pub(crate) fn encaps_prepare<const K: usize, Hasher: Hash<K>>(
         randomness: &[u8],
         pk_hash: &[u8],
     ) -> [u8; 64] {
+        #[cfg(hax)]
         hax_lib::fstar!(
             "eq_intro (Seq.slice (
             Libcrux_ml_kem.Utils.into_padded_array (sz 64) $randomness) 0 32) $randomness"
         );
         let mut to_hash: [u8; 2 * H_DIGEST_SIZE] = into_padded_array(randomness);
         to_hash[H_DIGEST_SIZE..].copy_from_slice(pk_hash);
+        #[cfg(hax)]
         hax_lib::fstar!(
             "eq_intro $to_hash (
             concat $randomness $pk_hash)"
@@ -1014,8 +1034,8 @@ pub(crate) mod unpacked {
 
     // Decapsulate with Unpacked Private Key
     #[inline(always)]
-    #[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -1026,15 +1046,15 @@ pub(crate) mod unpacked {
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $C1_BLOCK_SIZE == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
         $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
-        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
-    #[hax_lib::ensures(|result|
+        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"$result ==
             Spec.MLKEM.ind_cca_unpack_decapsulate $K ${key_pair.public_key.public_key_hash}
             ${key_pair.private_key.implicit_rejection_value}
             ${ciphertext.value}
             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${key_pair.private_key.ind_cpa_private_key.secret_as_ntt})
             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${key_pair.public_key.ind_cpa_public_key.t_as_ntt})
-            (Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${key_pair.public_key.ind_cpa_public_key.A})"#))
+            (Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${key_pair.public_key.ind_cpa_public_key.A})"#)))
     ]
     pub(crate) fn decapsulate<
         const K: usize,
@@ -1059,6 +1079,7 @@ pub(crate) mod unpacked {
         key_pair: &MlKemKeyPairUnpacked<K, Vector>,
         ciphertext: &MlKemCiphertext<CIPHERTEXT_SIZE>,
     ) -> MlKemSharedSecret {
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"assert (v $IMPLICIT_REJECTION_HASH_INPUT_SIZE == 32 + v (Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K));
         assert (v (Spec.MLKEM.v_C1_SIZE $K +! Spec.MLKEM.v_C2_SIZE $K) == v (Spec.MLKEM.v_C1_SIZE $K) + v (Spec.MLKEM.v_C2_SIZE $K));
@@ -1076,8 +1097,10 @@ pub(crate) mod unpacked {
         >(&key_pair.private_key.ind_cpa_private_key, &ciphertext.value);
 
         let mut to_hash: [u8; SHARED_SECRET_SIZE + H_DIGEST_SIZE] = into_padded_array(&decrypted);
+        #[cfg(hax)]
         hax_lib::fstar!(r#"eq_intro (Seq.slice $to_hash 0 32) $decrypted"#);
         to_hash[SHARED_SECRET_SIZE..].copy_from_slice(&key_pair.public_key.public_key_hash);
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"lemma_slice_append $to_hash $decrypted ${key_pair}.f_public_key.f_public_key_hash"#
         );
@@ -1087,11 +1110,13 @@ pub(crate) mod unpacked {
 
         let mut to_hash: [u8; IMPLICIT_REJECTION_HASH_INPUT_SIZE] =
             into_padded_array(&key_pair.private_key.implicit_rejection_value);
+        #[cfg(hax)]
         hax_lib::fstar!(
             "eq_intro
             (Seq.slice $to_hash 0 32) ${key_pair}.f_private_key.f_implicit_rejection_value"
         );
         to_hash[SHARED_SECRET_SIZE..].copy_from_slice(ciphertext.as_ref());
+        #[cfg(hax)]
         hax_lib::fstar!(
             "lemma_slice_append $to_hash ${key_pair}.f_private_key.f_implicit_rejection_value ${ciphertext}.f_value"
         );

--- a/libcrux-ml-kem/src/ind_cca/instantiations.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations.rs
@@ -7,12 +7,12 @@ macro_rules! instantiate {
             };
 
             /// Portable generate key pair.
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                 $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                 $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                 $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
                 $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-                $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
+                $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
             pub(crate) fn generate_keypair<
                 const K: usize,
                 const CPA_PRIVATE_KEY_SIZE: usize,
@@ -62,8 +62,8 @@ macro_rules! instantiate {
 
             /// Public key validation
             #[inline(always)]
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-                $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+                $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#)))]
             pub(crate) fn validate_public_key<
                 const K: usize,
                 const PUBLIC_KEY_SIZE: usize,
@@ -79,9 +79,9 @@ macro_rules! instantiate {
 
             /// Private key validation
             #[inline(always)]
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                 $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
-                $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+                $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
             pub(crate) fn validate_private_key<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -98,8 +98,8 @@ macro_rules! instantiate {
 
             /// Private key validation
             #[inline(always)]
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-                $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#))]
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+                $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#)))]
             pub(crate) fn validate_private_key_only<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -149,7 +149,7 @@ macro_rules! instantiate {
                 >(public_key, randomness)
             }
 
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                 $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
                 $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
                 $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -161,7 +161,7 @@ macro_rules! instantiate {
                 $ETA1 == Spec.MLKEM.v_ETA1 $K /\
                 $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
                 $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-                $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
+                $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
             pub(crate) fn encapsulate<
                 const K: usize,
                 const CIPHERTEXT_SIZE: usize,
@@ -247,7 +247,7 @@ macro_rules! instantiate {
             }
 
             /// Portable decapsulate
-            #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+            #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                 $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                 $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                 $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -262,7 +262,7 @@ macro_rules! instantiate {
                 $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
                 $ETA2 == Spec.MLKEM.v_ETA2 $K /\
                 $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-                $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+                $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
             pub fn decapsulate<
                 const K: usize,
                 const SECRET_KEY_SIZE: usize,
@@ -317,11 +317,11 @@ macro_rules! instantiate {
                     crate::ind_cca::unpacked::MlKemPublicKeyUnpacked<K, $vector>;
 
                 /// Get the unpacked public key.
-                #[hax_lib::requires(
+                #[cfg_attr(hax, hax_lib::requires(
                     fstar!(r#"Spec.MLKEM.is_rank $K /\
                     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
                     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K"#)
-                )]
+                ))]
                 #[inline(always)]
                 pub(crate) fn unpack_public_key<
                     const K: usize,
@@ -342,12 +342,12 @@ macro_rules! instantiate {
 
                 /// Take a serialized private key and generate an unpacked key pair from it.
                 #[inline(always)]
-                #[hax_lib::requires(
+                #[cfg_attr(hax, hax_lib::requires(
                     fstar!(r#"Spec.MLKEM.is_rank $K /\
                             v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
                             v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
                             v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-                            v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
+                            v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#)))]
                 pub(crate) fn keypair_from_private_key<
                     const K: usize,
                     const SECRET_KEY_SIZE: usize,
@@ -369,12 +369,12 @@ macro_rules! instantiate {
                 }
 
                 /// Generate a key pair
-                #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
                     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-                    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
+                    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
                 #[inline(always)]
                 pub(crate) fn generate_keypair<
                     const K: usize,
@@ -401,7 +401,7 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked encapsulate
-                #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
                     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
                     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -413,7 +413,7 @@ macro_rules! instantiate {
                     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
                     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
                     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-                    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
+                    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
                 #[inline(always)]
                 pub(crate) fn encapsulate<
                     const K: usize,
@@ -453,7 +453,7 @@ macro_rules! instantiate {
                 }
 
                 /// Unpacked decapsulate
-                #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
                     $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
                     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -468,7 +468,7 @@ macro_rules! instantiate {
                     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
                     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
                     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-                    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+                    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
                 #[inline(always)]
                 pub(crate) fn decapsulate<
                     const K: usize,

--- a/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
+++ b/libcrux-ml-kem/src/ind_cca/instantiations/avx2.rs
@@ -6,12 +6,12 @@ use crate::{
 #[allow(unsafe_code)]
 /// Portable generate key pair.
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
+    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
 unsafe fn generate_keypair_avx2<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -36,12 +36,12 @@ unsafe fn generate_keypair_avx2<
 }
 
 #[allow(unsafe_code)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
+    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
 pub(crate) fn generate_keypair<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -116,8 +116,8 @@ pub(crate) fn kyber_generate_keypair<
 
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#)))]
 unsafe fn validate_public_key_avx2<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
 ) -> bool {
@@ -127,8 +127,8 @@ unsafe fn validate_public_key_avx2<const K: usize, const PUBLIC_KEY_SIZE: usize>
 }
 
 #[allow(unsafe_code)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#)))]
 pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
 ) -> bool {
@@ -137,9 +137,9 @@ pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
 
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
-    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
 unsafe fn validate_private_key_avx2<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -157,9 +157,9 @@ unsafe fn validate_private_key_avx2<
 }
 
 #[allow(unsafe_code)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
-    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+    $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
 pub(crate) fn validate_private_key<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -175,8 +175,8 @@ pub(crate) fn validate_private_key<
 
 /// Private key validation
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K"#)))]
 pub(crate) fn validate_private_key_only<const K: usize, const SECRET_KEY_SIZE: usize>(
     private_key: &MlKemPrivateKey<SECRET_KEY_SIZE>,
 ) -> bool {
@@ -269,7 +269,7 @@ pub(crate) fn kyber_encapsulate<
 
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -281,7 +281,7 @@ pub(crate) fn kyber_encapsulate<
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
+    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
 unsafe fn encapsulate_avx2<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -321,7 +321,7 @@ unsafe fn encapsulate_avx2<
 }
 
 #[allow(unsafe_code)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -333,7 +333,7 @@ unsafe fn encapsulate_avx2<
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
+    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
 pub(crate) fn encapsulate<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -465,7 +465,7 @@ pub fn kyber_decapsulate<
 
 #[allow(unsafe_code)]
 #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -480,7 +480,7 @@ pub fn kyber_decapsulate<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
 unsafe fn decapsulate_avx2<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -526,7 +526,7 @@ unsafe fn decapsulate_avx2<
 }
 
 #[allow(unsafe_code)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -541,7 +541,7 @@ unsafe fn decapsulate_avx2<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
 pub fn decapsulate<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -597,11 +597,11 @@ pub(crate) mod unpacked {
     /// Get the unpacked public key.
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
     #[allow(unsafe_code)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         fstar!(r#"Spec.MLKEM.is_rank $K /\
         $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
         $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K"#)
-    )]
+    ))]
     unsafe fn unpack_public_key_avx2<
         const K: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
@@ -621,11 +621,11 @@ pub(crate) mod unpacked {
 
     /// Get the unpacked public key.
     #[allow(unsafe_code)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         fstar!(r#"Spec.MLKEM.is_rank $K /\
         $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
         $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K"#)
-    )]
+    ))]
     pub(crate) fn unpack_public_key<
         const K: usize,
         const T_AS_NTT_ENCODED_SIZE: usize,
@@ -644,12 +644,12 @@ pub(crate) mod unpacked {
 
     /// Take a serialized private key and generate an unpacked key pair from it.
     #[inline(always)]
-    #[hax_lib::requires(
+    #[cfg_attr(hax, hax_lib::requires(
         fstar!(r#"Spec.MLKEM.is_rank $K /\
                 v_SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE v_K /\
                 v_CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE v_K /\
                 v_PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE v_K /\
-                v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#))]
+                v_T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K"#)))]
     pub(crate) fn keypair_from_private_key<
         const K: usize,
         const SECRET_KEY_SIZE: usize,
@@ -672,10 +672,10 @@ pub(crate) mod unpacked {
 
     #[allow(unsafe_code)]
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
+        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
     unsafe fn generate_keypair_avx2<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
@@ -702,10 +702,10 @@ pub(crate) mod unpacked {
 
     /// Generate a key pair
     #[allow(unsafe_code)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
+        $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
     pub(crate) fn generate_keypair<
         const K: usize,
         const CPA_PRIVATE_KEY_SIZE: usize,
@@ -731,7 +731,7 @@ pub(crate) mod unpacked {
 
     #[allow(unsafe_code)]
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -741,7 +741,7 @@ pub(crate) mod unpacked {
         $VECTOR_U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $VECTOR_U_BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
-        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
     unsafe fn encapsulate_avx2<
         const K: usize,
         const CIPHERTEXT_SIZE: usize,
@@ -781,7 +781,7 @@ pub(crate) mod unpacked {
 
     /// Unpacked encapsulate
     #[allow(unsafe_code)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -791,7 +791,7 @@ pub(crate) mod unpacked {
         $VECTOR_U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $VECTOR_U_BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
-        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+        $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
     pub(crate) fn encapsulate<
         const K: usize,
         const CIPHERTEXT_SIZE: usize,
@@ -831,7 +831,7 @@ pub(crate) mod unpacked {
 
     #[cfg_attr(not(hax), target_feature(enable = "avx2"))]
     #[allow(unsafe_code)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -842,7 +842,7 @@ pub(crate) mod unpacked {
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $C1_BLOCK_SIZE == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
         $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
-        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
     unsafe fn decapsulate_avx2<
         const K: usize,
         const SECRET_KEY_SIZE: usize,
@@ -888,7 +888,7 @@ pub(crate) mod unpacked {
 
     /// Unpacked decapsulate
     #[allow(unsafe_code)]
-    #[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
         $ETA1 == Spec.MLKEM.v_ETA1 $K /\
         $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
         $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -899,7 +899,7 @@ pub(crate) mod unpacked {
         $VECTOR_V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
         $C1_BLOCK_SIZE == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
         $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
-        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+        $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
     pub(crate) fn decapsulate<
         const K: usize,
         const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cca/multiplexing.rs
+++ b/libcrux-ml-kem/src/ind_cca/multiplexing.rs
@@ -1,59 +1,51 @@
-use super::*;
-
 // For the case where we didn't compile with the simd128/simd256 features but
 // have a CPU that has it and thus tries to call the simd128/simd256 version,
 // we fall back to the portable version in this case.
-
 #[cfg(feature = "simd256")]
 use instantiations::avx2::{
     decapsulate as decapsulate_avx2, encapsulate as encapsulate_avx2,
     generate_keypair as generate_keypair_avx2,
 };
-
-#[cfg(feature = "simd128")]
-use instantiations::neon::{
-    decapsulate as decapsulate_neon, encapsulate as encapsulate_neon,
-    generate_keypair as generate_keypair_neon,
-};
-
-#[cfg(not(feature = "simd256"))]
-use instantiations::portable::{
-    decapsulate as decapsulate_avx2, encapsulate as encapsulate_avx2,
-    generate_keypair as generate_keypair_avx2,
-};
-
-#[cfg(not(feature = "simd128"))]
-use instantiations::portable::{
-    decapsulate as decapsulate_neon, encapsulate as encapsulate_neon,
-    generate_keypair as generate_keypair_neon,
-};
-
 #[cfg(all(feature = "simd256", feature = "kyber"))]
 use instantiations::avx2::{
     kyber_decapsulate as kyber_decapsulate_avx2, kyber_encapsulate as kyber_encapsulate_avx2,
     kyber_generate_keypair as kyber_generate_keypair_avx2,
 };
-
+#[cfg(feature = "simd128")]
+use instantiations::neon::{
+    decapsulate as decapsulate_neon, encapsulate as encapsulate_neon,
+    generate_keypair as generate_keypair_neon,
+};
 #[cfg(all(feature = "simd128", feature = "kyber"))]
 use instantiations::neon::{
     kyber_decapsulate as kyber_decapsulate_neon, kyber_encapsulate as kyber_encapsulate_neon,
     kyber_generate_keypair as kyber_generate_keypair_neon,
 };
-
+#[cfg(not(feature = "simd256"))]
+use instantiations::portable::{
+    decapsulate as decapsulate_avx2, encapsulate as encapsulate_avx2,
+    generate_keypair as generate_keypair_avx2,
+};
+#[cfg(not(feature = "simd128"))]
+use instantiations::portable::{
+    decapsulate as decapsulate_neon, encapsulate as encapsulate_neon,
+    generate_keypair as generate_keypair_neon,
+};
 #[cfg(all(not(feature = "simd256"), feature = "kyber"))]
 use instantiations::portable::{
     kyber_decapsulate as kyber_decapsulate_avx2, kyber_encapsulate as kyber_encapsulate_avx2,
     kyber_generate_keypair as kyber_generate_keypair_avx2,
 };
-
 #[cfg(all(not(feature = "simd128"), feature = "kyber"))]
 use instantiations::portable::{
     kyber_decapsulate as kyber_decapsulate_neon, kyber_encapsulate as kyber_encapsulate_neon,
     kyber_generate_keypair as kyber_generate_keypair_neon,
 };
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
-    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#))]
+use super::*;
+
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+    $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CCA_PUBLIC_KEY_SIZE $K"#)))]
 #[inline(always)]
 pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
     public_key: &[u8; PUBLIC_KEY_SIZE],
@@ -62,9 +54,9 @@ pub(crate) fn validate_public_key<const K: usize, const PUBLIC_KEY_SIZE: usize>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
                 $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
-                $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#))]
+                $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K"#)))]
 pub(crate) fn validate_private_key<
     const K: usize,
     const SECRET_KEY_SIZE: usize,
@@ -121,12 +113,12 @@ pub(crate) fn kyber_generate_keypair<
     }
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CPA_PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#))]
+    $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K"#)))]
 pub(crate) fn generate_keypair<
     const K: usize,
     const CPA_PRIVATE_KEY_SIZE: usize,
@@ -238,7 +230,7 @@ pub(crate) fn kyber_encapsulate<
     }
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
@@ -250,7 +242,7 @@ pub(crate) fn kyber_encapsulate<
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
-    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#))]
+    $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K"#)))]
 pub(crate) fn encapsulate<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -402,7 +394,7 @@ pub(crate) fn kyber_decapsulate<
     }
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $SECRET_KEY_SIZE == Spec.MLKEM.v_CCA_PRIVATE_KEY_SIZE $K /\
     $CPA_SECRET_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
@@ -417,7 +409,7 @@ pub(crate) fn kyber_decapsulate<
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
-    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#))]
+    $IMPLICIT_REJECTION_HASH_INPUT_SIZE == Spec.MLKEM.v_IMPLICIT_REJECTION_HASH_INPUT_SIZE $K"#)))]
 pub(crate) fn decapsulate<
     const K: usize,
     const SECRET_KEY_SIZE: usize,

--- a/libcrux-ml-kem/src/ind_cpa.rs
+++ b/libcrux-ml-kem/src/ind_cpa.rs
@@ -63,16 +63,16 @@ use unpacked::*;
 
 /// Concatenate `t` and `ρ` into the public key.
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     length $seed_for_a == sz 32 /\
     (forall (i:nat). i < v $K ==>
-        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $t_as_ntt i))"#))]
-#[hax_lib::ensures(|res|
+        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $t_as_ntt i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"$res == Seq.append (Spec.MLKEM.vector_encode_12 #$K
                             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $t_as_ntt))
                         $seed_for_a)"#)
-)]
+))]
 pub(crate) fn serialize_public_key<
     const K: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -92,17 +92,17 @@ pub(crate) fn serialize_public_key<
 
 /// Concatenate `t` and `ρ` into the public key.
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     length $seed_for_a == sz 32 /\
     (forall (i:nat). i < v $K ==>
-        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $t_as_ntt i))"#))]
-#[hax_lib::ensures(|res|
+        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $t_as_ntt i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"${serialized}_future == 
                         Seq.append (Spec.MLKEM.vector_encode_12 #$K
                             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $t_as_ntt))
                         $seed_for_a)"#)
-)]
+))]
 pub(crate) fn serialize_public_key_mut<
     const K: usize,
     const PUBLIC_KEY_SIZE: usize,
@@ -118,6 +118,7 @@ pub(crate) fn serialize_public_key_mut<
     );
 
     serialized[ranked_bytes_per_ring_element(K)..].copy_from_slice(seed_for_a);
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro serialized
         (Seq.append (Spec.MLKEM.vector_encode_12 #$K (Libcrux_ml_kem.Polynomial.to_spec_vector_t
@@ -127,23 +128,25 @@ pub(crate) fn serialize_public_key_mut<
 
 /// Call [`serialize_uncompressed_ring_element`] for each ring element.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 1000 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 1000 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     ${out.len()} == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
     (forall (i:nat). i < v $K ==>
-        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $key i))"#))]
-#[hax_lib::ensures(|()|
+        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $key i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|()|
     fstar!(r#"$out == Spec.MLKEM.vector_encode_12 #$K
             (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key)"#)
-)]
+))]
 pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
     key: &[PolynomialRingElement<Vector>; K],
     out: &mut [u8],
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial)"#);
 
     cloop! {
         for (i, re) in key.into_iter().enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| {
                 fstar!(r#"${out.len()} == Spec.MLKEM.v_RANKED_BYTES_PER_RING_ELEMENT $K /\
                     (v $i < v $K ==>
@@ -158,6 +161,7 @@ pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
             out[i * BYTES_PER_RING_ELEMENT..(i + 1) * BYTES_PER_RING_ELEMENT]
             .copy_from_slice(&serialize_uncompressed_ring_element(&re));
 
+            #[cfg(hax)]
             hax_lib::fstar!(r#"
                 let lemma_aux (j: nat{ j < v $i }) : Lemma
                 (Seq.slice out (j * v $BYTES_PER_RING_ELEMENT) ((j + 1) * v $BYTES_PER_RING_ELEMENT) ==
@@ -170,6 +174,7 @@ pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
         }
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Spec.MLKEM.coerce_vector_12 (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key) ==
         Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $key);
@@ -182,8 +187,11 @@ pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
 
 /// Sample a vector of ring elements from a centered binomial distribution.
 #[inline(always)]
-#[hax_lib::fstar::options(
-    "--max_fuel 15 --z3rlimit 1500 --ext context_pruning --split_queries always"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(
+        "--max_fuel 15 --z3rlimit 1500 --ext context_pruning --split_queries always"
+    )
 )]
 #[cfg_attr(
     hax,
@@ -244,18 +252,18 @@ pub(crate) fn serialize_vector<const K: usize, Vector: Operations>(
         (Seq.slice prf_input 0 32) (sz (v domain_separator))))"#
     )
 )]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $ETA2_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA2_RANDOMNESS_SIZE $K /\
     $ETA2 == Spec.MLKEM.v_ETA2 $K /\
     v $domain_separator < 2 * v $K /\
-    range (v $domain_separator + v $K) u8_inttype"#))]
-#[hax_lib::ensures(|ds|
+    range (v $domain_separator + v $K) u8_inttype"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|ds|
     fstar!(r#"v $ds == v $domain_separator + v $K /\
               (forall i. i < v $K ==> 
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 7 (Seq.index ${error_1} i))/\
                Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $error_1 ==
                Spec.MLKEM.sample_vector_cbd2 #$K (Seq.slice $prf_input 0 32) (sz (v $domain_separator))"#)
-)]
+))]
 fn sample_ring_element_cbd<
     const K: usize,
     const ETA2_RANDOMNESS_SIZE: usize,
@@ -273,11 +281,13 @@ fn sample_ring_element_cbd<
     let _domain_separator_init = domain_separator;
 
     domain_separator = prf_input_inc::<K>(&mut prf_inputs, domain_separator);
+    #[cfg(hax)]
     hax_lib::fstar!(
         "sample_ring_element_cbd_helper_1 $K $prf_inputs $prf_input $_domain_separator_init"
     );
     let prf_outputs: [[u8; ETA2_RANDOMNESS_SIZE]; K] = Hasher::PRFxN(&prf_inputs);
     for i in 0..K {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -289,6 +299,7 @@ fn sample_ring_element_cbd<
         });
         error_1[i] = sample_from_binomial_distribution::<ETA2, Vector>(&prf_outputs[i]);
     }
+    #[cfg(hax)]
     hax_lib::fstar!(
         "sample_ring_element_cbd_helper_2
         $K $ETA2 $ETA2_RANDOMNESS_SIZE #$:Vector error_1_ $prf_input $_domain_separator_init"
@@ -300,8 +311,11 @@ fn sample_ring_element_cbd<
 /// Sample a vector of ring elements from a centered binomial distribution and
 /// convert them into their NTT representations.
 #[inline(always)]
-#[hax_lib::fstar::options(
-    "--max_fuel 25 --z3rlimit 2500 --ext context_pruning --split_queries always"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(
+        "--max_fuel 25 --z3rlimit 2500 --ext context_pruning --split_queries always"
+    )
 )]
 #[cfg_attr(hax, hax_lib::fstar::before(r#"let sample_vector_cbd_then_ntt_helper_2
       (v_K v_ETA v_ETA_RANDOMNESS_SIZE: usize)
@@ -359,18 +373,18 @@ fn sample_ring_element_cbd<
         (Seq.slice prf_input 0 32) (sz (v domain_separator))))"#
     )
 )]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $ETA_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA == Spec.MLKEM.v_ETA1 $K /\
     v $domain_separator < 2 * v $K /\
-    range (v $domain_separator + v $K) u8_inttype"#))]
-#[hax_lib::ensures(|ds|
+    range (v $domain_separator + v $K) u8_inttype"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|ds|
     fstar!(r#"v $ds == v $domain_separator + v $K /\
             Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${re_as_ntt}_future ==
             Spec.MLKEM.sample_vector_cbd_then_ntt #$K (Seq.slice $prf_input 0 32) (sz (v $domain_separator)) /\
             (forall (i: nat). i < v $K ==>
               Libcrux_ml_kem.Polynomial.is_bounded_poly #$:Vector 3328 (Seq.index ${re_as_ntt}_future i))"#)
-)]
+))]
 fn sample_vector_cbd_then_ntt<
     const K: usize,
     const ETA: usize,
@@ -388,11 +402,13 @@ fn sample_vector_cbd_then_ntt<
     let _domain_separator_init = domain_separator;
 
     domain_separator = prf_input_inc::<K>(&mut prf_inputs, domain_separator);
+    #[cfg(hax)]
     hax_lib::fstar!(
         "sample_vector_cbd_then_ntt_helper_1 $K $prf_inputs $prf_input $_domain_separator_init"
     );
     let prf_outputs: [[u8; ETA_RANDOMNESS_SIZE]; K] = Hasher::PRFxN(&prf_inputs);
     for i in 0..K {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"forall (j:nat). j < v $i ==>
@@ -404,6 +420,7 @@ fn sample_vector_cbd_then_ntt<
         re_as_ntt[i] = sample_from_binomial_distribution::<ETA, Vector>(&prf_outputs[i]);
         ntt_binomially_sampled_ring_element(&mut re_as_ntt[i]);
     }
+    #[cfg(hax)]
     hax_lib::fstar!(
         "sample_vector_cbd_then_ntt_helper_2
         $K $ETA $ETA_RANDOMNESS_SIZE #$:Vector re_as_ntt $prf_input $_domain_separator_init"
@@ -450,13 +467,13 @@ fn sample_vector_cbd_then_ntt<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
-#[hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
-    length $key_generation_seed == Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE"#))]
-#[hax_lib::ensures(|_|
+    length $key_generation_seed == Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     {
     let public_key_future = future(public_key);
     {fstar!(r#"let ((((t_as_ntt,seed_for_A), matrix_A_as_ntt), secret_as_ntt), valid) = Spec.MLKEM.ind_cpa_generate_keypair_unpacked $K $key_generation_seed in 
@@ -468,7 +485,7 @@ fn sample_vector_cbd_then_ntt<
         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index ${private_key}_future.f_secret_as_ntt i)) /\
     (forall (i:nat). i < v $K ==>
         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index ${public_key_future.t_as_ntt} i))
-"#)}})]
+"#)}}))]
 #[inline(always)]
 pub(crate) fn generate_keypair_unpacked<
     const K: usize,
@@ -486,17 +503,20 @@ pub(crate) fn generate_keypair_unpacked<
     let hashed = Scheme::cpa_keygen_seed::<K, Hasher>(key_generation_seed);
     let (seed_for_A, seed_for_secret_and_error) = hashed.split_at(32);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro $seed_for_A
         (Seq.slice (Libcrux_ml_kem.Utils.into_padded_array (sz 34) $seed_for_A) 0 32)"
     );
     sample_matrix_A::<K, Vector, Hasher>(&mut public_key.A, &into_padded_array(seed_for_A), true);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"let (matrix_A_as_ntt, valid) = Spec.MLKEM.sample_matrix_A_ntt #$K $seed_for_A in
         assert (valid ==> matrix_A_as_ntt == Libcrux_ml_kem.Polynomial.to_spec_matrix_t public_key.f_A)"#
     );
     let prf_input: [u8; 33] = into_padded_array(seed_for_secret_and_error);
+    #[cfg(hax)]
     hax_lib::fstar!("eq_intro $seed_for_secret_and_error (Seq.slice $prf_input 0 32)");
     let domain_separator =
         sample_vector_cbd_then_ntt::<K, ETA1, ETA1_RANDOMNESS_SIZE, Vector, Hasher>(
@@ -522,6 +542,7 @@ pub(crate) fn generate_keypair_unpacked<
 
     public_key.seed_for_A = seed_for_A.try_into().unwrap();
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"let (((t_as_ntt,seed_for_A), matrix_A_as_ntt), secret_as_ntt), valid =
         Spec.MLKEM.ind_cpa_generate_keypair_unpacked $K $key_generation_seed in
@@ -543,14 +564,14 @@ pub(crate) fn generate_keypair_unpacked<
 }
 
 #[allow(non_snake_case)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $PRIVATE_KEY_SIZE == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
     $PUBLIC_KEY_SIZE == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K /\
     $ETA1 == Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
-    length $key_generation_seed == Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE"#))]
-#[hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cpa_generate_keypair $K $key_generation_seed in 
-                                    valid ==> $result == expected"#))]
+    length $key_generation_seed == Spec.MLKEM.v_CPA_KEY_GENERATION_SEED_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cpa_generate_keypair $K $key_generation_seed in 
+                                    valid ==> $result == expected"#)))]
 #[inline(always)]
 pub(crate) fn generate_keypair<
     const K: usize,
@@ -603,18 +624,18 @@ pub(crate) fn serialize_unpacked_secret_key<
 }
 
 /// Call [`compress_then_serialize_ring_element_u`] on each ring element.
-#[hax_lib::fstar::options("--z3rlimit 1500 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 1500 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $OUT_LEN == Spec.MLKEM.v_C1_SIZE $K /\
     $COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
     $BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
     ${out.len()} == $OUT_LEN /\
     (forall (i:nat). i < v $K ==>
-        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $input i))"#))]
-#[hax_lib::ensures(|_|
+        Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $input i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     fstar!(r#"$out_future == Spec.MLKEM.compress_then_encode_u #$K
                (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $input)"#)
-)]
+))]
 #[inline(always)]
 fn compress_then_serialize_u<
     const K: usize,
@@ -626,6 +647,7 @@ fn compress_then_serialize_u<
     input: [PolynomialRingElement<Vector>; K],
     out: &mut [u8],
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v (sz 32 *! $COMPRESSION_FACTOR) == 32 * v $COMPRESSION_FACTOR);
         assert (v ($OUT_LEN /! $K) == v $OUT_LEN / v $K);
@@ -633,6 +655,7 @@ fn compress_then_serialize_u<
     );
     cloop! {
         for (i, re) in input.into_iter().enumerate() {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| { fstar!(r#"(v $i < v $K ==> Seq.length out == v $OUT_LEN /\
                 Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $input (v $i))) /\
             (forall (j: nat). j < v $i ==>
@@ -641,6 +664,7 @@ fn compress_then_serialize_u<
                 (Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) == 
                     Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
                         (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $input j))))"#) });
+            #[cfg(hax)]
             hax_lib::fstar!(r#"assert (forall (j: nat). j < v $i ==>
                 ((Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) == 
                 Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
@@ -648,6 +672,7 @@ fn compress_then_serialize_u<
             out[i * (OUT_LEN / K)..(i + 1) * (OUT_LEN / K)].copy_from_slice(
                 &compress_then_serialize_ring_element_u::<COMPRESSION_FACTOR, BLOCK_LEN, Vector>(&re),
             );
+            #[cfg(hax)]
             hax_lib::fstar!(r#"let lemma_aux (j: nat{ j < v $i }) : Lemma
                 (Seq.slice out (j * (v $OUT_LEN / v $K)) (((j + 1)) * (v $OUT_LEN / v $K)) ==
                 Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
@@ -660,6 +685,7 @@ fn compress_then_serialize_u<
             Classical.forall_intro lemma_aux"#);
         }
     };
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro out
         (Spec.MLKEM.compress_then_encode_u #$K
@@ -707,8 +733,8 @@ fn compress_then_serialize_u<
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
       $ETA1 == Spec.MLKEM.v_ETA1 $K /\
       $ETA1_RANDOMNESS_SIZE == Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
       $ETA2 == Spec.MLKEM.v_ETA2 $K /\
@@ -719,12 +745,12 @@ fn compress_then_serialize_u<
       $V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
       $BLOCK_LEN == Spec.MLKEM.v_C1_BLOCK_SIZE $K /\
       $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
-      length $randomness == Spec.MLKEM.v_SHARED_SECRET_SIZE"#))]
-#[hax_lib::ensures(|result|
+      length $randomness == Spec.MLKEM.v_SHARED_SECRET_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result == Spec.MLKEM.ind_cpa_encrypt_unpacked $K $message $randomness
         (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${public_key.t_as_ntt})
         (Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${public_key.A})"#)
-)]
+))]
 #[inline(always)]
 pub(crate) fn encrypt_unpacked<
     const K: usize,
@@ -806,6 +832,7 @@ pub(crate) fn encrypt_c1<
             &prf_input,
             0,
         );
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro $randomness (Seq.slice $prf_input 0 32);
         assert (v $domain_separator == v $K)"
@@ -824,6 +851,7 @@ pub(crate) fn encrypt_c1<
 
     // e_2 := CBD{η2}(PRF(r, N))
     prf_input[32] = domain_separator;
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (Seq.equal $prf_input (Seq.append $randomness (Seq.create 1 $domain_separator)));
         assert ($prf_input == Seq.append $randomness (Seq.create 1 $domain_separator))"
@@ -856,6 +884,7 @@ pub(crate) fn encrypt_c2<
     // v := NTT^{−1}(tˆT ◦ rˆ) + e_2 + Decompress_q(Decode_1(m),1)
     let message_as_ring_element = deserialize_then_decompress_message(message);
     let v = compute_ring_element_v(t_as_ntt, r_as_ntt, error_2, &message_as_ring_element);
+    #[cfg(hax)]
     hax_lib::fstar!("assert ($C2_LEN = Spec.MLKEM.v_C2_SIZE v_K)");
 
     // c_2 := Encode_{dv}(Compress_q(v,d_v))
@@ -865,8 +894,8 @@ pub(crate) fn encrypt_c2<
 }
 
 #[allow(non_snake_case)]
-#[hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $ETA1 = Spec.MLKEM.v_ETA1 $K /\
     $ETA1_RANDOMNESS_SIZE = Spec.MLKEM.v_ETA1_RANDOMNESS_SIZE $K /\
     $ETA2 = Spec.MLKEM.v_ETA2 $K /\
@@ -879,11 +908,11 @@ pub(crate) fn encrypt_c2<
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
     $C1_LEN == Spec.MLKEM.v_C1_SIZE $K /\
-    $C2_LEN == Spec.MLKEM.v_C2_SIZE $K"#))]
-#[hax_lib::ensures(|result|
+    $C2_LEN == Spec.MLKEM.v_C2_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"let (expected, valid) = Spec.MLKEM.ind_cpa_encrypt $K $public_key $message $randomness in
             valid ==> $result == expected"#)
-)]
+))]
 #[inline(always)]
 pub(crate) fn encrypt<
     const K: usize,
@@ -905,6 +934,7 @@ pub(crate) fn encrypt<
     message: &[u8; SHARED_SECRET_SIZE],
     randomness: &[u8],
 ) -> [u8; CIPHERTEXT_SIZE] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLKEM.ind_cpa_encrypt) Spec.MLKEM.ind_cpa_encrypt"#);
     let unpacked_public_key =
         build_unpacked_public_key::<K, T_AS_NTT_ENCODED_SIZE, Vector, Hasher>(public_key);
@@ -929,15 +959,15 @@ pub(crate) fn encrypt<
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
-    length $public_key == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+    length $public_key == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
     let (t_as_ntt_bytes, seed_for_A) = split public_key $T_AS_NTT_ENCODED_SIZE in
     let t_as_ntt = Spec.MLKEM.vector_decode_12 #$K t_as_ntt_bytes in 
     let matrix_A_as_ntt, valid = Spec.MLKEM.sample_matrix_A_ntt #$K seed_for_A in
     (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${result.t_as_ntt} == t_as_ntt /\
-     valid ==> Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${result.A} == Spec.MLKEM.matrix_transpose matrix_A_as_ntt)"#))]
+     valid ==> Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${result.A} == Spec.MLKEM.matrix_transpose matrix_A_as_ntt)"#)))]
 fn build_unpacked_public_key<
     const K: usize,
     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -955,17 +985,17 @@ fn build_unpacked_public_key<
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $T_AS_NTT_ENCODED_SIZE == Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE $K /\
-    length $public_key == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#))]
-#[hax_lib::ensures(|_| {
+    length $public_key == Spec.MLKEM.v_CPA_PUBLIC_KEY_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| {
     let unpacked_public_key_future = future(unpacked_public_key);
     {fstar!(r#"
     let (t_as_ntt_bytes, seed_for_A) = split public_key $T_AS_NTT_ENCODED_SIZE in
     let t_as_ntt = Spec.MLKEM.vector_decode_12 #$K t_as_ntt_bytes in 
     let matrix_A_as_ntt, valid = Spec.MLKEM.sample_matrix_A_ntt #$K seed_for_A in
     (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${unpacked_public_key_future.t_as_ntt} == t_as_ntt /\
-    valid ==> Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${unpacked_public_key_future.A} == Spec.MLKEM.matrix_transpose matrix_A_as_ntt)"#)}})]
+    valid ==> Libcrux_ml_kem.Polynomial.to_spec_matrix_t #$K #$:Vector ${unpacked_public_key_future.A} == Spec.MLKEM.matrix_transpose matrix_A_as_ntt)"#)}}))]
 pub(crate) fn build_unpacked_public_key_mut<
     const K: usize,
     const T_AS_NTT_ENCODED_SIZE: usize,
@@ -988,6 +1018,7 @@ pub(crate) fn build_unpacked_public_key_mut<
     //     end for
     // end for
     let seed = &public_key[T_AS_NTT_ENCODED_SIZE..];
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro $seed
       (Seq.slice (Libcrux_ml_kem.Utils.into_padded_array (sz 34) $seed) 0 32)"
@@ -1002,14 +1033,14 @@ pub(crate) fn build_unpacked_public_key_mut<
 /// Call [`deserialize_then_decompress_ring_element_u`] on each ring element
 /// in the `ciphertext`.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
-    $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K"#))]
-#[hax_lib::ensures(|res|
+    $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $res ==
         Spec.MLKEM.(vector_ntt (decode_then_decompress_u #$K (Seq.slice $ciphertext 0 (v (Spec.MLKEM.v_C1_SIZE $K)))))"#)
-)]
+))]
 fn deserialize_then_decompress_u<
     const K: usize,
     const CIPHERTEXT_SIZE: usize,
@@ -1018,6 +1049,7 @@ fn deserialize_then_decompress_u<
 >(
     ciphertext: &[u8; CIPHERTEXT_SIZE],
 ) -> [PolynomialRingElement<Vector>; K] {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v (($COEFFICIENTS_IN_RING_ELEMENT *! $U_COMPRESSION_FACTOR ) /!
         sz 8) == v (Spec.MLKEM.v_C1_BLOCK_SIZE $K))"
@@ -1028,6 +1060,7 @@ fn deserialize_then_decompress_u<
             .chunks_exact((COEFFICIENTS_IN_RING_ELEMENT * U_COMPRESSION_FACTOR) / 8)
             .enumerate()
         {
+            #[cfg(hax)]
             hax_lib::loop_invariant!(|i: usize| { fstar!(r#"forall (j: nat). j < v $i ==>
               j * v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) + v (Spec.MLKEM.v_C1_BLOCK_SIZE $K) <= v $CIPHERTEXT_SIZE /\
               Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector (Seq.index $u_as_ntt j) ==
@@ -1038,6 +1071,7 @@ fn deserialize_then_decompress_u<
             ntt_vector_u::<U_COMPRESSION_FACTOR, Vector>(&mut u_as_ntt[i]);
         }
     }
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro
         (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $u_as_ntt)
@@ -1049,21 +1083,23 @@ fn deserialize_then_decompress_u<
 
 /// Call [`deserialize_to_uncompressed_ring_element`] for each ring element.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     length $secret_key == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\
-    v (${secret_key.len()}) / v $BYTES_PER_RING_ELEMENT <= v $K"#))]
-#[hax_lib::ensures(|()|
+    v (${secret_key.len()}) / v $BYTES_PER_RING_ELEMENT <= v $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|()|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $secret_as_ntt ==
          Spec.MLKEM.vector_decode_12 #$K $secret_key"#)
-)]
+))]
 pub(crate) fn deserialize_vector<const K: usize, Vector: Operations>(
     secret_key: &[u8],
     secret_as_ntt: &mut [PolynomialRingElement<Vector>; K],
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (Spec.MLKEM.polynomial_d 12 == Spec.MLKEM.polynomial)"#);
 
     for i in 0..K {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"forall (j: nat). j < v $i ==>
@@ -1079,6 +1115,7 @@ pub(crate) fn deserialize_vector<const K: usize, Vector: Operations>(
             &secret_key[i * BYTES_PER_RING_ELEMENT..(i + 1) * BYTES_PER_RING_ELEMENT],
         );
     }
+    #[cfg(hax)]
     hax_lib::fstar!(
         "eq_intro
         (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector $secret_as_ntt)
@@ -1109,15 +1146,15 @@ pub(crate) fn deserialize_vector<const K: usize, Vector: Operations>(
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[allow(non_snake_case)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
     $V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
-    $VECTOR_U_ENCODED_SIZE == Spec.MLKEM.v_C1_SIZE $K"#))]
-#[hax_lib::ensures(|result|
+    $VECTOR_U_ENCODED_SIZE == Spec.MLKEM.v_C1_SIZE $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result == Spec.MLKEM.ind_cpa_decrypt_unpacked $K $ciphertext
         (Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${secret_key}.f_secret_as_ntt)"#)
-)]
+))]
 #[inline(always)]
 pub(crate) fn decrypt_unpacked<
     const K: usize,
@@ -1146,15 +1183,15 @@ pub(crate) fn decrypt_unpacked<
 }
 
 #[allow(non_snake_case)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\
     length $secret_key == Spec.MLKEM.v_CPA_PRIVATE_KEY_SIZE $K /\ 
     $CIPHERTEXT_SIZE == Spec.MLKEM.v_CPA_CIPHERTEXT_SIZE $K /\
     $VECTOR_U_ENCODED_SIZE == Spec.MLKEM.v_C1_SIZE $K /\
     $U_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_U_COMPRESSION_FACTOR $K /\
-    $V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K"#))]
-#[hax_lib::ensures(|result|
+    $V_COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result == Spec.MLKEM.ind_cpa_decrypt $K $secret_key $ciphertext"#)
-)]
+))]
 #[inline(always)]
 pub(crate) fn decrypt<
     const K: usize,
@@ -1167,6 +1204,7 @@ pub(crate) fn decrypt<
     secret_key: &[u8],
     ciphertext: &[u8; CIPHERTEXT_SIZE],
 ) -> [u8; SHARED_SECRET_SIZE] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%Spec.MLKEM.ind_cpa_decrypt) Spec.MLKEM.ind_cpa_decrypt"#);
     // sˆ := Decode_12(sk)
     let mut secret_key_unpacked = IndCpaPrivateKeyUnpacked {

--- a/libcrux-ml-kem/src/invert_ntt.rs
+++ b/libcrux-ml-kem/src/invert_ntt.rs
@@ -5,39 +5,48 @@ use crate::{
 };
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(
-    interface,
-    "[@@ \"opaque_to_smt\"]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        "[@@ \"opaque_to_smt\"]
    let invert_ntt_re_range_2 (#v_Vector: Type0)
            {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
            (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
        forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque 3328
                (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"
+    )
 )]
-#[hax_lib::fstar::before(
-    interface,
-    "[@@ \"opaque_to_smt\"]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        "[@@ \"opaque_to_smt\"]
    let invert_ntt_re_range_1 (#v_Vector: Type0)
          {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
          (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
        forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque (4 * 3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"
+    )
 )]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 128 /\
-    invert_ntt_re_range_1 $re"#))]
-#[hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
-    v ${*zeta_i}_future == 64"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 128 /\
+    invert_ntt_re_range_1 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
+    v ${*zeta_i}_future == 64"#)))]
 pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_1) (invert_ntt_re_range_1 #$:Vector)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     #[cfg(hax)]
     let _zeta_i_init = *zeta_i;
 
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init - v $round * 4 /\
@@ -49,6 +58,7 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
             )
         });
         *zeta_i -= 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (4*3328) 
@@ -62,11 +72,13 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
             zeta(*zeta_i - 3),
         );
         *zeta_i -= 3;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque 3328 
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque 3328
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -75,20 +87,22 @@ pub(crate) fn invert_ntt_at_layer_1<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 64 /\
-    invert_ntt_re_range_2 $re "#))]
-#[hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
-    v ${*zeta_i}_future == 32"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 64 /\
+    invert_ntt_re_range_2 $re "#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
+    v ${*zeta_i}_future == 32"#)))]
 pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     #[cfg(hax)]
     let _zeta_i_init = *zeta_i;
 
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init - v $round * 2 /\
@@ -100,6 +114,7 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
             )
         });
         *zeta_i -= 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque 3328 
@@ -108,11 +123,13 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
         re.coefficients[round] =
             Vector::inv_ntt_layer_2_step(re.coefficients[round], zeta(*zeta_i), zeta(*zeta_i - 1));
         *zeta_i -= 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque 3328 
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque 3328
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -121,20 +138,22 @@ pub(crate) fn invert_ntt_at_layer_2<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 32 /\
-    invert_ntt_re_range_2 $re"#))]
-#[hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
-    v ${*zeta_i}_future == 16"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 32 /\
+    invert_ntt_re_range_2 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"invert_ntt_re_range_2 ${re}_future /\
+    v ${*zeta_i}_future == 16"#)))]
 pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%invert_ntt_re_range_2) (invert_ntt_re_range_2 #$:Vector)"#);
     #[cfg(hax)]
     let _zeta_i_init = *zeta_i;
 
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init - v $round /\
@@ -146,6 +165,7 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
             )
         });
         *zeta_i -= 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque 3328 
@@ -153,11 +173,13 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
         );
         re.coefficients[round] =
             Vector::inv_ntt_layer_3_step(re.coefficients[round], zeta(*zeta_i));
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
             (Spec.Utils.is_i16b_array_opaque 3328 
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque 3328
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -166,7 +188,7 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta_r /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta_r /\
     (forall i. i < 16 ==>
         Spec.Utils.is_intb (pow2 15 - 1)
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $b) i) -
@@ -176,7 +198,7 @@ pub(crate) fn invert_ntt_at_layer_3<Vector: Operations>(
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $a) i) +
         v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $b) i))) /\
     Spec.Utils.is_i16b_array 28296 (Libcrux_ml_kem.Vector.Traits.f_to_i16_array
-        (Libcrux_ml_kem.Vector.Traits.f_add $a $b))"#))]
+        (Libcrux_ml_kem.Vector.Traits.f_add $a $b))"#)))]
 pub(crate) fn inv_ntt_layer_int_vec_step_reduce<Vector: Operations>(
     mut a: Vector,
     mut b: Vector,
@@ -189,8 +211,8 @@ pub(crate) fn inv_ntt_layer_int_vec_step_reduce<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"v $layer >= 4 /\ v $layer <= 7"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $layer >= 4 /\ v $layer <= 7"#)))]
 pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
@@ -218,8 +240,8 @@ pub(crate) fn invert_ntt_at_layer_4_plus<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"invert_ntt_re_range_1 $re"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"invert_ntt_re_range_1 $re"#)))]
 pub(crate) fn invert_ntt_montgomery<const K: usize, Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
 ) {

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -64,9 +64,7 @@ pub mod mlkem768;
 pub mod mlkem1024;
 
 pub use constants::SHARED_SECRET_SIZE;
-
 pub use ind_cca::{MlKemSharedSecret, ENCAPS_SEED_SIZE, KEY_GENERATION_SEED_SIZE};
-
 // These types all have type aliases for the different variants.
 pub use types::{MlKemCiphertext, MlKemKeyPair, MlKemPrivateKey, MlKemPublicKey};
 
@@ -116,7 +114,7 @@ cfg_kyber! {
 
 macro_rules! impl_kem_trait {
     ($variant:ty, $pk:ty, $sk:ty, $ct:ty) => {
-        #[hax_lib::exclude]
+        #[cfg_attr(hax, hax_lib::exclude)]
         impl
             libcrux_traits::kem::arrayref::Kem<
                 CPA_PKE_PUBLIC_KEY_SIZE,

--- a/libcrux-ml-kem/src/matrix.rs
+++ b/libcrux-ml-kem/src/matrix.rs
@@ -5,14 +5,14 @@ use crate::{
 
 #[inline(always)]
 #[allow(non_snake_case)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#))]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let (matrix_A, valid) = Spec.MLKEM.sample_matrix_A_ntt (Seq.slice $seed 0 32) in
         valid ==> (
         if $transpose then Libcrux_ml_kem.Polynomial.to_spec_matrix_t ${A_transpose}_future == matrix_A
         else Libcrux_ml_kem.Polynomial.to_spec_matrix_t ${A_transpose}_future == Spec.MLKEM.matrix_transpose matrix_A)"#)
-)]
+))]
 pub(crate) fn sample_matrix_A<const K: usize, Vector: Operations, Hasher: Hash<K>>(
     A_transpose: &mut [[PolynomialRingElement<Vector>; K]; K],
     seed: &[u8; 34],
@@ -45,9 +45,9 @@ pub(crate) fn sample_matrix_A<const K: usize, Vector: Operations, Hasher: Hash<K
 
 /// Compute v − InverseNTT(sᵀ ◦ NTT(u))
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#))]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let open Libcrux_ml_kem.Polynomial in
         let secret_spec = to_spec_vector_t $secret_as_ntt in
         let u_spec = to_spec_vector_t $u_as_ntt in
@@ -55,7 +55,7 @@ pub(crate) fn sample_matrix_A<const K: usize, Vector: Operations, Hasher: Hash<K
         to_spec_poly_t $res ==
             Spec.MLKEM.(poly_sub v_spec (poly_inv_ntt (vector_dot_product_ntt #$K secret_spec u_spec))) /\
         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $res"#)
-)]
+))]
 pub(crate) fn compute_message<const K: usize, Vector: Operations>(
     v: &PolynomialRingElement<Vector>,
     secret_as_ntt: &[PolynomialRingElement<Vector>; K],
@@ -76,9 +76,9 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
 
 /// Compute InverseNTT(tᵀ ◦ r̂) + e₂ + message
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#))]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let open Libcrux_ml_kem.Polynomial in
         let tt_spec = to_spec_vector_t $t_as_ntt in
         let r_spec = to_spec_vector_t $r_as_ntt in
@@ -87,7 +87,7 @@ pub(crate) fn compute_message<const K: usize, Vector: Operations>(
         let res_spec = to_spec_poly_t $res in
         res_spec == Spec.MLKEM.(poly_add (poly_add (vector_dot_product_ntt #$K tt_spec r_spec) e2_spec) m_spec) /\
         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $res"#)
-)]
+))]
 pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
     t_as_ntt: &[PolynomialRingElement<Vector>; K],
     r_as_ntt: &[PolynomialRingElement<Vector>; K],
@@ -109,12 +109,12 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
 
 /// Compute u := InvertNTT(Aᵀ ◦ r̂) + e₁
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     Spec.MLKEM.is_rank $K /\
     (forall (i:nat). i < v $K ==>
-        Libcrux_ml_kem.Polynomial.is_bounded_poly 7 (Seq.index ${error_1} i))"#))]
-#[hax_lib::ensures(|res|
+        Libcrux_ml_kem.Polynomial.is_bounded_poly 7 (Seq.index ${error_1} i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let open Libcrux_ml_kem.Polynomial in
         let a_spec = to_spec_matrix_t $a_as_ntt in
         let r_spec = to_spec_vector_t $r_as_ntt in
@@ -123,7 +123,7 @@ pub(crate) fn compute_ring_element_v<const K: usize, Vector: Operations>(
         res_spec == Spec.MLKEM.(vector_add (vector_inv_ntt (matrix_vector_mul_ntt a_spec r_spec)) e_spec) /\
         (forall (i:nat). i < v $K ==>
             Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $res i))"#)
-)]
+))]
 pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
     a_as_ntt: &[[PolynomialRingElement<Vector>; K]; K],
     r_as_ntt: &[PolynomialRingElement<Vector>; K],
@@ -151,9 +151,9 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
 /// Compute Â ◦ ŝ + ê
 #[inline(always)]
 #[allow(non_snake_case)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#))]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let open Libcrux_ml_kem.Polynomial in
         to_spec_vector_t ${t_as_ntt}_future =
              Spec.MLKEM.compute_As_plus_e_ntt
@@ -162,7 +162,7 @@ pub(crate) fn compute_vector_u<const K: usize, Vector: Operations>(
                (to_spec_vector_t $error_as_ntt) /\
         (forall (i: nat). i < v $K ==>
             Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index ${t_as_ntt}_future i))"#)
-)]
+))]
 pub(crate) fn compute_As_plus_e<const K: usize, Vector: Operations>(
     t_as_ntt: &mut [PolynomialRingElement<Vector>; K],
     matrix_A: &[[PolynomialRingElement<Vector>; K]; K],

--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -279,9 +279,9 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn serialized_public_key(
                     public_key: &MlKem1024PublicKeyUnpacked,
                     serialized: &mut MlKem1024PublicKey,
@@ -302,17 +302,17 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn key_pair_serialized_public_key_mut(key_pair: &MlKem1024KeyPairUnpacked, serialized: &mut MlKem1024PublicKey) {
                     key_pair.serialized_public_key_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 4 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn key_pair_serialized_public_key(key_pair: &MlKem1024KeyPairUnpacked) ->MlKem1024PublicKey {
                     key_pair.serialized_public_key::<CPA_PKE_PUBLIC_KEY_SIZE>()
                 }
@@ -473,11 +473,11 @@ pub fn validate_private_key(
 ///
 /// This function returns an [`MlKem1024KeyPair`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let ((secret_key, public_key), valid) = Spec.MLKEM.Instances.mlkem1024_generate_keypair $randomness in
         valid ==> (${res}.f_sk.f_value == secret_key /\ ${res}.f_pk.f_value == public_key)"#)
-)]
+))]
 pub fn generate_key_pair(
     randomness: [u8; KEY_GENERATION_SEED_SIZE],
 ) -> MlKemKeyPair<SECRET_KEY_SIZE, CPA_PKE_PUBLIC_KEY_SIZE> {
@@ -497,12 +497,12 @@ pub fn generate_key_pair(
 /// The input is a reference to an [`MlKem1024PublicKey`] and [`SHARED_SECRET_SIZE`]
 /// bytes of `randomness`.
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let ((ciphertext, shared_secret), valid) = Spec.MLKEM.Instances.mlkem1024_encapsulate ${public_key}.f_value $randomness in
         let (res_ciphertext, res_shared_secret) = $res in
         valid ==> (res_ciphertext.f_value == ciphertext /\ res_shared_secret == shared_secret)"#)
-)]
+))]
 pub fn encapsulate(
     public_key: &MlKem1024PublicKey,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -529,11 +529,11 @@ pub fn encapsulate(
 /// Generates an [`MlKemSharedSecret`].
 /// The input is a reference to an [`MlKem1024PrivateKey`] and an [`MlKem1024Ciphertext`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let (shared_secret, valid) = Spec.MLKEM.Instances.mlkem1024_decapsulate ${private_key}.f_value ${ciphertext}.f_value in
         valid ==> $res == shared_secret"#)
-)]
+))]
 pub fn decapsulate(
     private_key: &MlKem1024PrivateKey,
     ciphertext: &MlKem1024Ciphertext,
@@ -567,11 +567,12 @@ pub fn decapsulate(
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
 pub mod rand {
+    use ::rand::CryptoRng;
+
     use super::{
         MlKem1024Ciphertext, MlKem1024KeyPair, MlKem1024PublicKey, MlKemSharedSecret,
         KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
     };
-    use ::rand::CryptoRng;
 
     /// Generate ML-KEM 1024 Key Pair
     ///
@@ -579,7 +580,7 @@ pub mod rand {
     /// to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem1024KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem1024KeyPair {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
         rng.fill_bytes(&mut randomness);
@@ -593,7 +594,7 @@ pub mod rand {
     /// The input is a reference to an [`MlKem1024PublicKey`].
     /// The random number generator `rng` needs to implement `CryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn encapsulate(
         public_key: &MlKem1024PublicKey,
         rng: &mut impl CryptoRng,

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -273,9 +273,9 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn serialized_public_key(
                     public_key: &MlKem512PublicKeyUnpacked,
                     serialized: &mut MlKem512PublicKey,
@@ -296,17 +296,17 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn key_pair_serialized_public_key_mut(key_pair: &MlKem512KeyPairUnpacked, serialized: &mut MlKem512PublicKey) {
                     key_pair.serialized_public_key_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 2 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn key_pair_serialized_public_key(key_pair: &MlKem512KeyPairUnpacked) ->MlKem512PublicKey {
                     key_pair.serialized_public_key::<CPA_PKE_PUBLIC_KEY_SIZE>()
                 }
@@ -464,11 +464,11 @@ pub fn validate_private_key(
 ///
 /// This function returns an [`MlKem512KeyPair`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let ((secret_key, public_key), valid) = Spec.MLKEM.Instances.mlkem512_generate_keypair $randomness in
         valid ==> (${res}.f_sk.f_value == secret_key /\ ${res}.f_pk.f_value == public_key)"#)
-)]
+))]
 pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512KeyPair {
     multiplexing::generate_keypair::<
         RANK,
@@ -486,12 +486,12 @@ pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512
 /// The input is a reference to an [`MlKem512PublicKey`] and [`SHARED_SECRET_SIZE`]
 /// bytes of `randomness`.
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let ((ciphertext, shared_secret), valid) = Spec.MLKEM.Instances.mlkem512_encapsulate ${public_key}.f_value $randomness in
         let (res_ciphertext, res_shared_secret) = $res in
         valid ==> (res_ciphertext.f_value == ciphertext /\ res_shared_secret == shared_secret)"#)
-)]
+))]
 pub fn encapsulate(
     public_key: &MlKem512PublicKey,
     randomness: [u8; SHARED_SECRET_SIZE],
@@ -518,11 +518,11 @@ pub fn encapsulate(
 /// Generates an [`MlKemSharedSecret`].
 /// The input is a reference to an [`MlKem512PrivateKey`] and an [`MlKem512Ciphertext`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
     fstar!(r#"let (shared_secret, valid) = Spec.MLKEM.Instances.mlkem512_decapsulate ${private_key}.f_value ${ciphertext}.f_value in
         valid ==> $res == shared_secret"#)
-)]
+))]
 pub fn decapsulate(
     private_key: &MlKem512PrivateKey,
     ciphertext: &MlKem512Ciphertext,
@@ -556,11 +556,12 @@ pub fn decapsulate(
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
 pub mod rand {
+    use ::rand::CryptoRng;
+
     use super::{
         MlKem512Ciphertext, MlKem512KeyPair, MlKem512PublicKey, MlKemSharedSecret,
         KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
     };
-    use ::rand::CryptoRng;
 
     /// Generate ML-KEM 512 Key Pair
     ///
@@ -568,7 +569,7 @@ pub mod rand {
     /// `CryptoRng` to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem512KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem512KeyPair {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
         rng.fill_bytes(&mut randomness);
@@ -582,7 +583,7 @@ pub mod rand {
     /// The input is a reference to an [`MlKem512PublicKey`].
     /// The random number generator `rng` needs to implement `CryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn encapsulate(
         public_key: &MlKem512PublicKey,
         rng: &mut impl CryptoRng,

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -274,9 +274,9 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn serialized_public_key(public_key: &MlKem768PublicKeyUnpacked, serialized : &mut MlKem768PublicKey) {
                     public_key.serialized_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
@@ -292,17 +292,17 @@ macro_rules! instantiate {
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"(forall (i:nat). i < 3 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(forall (i:nat). i < 3 ==>
                         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                            ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i))"#))]
+                            ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i))"#)))]
                 pub fn key_pair_serialized_public_key_mut(key_pair: &MlKem768KeyPairUnpacked, serialized: &mut MlKem768PublicKey) {
                     key_pair.serialized_public_key_mut::<CPA_PKE_PUBLIC_KEY_SIZE>(serialized);
                 }
 
                 /// Get the serialized public key.
-                #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
+                #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 3 ==>
                     Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index 
-                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#))]
+                        ${key_pair.public_key.ind_cpa_public_key.t_as_ntt} i)"#)))]
                 pub fn key_pair_serialized_public_key(key_pair: &MlKem768KeyPairUnpacked) ->MlKem768PublicKey {
                     key_pair.serialized_public_key::<CPA_PKE_PUBLIC_KEY_SIZE>()
                 }
@@ -551,7 +551,7 @@ pub mod rand {
     /// to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem768KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem768KeyPair {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
         rng.fill_bytes(&mut randomness);
@@ -565,7 +565,7 @@ pub mod rand {
     /// The input is a reference to an [`MlKem768PublicKey`].
     /// The random number generator `rng` needs to implement `CryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    #[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
     pub fn encapsulate(
         public_key: &MlKem768PublicKey,
         rng: &mut impl CryptoRng,

--- a/libcrux-ml-kem/src/ntt.rs
+++ b/libcrux-ml-kem/src/ntt.rs
@@ -5,38 +5,47 @@ use crate::{
 };
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(
-    interface,
-    r#"[@@ "opaque_to_smt"]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        r#"[@@ "opaque_to_smt"]
    let ntt_re_range_2 (#v_Vector: Type0)
          {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
          (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
        forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque (11207+5*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"#
+    )
 )]
-#[hax_lib::fstar::before(
-    interface,
-    r#"[@@ "opaque_to_smt"]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        r#"[@@ "opaque_to_smt"]
     let ntt_re_range_1 (#v_Vector: Type0)
             {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
             (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
         forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque (11207+6*3328)
                 (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 63 /\
-    ntt_re_range_2 $re"#))]
-#[hax_lib::ensures(|result| fstar!(r#"ntt_re_range_1 ${re}_future /\
-    v ${*zeta_i}_future == 127"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 63 /\
+    ntt_re_range_2 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"ntt_re_range_1 ${re}_future /\
+    v ${*zeta_i}_future == 127"#)))]
 pub(crate) fn ntt_at_layer_1<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
     _initial_coefficient_bound: usize, // This can be used for specifying the range of values allowed in re
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_2) (ntt_re_range_2 #$:Vector)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_1) (ntt_re_range_1 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init + v $round * 4 /\
@@ -48,6 +57,7 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
             )
         });
         *zeta_i += 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (11207+5*3328)
@@ -61,11 +71,13 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
             zeta(*zeta_i + 3),
         );
         *zeta_i += 3;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (11207+6*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque (11207+6*3328)
         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -74,29 +86,35 @@ pub(crate) fn ntt_at_layer_1<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(
-    interface,
-    r#"[@@ "opaque_to_smt"]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        r#"[@@ "opaque_to_smt"]
    let ntt_re_range_3 (#v_Vector: Type0)
          {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
          (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
        forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque (11207+4*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 31 /\
-    ntt_re_range_3 $re"#))]
-#[hax_lib::ensures(|result| fstar!(r#"ntt_re_range_2 ${re}_future /\
-    v ${*zeta_i}_future == 63"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 31 /\
+    ntt_re_range_3 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"ntt_re_range_2 ${re}_future /\
+    v ${*zeta_i}_future == 63"#)))]
 pub(crate) fn ntt_at_layer_2<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
     _initial_coefficient_bound: usize, // This can be used for specifying the range of values allowed in re
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_3) (ntt_re_range_3 #$:Vector)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_2) (ntt_re_range_2 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init + v $round * 2 /\
@@ -108,6 +126,7 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
             )
         });
         *zeta_i += 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (11207+4*3328)
@@ -116,11 +135,13 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
         re.coefficients[round] =
             Vector::ntt_layer_2_step(re.coefficients[round], zeta(*zeta_i), zeta(*zeta_i + 1));
         *zeta_i += 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (11207+5*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque (11207+5*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -129,29 +150,35 @@ pub(crate) fn ntt_at_layer_2<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(
-    interface,
-    r#"[@@ "opaque_to_smt"]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        r#"[@@ "opaque_to_smt"]
    let ntt_re_range_4 (#v_Vector: Type0)
          {| i1: Libcrux_ml_kem.Vector.Traits.t_Operations v_Vector |}
          (re: Libcrux_ml_kem.Polynomial.t_PolynomialRingElement v_Vector) =
        forall (i:nat). i < 16 ==> Spec.Utils.is_i16b_array_opaque (11207+3*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ sz i ]))"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"v ${*zeta_i} == 15 /\
-    ntt_re_range_4 $re"#))]
-#[hax_lib::ensures(|result| fstar!(r#"ntt_re_range_3 ${re}_future /\
-    v ${*zeta_i}_future == 31"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v ${*zeta_i} == 15 /\
+    ntt_re_range_4 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"ntt_re_range_3 ${re}_future /\
+    v ${*zeta_i}_future == 31"#)))]
 pub(crate) fn ntt_at_layer_3<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
     _initial_coefficient_bound: usize, // This can be used for specifying the range of values allowed in re
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_4) (ntt_re_range_4 #$:Vector)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"reveal_opaque (`%ntt_re_range_3) (ntt_re_range_3 #$:Vector)"#);
     let _zeta_i_init = *zeta_i;
     for round in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|round: usize| {
             fstar!(
                 r#"v zeta_i == v $_zeta_i_init + v $round /\
@@ -163,17 +190,20 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
             )
         });
         *zeta_i += 1;
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
                         (Spec.Utils.is_i16b_array_opaque (11207+3*3328)
                         (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"#
         );
         re.coefficients[round] = Vector::ntt_layer_3_step(re.coefficients[round], zeta(*zeta_i));
+        #[cfg(hax)]
         hax_lib::fstar!(
             "reveal_opaque (`%Spec.Utils.is_i16b_array_opaque) 
             (Spec.Utils.is_i16b_array_opaque (11207+4*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ round ])))"
         );
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (Spec.Utils.is_i16b_array_opaque (11207+4*3328)
             (Libcrux_ml_kem.Vector.Traits.f_to_i16_array (re.f_coefficients.[ $round ])))"
@@ -182,7 +212,7 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta_r /\
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta_r /\
     (let t = ${Vector::montgomery_multiply_by_constant} $b $zeta_r in
     (forall i. i < 16 ==>
         Spec.Utils.is_intb (pow2 15 - 1)
@@ -191,7 +221,7 @@ pub(crate) fn ntt_at_layer_3<Vector: Operations>(
     (forall i. i < 16 ==>
         Spec.Utils.is_intb (pow2 15 - 1)
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $a) i) +
-        v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array t) i))))"#))]
+        v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array t) i))))"#)))]
 fn ntt_layer_int_vec_step<Vector: Operations>(
     mut a: Vector,
     mut b: Vector,
@@ -204,17 +234,17 @@ fn ntt_layer_int_vec_step<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"v $layer >= 4 /\ v $layer <= 7 /\
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $layer >= 4 /\ v $layer <= 7 /\
     ((v $layer == 4 ==> v ${*zeta_i} == 7) /\
     (v $layer == 5 ==> v ${*zeta_i} == 3) /\
     (v $layer == 6 ==> v ${*zeta_i} == 1) /\
-    (v $layer == 7 ==> v ${*zeta_i} == 0))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"ntt_re_range_4 ${re}_future /\
+    (v $layer == 7 ==> v ${*zeta_i} == 0))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"ntt_re_range_4 ${re}_future /\
     (v $layer == 4 ==> v ${*zeta_i}_future == 15) /\
     (v $layer == 5 ==> v ${*zeta_i}_future == 7) /\
     (v $layer == 6 ==> v ${*zeta_i}_future == 3) /\
-    (v $layer == 7 ==> v ${*zeta_i}_future == 1)"#))]
+    (v $layer == 7 ==> v ${*zeta_i}_future == 1)"#)))]
 pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
     zeta_i: &mut usize,
     re: &mut PolynomialRingElement<Vector>,
@@ -244,9 +274,9 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 //We should make the loops inside this function `opaque_to_smt` to get it work
-#[hax_lib::fstar::before(
+#[cfg_attr(hax, hax_lib::fstar::before(
     interface,
     r#"[@@ "opaque_to_smt"]
    let ntt_layer_7_pre (#v_Vector: Type0)
@@ -264,13 +294,15 @@ pub(crate) fn ntt_at_layer_4_plus<Vector: Operations>(
       Spec.Utils.is_intb (pow2 15 - 1) 
         (v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array re_0) i) + 
           v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array t) i))))"#
-)]
-#[hax_lib::requires(fstar!(r#"forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
-    (${re}.f_coefficients.[ sz i +! sz 8 ])"#))]
+))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
+    (${re}.f_coefficients.[ sz i +! sz 8 ])"#)))]
 pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<Vector>) {
     let step = VECTORS_IN_RING_ELEMENT / 2;
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $step == 8)"#);
     for j in 0..step {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|j: usize| {
             fstar!(
                 r#"(v j < 8 ==>
@@ -278,6 +310,7 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
             ntt_layer_7_pre (re.f_coefficients.[ sz i ]) (re.f_coefficients.[ sz i +! sz 8 ])))"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"reveal_opaque (`%ntt_layer_7_pre) (ntt_layer_7_pre #$:Vector)"#);
         let t = Vector::multiply_by_constant(re.coefficients[j + step], -1600);
         re.coefficients[j + step] = Vector::sub(re.coefficients[j], &t);
@@ -286,14 +319,14 @@ pub(crate) fn ntt_at_layer_7<Vector: Operations>(re: &mut PolynomialRingElement<
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::requires(fstar!(r#"forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
-    (${re}.f_coefficients.[ sz i +! sz 8 ])"#))]
-#[hax_lib::ensures(|_| fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 ${re}_future /\
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 8 ==> ntt_layer_7_pre (${re}.f_coefficients.[ sz i ])
+    (${re}.f_coefficients.[ sz i +! sz 8 ])"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 ${re}_future /\
     Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${re}_future ==
     Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re) /\
-    Libcrux_ml_kem.Polynomial.is_bounded_poly #$:Vector 3328 ${re}_future"#))]
+    Libcrux_ml_kem.Polynomial.is_bounded_poly #$:Vector 3328 ${re}_future"#)))]
 pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
 ) {
@@ -313,10 +346,10 @@ pub(crate) fn ntt_binomially_sampled_ring_element<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::ensures(|_| fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${re}_future ==
-    Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector ${re}_future ==
+    Spec.MLKEM.poly_ntt (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#)))]
 pub(crate) fn ntt_vector_u<const VECTOR_U_COMPRESSION_FACTOR: usize, Vector: Operations>(
     re: &mut PolynomialRingElement<Vector>,
 ) {

--- a/libcrux-ml-kem/src/polynomial.rs
+++ b/libcrux-ml-kem/src/polynomial.rs
@@ -1,6 +1,7 @@
 use crate::vector::{Operations, MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS};
 
 pub(crate) const ZETAS_TIMES_MONTGOMERY_R: [i16; 128] = {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (pow2 16 == 65536)"#);
     [
         -1044, -758, -359, -1517, 1493, 1422, 287, 202, -171, 622, 1577, 182, 962, -1202, -1474,
@@ -17,9 +18,9 @@ pub(crate) const ZETAS_TIMES_MONTGOMERY_R: [i16; 128] = {
 
 // A function to retrieve zetas so that we can add a post-condition
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(i < 128)]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b 1664 result"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(i < 128))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b 1664 result"#)))]
 pub fn zeta(i: usize) -> i16 {
     ZETAS_TIMES_MONTGOMERY_R[i]
 }
@@ -73,7 +74,7 @@ fn ZERO<Vector: Operations>() -> PolynomialRingElement<Vector> {
 }
 
 #[inline(always)]
-#[hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 <= a.len())]
+#[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 <= a.len()))]
 fn from_i16_array<Vector: Operations>(a: &[i16]) -> PolynomialRingElement<Vector> {
     let mut result = ZERO();
     for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -84,19 +85,20 @@ fn from_i16_array<Vector: Operations>(a: &[i16]) -> PolynomialRingElement<Vector
 
 #[allow(dead_code)]
 #[inline(always)]
-#[hax_lib::requires(out.len() >= VECTORS_IN_RING_ELEMENT * 16)]
+#[cfg_attr(hax, hax_lib::requires(out.len() >= VECTORS_IN_RING_ELEMENT * 16))]
 fn to_i16_array<Vector: Operations>(re: PolynomialRingElement<Vector>, out: &mut [i16]) {
     #[cfg(hax)]
     let _out_len = out.len();
 
     for i in 0..re.coefficients.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|_i: usize| out.len() == _out_len);
         out[i * 16..(i + 1) * 16].copy_from_slice(&Vector::to_i16_array(re.coefficients[i]));
     }
 }
 
 #[inline(always)]
-#[hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 *2 <= bytes.len())]
+#[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 *2 <= bytes.len()))]
 fn from_bytes<Vector: Operations>(bytes: &[u8]) -> PolynomialRingElement<Vector> {
     let mut result = ZERO();
     for i in 0..VECTORS_IN_RING_ELEMENT {
@@ -106,12 +108,13 @@ fn from_bytes<Vector: Operations>(bytes: &[u8]) -> PolynomialRingElement<Vector>
 }
 
 #[inline(always)]
-#[hax_lib::requires(VECTORS_IN_RING_ELEMENT * 32 <= out.len())]
+#[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 32 <= out.len()))]
 fn to_bytes<Vector: Operations>(re: PolynomialRingElement<Vector>, out: &mut [u8]) {
     #[cfg(hax)]
     let _out_len = out.len();
 
     for i in 0..re.coefficients.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|_i: usize| out.len() == _out_len);
         Vector::to_bytes(re.coefficients[i], &mut out[i * 32..(i + 1) * 32]);
     }
@@ -120,8 +123,8 @@ fn to_bytes<Vector: Operations>(re: PolynomialRingElement<Vector>, out: &mut [u8
 /// Get the bytes of the vector of ring elements in `re` and write them to `out`.
 #[inline(always)]
 #[allow(dead_code)]
-#[hax_lib::fstar::options("--z3rlimit 500 --split_queries always")]
-#[hax_lib::requires(re.len() <= 4 && 512 * re.len() <= out.len())]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(re.len() <= 4 && 512 * re.len() <= out.len()))]
 pub(crate) fn vec_to_bytes<Vector: Operations>(
     re: &[PolynomialRingElement<Vector>],
     out: &mut [u8],
@@ -130,6 +133,7 @@ pub(crate) fn vec_to_bytes<Vector: Operations>(
     let _out_len = out.len();
     let re_bytes = PolynomialRingElement::<Vector>::num_bytes();
     for i in 0..re.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|_i: usize| out.len() == _out_len);
         PolynomialRingElement::<Vector>::to_bytes(re[i], &mut out[i * re_bytes..]);
     }
@@ -138,10 +142,10 @@ pub(crate) fn vec_to_bytes<Vector: Operations>(
 /// Build a vector of ring elements from `bytes`.
 #[inline(always)]
 #[allow(dead_code)]
-#[hax_lib::fstar::options("--z3rlimit 500 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"Seq.length out <= 4 /\ 
-    Seq.length bytes >= 512 * Seq.length out"#))]
-#[hax_lib::ensures(|_| future(out).len() == out.len())]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length out <= 4 /\ 
+    Seq.length bytes >= 512 * Seq.length out"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(out).len() == out.len()))]
 pub(crate) fn vec_from_bytes<Vector: Operations>(
     bytes: &[u8],
     out: &mut [PolynomialRingElement<Vector>],
@@ -151,13 +155,14 @@ pub(crate) fn vec_from_bytes<Vector: Operations>(
 
     let re_bytes = PolynomialRingElement::<Vector>::num_bytes();
     for i in 0..out.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|_i: usize| out.len() == _out_len);
         out[i] = PolynomialRingElement::<Vector>::from_bytes(&bytes[i * re_bytes..]);
     }
 }
 
 /// The length of a vector of ring elements in bytes
-#[hax_lib::requires(K <= 4)]
+#[cfg_attr(hax, hax_lib::requires(K <= 4))]
 #[allow(dead_code)]
 pub(crate) const fn vec_len_bytes<const K: usize, Vector: Operations>() -> usize {
     K * PolynomialRingElement::<Vector>::num_bytes()
@@ -166,30 +171,32 @@ pub(crate) const fn vec_len_bytes<const K: usize, Vector: Operations>() -> usize
 /// Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
 /// sum of their constituent coefficients.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 500 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 500 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         forall (i:nat). i < v ${VECTORS_IN_RING_ELEMENT} ==>
          (let lhs_i = i0.f_to_i16_array (${myself}.f_coefficients.[ sz i ]) in
           let rhs_i = i0.f_to_i16_array (${rhs}.f_coefficients.[ sz i ]) in
-          Libcrux_ml_kem.Vector.Traits.Spec.add_pre lhs_i rhs_i)"#))]
-#[hax_lib::ensures(|_| fstar!(r#"
+          Libcrux_ml_kem.Vector.Traits.Spec.add_pre lhs_i rhs_i)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         forall (i:nat). i < v ${VECTORS_IN_RING_ELEMENT} ==>
          (let lhs_i = i0.f_to_i16_array (${myself}.f_coefficients.[ sz i ]) in
           let rhs_i = i0.f_to_i16_array (${rhs}.f_coefficients.[ sz i ]) in
           let result_i = i0.f_to_i16_array (${myself}_future.f_coefficients.[ sz i ]) in
-          Libcrux_ml_kem.Vector.Traits.Spec.add_post lhs_i rhs_i result_i)"#))]
+          Libcrux_ml_kem.Vector.Traits.Spec.add_post lhs_i rhs_i result_i)"#)))]
 fn add_to_ring_element<Vector: Operations, const K: usize>(
     myself: &mut PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
 ) {
     #[cfg(hax)]
     let _myself = myself.coefficients;
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall (v: v_Vector).
         i0.f_to_i16_array v == i0._super_i2.f_repr v)"#
     );
 
     for i in 0..myself.coefficients.len() {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -213,13 +220,14 @@ fn add_to_ring_element<Vector: Operations, const K: usize>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"is_bounded_poly 28296 ${myself}"#))]
-#[hax_lib::ensures(|_| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly 28296 ${myself}"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#)))]
 fn poly_barrett_reduce<Vector: Operations>(myself: &mut PolynomialRingElement<Vector>) {
     #[cfg(hax)]
     let _myself = myself.coefficients;
 
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
         (forall j. j < v i ==> is_bounded_vector 3328 ${myself}.f_coefficients.[ sz j ]) /\
@@ -232,10 +240,10 @@ fn poly_barrett_reduce<Vector: Operations>(myself: &mut PolynomialRingElement<Ve
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"is_bounded_poly (pow2 12 - 1) ${myself}"#))]
-#[hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${result}"#))]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly (pow2 12 - 1) ${myself}"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${result}"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn subtract_reduce<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     mut b: PolynomialRingElement<Vector>,
@@ -244,12 +252,14 @@ fn subtract_reduce<Vector: Operations>(
     let _b = b.coefficients;
 
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
         (forall j. j < v i ==> is_bounded_vector 3328 ${b}.f_coefficients.[ sz j ]) /\
         (forall j. (j >= v i /\ j < 16) ==> ${b}.f_coefficients.[ sz j ] == ${_b}.[ sz j ])
         "#
         ));
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
           assert (v $i < 16);
@@ -263,6 +273,7 @@ fn subtract_reduce<Vector: Operations>(
         let coefficient_normal_form =
             Vector::montgomery_multiply_by_constant(b.coefficients[i], 1441);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
             assert (is_bounded_vector 3328 ${coefficient_normal_form});
@@ -285,11 +296,14 @@ fn subtract_reduce<Vector: Operations>(
         );
 
         let diff = Vector::sub(myself.coefficients[i], &coefficient_normal_form);
+        #[cfg(hax)]
         hax_lib::fstar!("assert (is_bounded_vector 28296 diff)");
         let red = Vector::barrett_reduce(diff);
+        #[cfg(hax)]
         hax_lib::fstar!("assert (is_bounded_vector 3328 red)");
         b.coefficients[i] = red;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
             assert (forall j. (j > v $i /\ j < 16) ==> ${b}.f_coefficients.[ sz j ] == ${_b}.[ sz j]);
@@ -303,11 +317,11 @@ fn subtract_reduce<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
     is_bounded_poly 3328 ${myself} /\ 
-    is_bounded_poly 3328 ${message}"#))]
-#[hax_lib::ensures(|output| fstar!("is_bounded_poly 3328 ${output}"))]
+    is_bounded_poly 3328 ${message}"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|output| fstar!("is_bounded_poly 3328 ${output}")))]
 fn add_message_error_reduce<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     message: &PolynomialRingElement<Vector>,
@@ -317,12 +331,14 @@ fn add_message_error_reduce<Vector: Operations>(
     let _result = result.coefficients;
 
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             (forall j. j < v i ==> is_bounded_vector 3328 ${result}.f_coefficients.[ sz j ]) /\
             (forall j. (j >= v i /\ j < 16) ==> ${result}.f_coefficients.[ sz j ] == ${_result}.[ sz j ])
             "#
         ));
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
           assert (v $i < 16);
@@ -337,6 +353,7 @@ fn add_message_error_reduce<Vector: Operations>(
         let coefficient_normal_form =
             Vector::montgomery_multiply_by_constant(result.coefficients[i], 1441);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
                 Spec.Utils.lemma_add_intb_forall 3328 3328;
@@ -352,8 +369,10 @@ fn add_message_error_reduce<Vector: Operations>(
         );
 
         let sum1 = Vector::add(myself.coefficients[i], &message.coefficients[i]);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 6656 sum1)");
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"                
                 Spec.Utils.lemma_add_intb_forall 3328 6656;
@@ -372,11 +391,14 @@ fn add_message_error_reduce<Vector: Operations>(
         );
 
         let sum2 = Vector::add(coefficient_normal_form, &sum1);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 9984 sum2)");
         let red = Vector::barrett_reduce(sum2);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 3328 red)");
         result.coefficients[i] = red;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
             assert (forall j. (j > v $i /\ j < 16) ==> ${result}.f_coefficients.[ sz j ] == ${_result}.[ sz j]);
@@ -390,9 +412,9 @@ fn add_message_error_reduce<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 400 --split_queries always")]
-#[hax_lib::requires(fstar!("is_bounded_poly 7 ${error}"))]
-#[hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 400 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!("is_bounded_poly 7 ${error}")))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#)))]
 fn add_error_reduce<Vector: Operations>(
     myself: &mut PolynomialRingElement<Vector>,
     error: &PolynomialRingElement<Vector>,
@@ -401,6 +423,7 @@ fn add_error_reduce<Vector: Operations>(
     let _myself = myself.coefficients;
 
     for j in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             (forall j. j < v i ==> is_bounded_vector 3328 ${myself}.f_coefficients.[ sz j ]) /\
@@ -411,6 +434,7 @@ fn add_error_reduce<Vector: Operations>(
         let coefficient_normal_form =
             Vector::montgomery_multiply_by_constant(myself.coefficients[j], 1441);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
               assert (is_bounded_vector 3328 ${coefficient_normal_form});
@@ -432,11 +456,14 @@ fn add_error_reduce<Vector: Operations>(
         );
 
         let sum = Vector::add(coefficient_normal_form, &error.coefficients[j]);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 3335 sum)");
         let red = Vector::barrett_reduce(sum);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 3328 red)");
         myself.coefficients[j] = red;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
             assert (forall i. (i > v $j /\ i < 16) ==> ${myself}.f_coefficients.[ sz i ] == ${_myself}.[ sz i]);
@@ -449,17 +476,17 @@ fn add_error_reduce<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (i0.f_to_i16_array ${result}) /\
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (i0.f_to_i16_array ${result}) /\
                 (forall i. i < 16 ==> ((v (Seq.index (i0.f_to_i16_array ${result}) i) % 3329)==
-                                       (v (Seq.index (i0.f_to_i16_array ${vector}) i) * 1353 * 169) % 3329))"#))]
+                                       (v (Seq.index (i0.f_to_i16_array ${vector}) i) * 1353 * 169) % 3329))"#)))]
 fn to_standard_domain<T: Operations>(vector: T) -> T {
     T::montgomery_multiply_by_constant(vector, MONTGOMERY_R_SQUARED_MOD_FIELD_MODULUS as i16)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"is_bounded_poly #$:Vector 3328 ${error}"#))]
-#[hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly #$:Vector 3328 ${error}"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${myself}_future"#)))]
 fn add_standard_error_reduce<Vector: Operations>(
     myself: &mut PolynomialRingElement<Vector>,
     error: &PolynomialRingElement<Vector>,
@@ -468,6 +495,7 @@ fn add_standard_error_reduce<Vector: Operations>(
     let _myself = myself.coefficients;
 
     for j in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| fstar!(
             r#"
             (forall j. j < v i ==> is_bounded_vector 3328 ${myself}.f_coefficients.[ sz j ]) /\
@@ -479,6 +507,7 @@ fn add_standard_error_reduce<Vector: Operations>(
         // calling to_montgomery_domain() on them should return a mod q.
         let coefficient_normal_form = to_standard_domain::<Vector>(myself.coefficients[j]);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
           Spec.Utils.pow2_more_values 15;
@@ -501,11 +530,14 @@ fn add_standard_error_reduce<Vector: Operations>(
         );
 
         let sum = Vector::add(coefficient_normal_form, &error.coefficients[j]);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 6656 sum)");
         let red = Vector::barrett_reduce(sum);
+        #[cfg(hax)]
         hax_lib::fstar!("assert(is_bounded_vector 3328 red)");
         myself.coefficients[j] = red;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
             assert (forall i. (i > v $j /\ i < 16) ==> ${myself}.f_coefficients.[ sz i ] == ${_myself}.[ sz i]);
@@ -556,9 +588,9 @@ fn add_standard_error_reduce<Vector: Operations>(
 //                 result.coefficients[i].abs() <= FIELD_MODULUS
 // ))))]
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"is_bounded_poly 3328 ${myself} /\
-                              is_bounded_poly 3328 ${rhs}"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly 3328 ${myself} /\
+                              is_bounded_poly 3328 ${rhs}"#)))]
 fn ntt_multiply<Vector: Operations>(
     myself: &PolynomialRingElement<Vector>,
     rhs: &PolynomialRingElement<Vector>,
@@ -581,7 +613,7 @@ fn ntt_multiply<Vector: Operations>(
 
 // FIXME: We pulled out all the items because of https://github.com/hacspec/hax/issues/1183
 // Revisit when that issue is fixed.
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<Vector: Operations> PolynomialRingElement<Vector> {
     #[allow(non_snake_case)]
     pub(crate) fn ZERO() -> Self {
@@ -593,34 +625,34 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     /// Size of a ring element in bytes.
     #[inline(always)]
     #[allow(dead_code)]
-    #[ensures(|result| result == 512 )]
+    #[cfg_attr(hax, hax_lib::ensures(|result| result == 512 ))]
     pub(crate) const fn num_bytes() -> usize {
         VECTORS_IN_RING_ELEMENT * 32
     }
 
     #[inline(always)]
-    #[requires(VECTORS_IN_RING_ELEMENT * 16 <= a.len())]
+    #[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 <= a.len()))]
     pub(crate) fn from_i16_array(a: &[i16]) -> Self {
         from_i16_array(a)
     }
 
     #[allow(dead_code)]
     #[inline(always)]
-    #[requires(VECTORS_IN_RING_ELEMENT * 16 <= out.len())]
+    #[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 <= out.len()))]
     pub(crate) fn to_i16_array(self, out: &mut [i16]) {
         to_i16_array(self, out)
     }
 
     #[inline(always)]
     #[allow(dead_code)]
-    #[requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= bytes.len())]
+    #[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= bytes.len()))]
     pub(crate) fn from_bytes(bytes: &[u8]) -> Self {
         from_bytes(bytes)
     }
 
     #[inline(always)]
     #[allow(dead_code)]
-    #[requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= out.len())]
+    #[cfg_attr(hax, hax_lib::requires(VECTORS_IN_RING_ELEMENT * 16 * 2 <= out.len()))]
     pub(crate) fn to_bytes(self, out: &mut [u8]) {
         to_bytes(self, out)
     }
@@ -628,58 +660,58 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
     /// Given two polynomial ring elements `lhs` and `rhs`, compute the pointwise
     /// sum of their constituent coefficients.
     #[inline(always)]
-    #[requires(fstar!(r#"
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"
         forall (i:nat). i < v ${VECTORS_IN_RING_ELEMENT} ==>
             (let lhs_i = i0.f_to_i16_array (self.f_coefficients.[ sz i ]) in
             let rhs_i = i0.f_to_i16_array (${rhs}.f_coefficients.[ sz i ]) in
-            Libcrux_ml_kem.Vector.Traits.Spec.add_pre lhs_i rhs_i)"#))]
-    #[ensures(|_| fstar!(r#"
+            Libcrux_ml_kem.Vector.Traits.Spec.add_pre lhs_i rhs_i)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"
         forall (i:nat). i < v ${VECTORS_IN_RING_ELEMENT} ==>
             (let lhs_i = i0.f_to_i16_array (self.f_coefficients.[ sz i ]) in
             let rhs_i = i0.f_to_i16_array (${rhs}.f_coefficients.[ sz i ]) in
             let result_i = i0.f_to_i16_array (self_e_future.f_coefficients.[ sz i ]) in
-            Libcrux_ml_kem.Vector.Traits.Spec.add_post lhs_i rhs_i result_i)"#))]
+            Libcrux_ml_kem.Vector.Traits.Spec.add_post lhs_i rhs_i result_i)"#)))]
     pub(crate) fn add_to_ring_element<const K: usize>(&mut self, rhs: &Self) {
         add_to_ring_element::<Vector, K>(self, rhs);
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"is_bounded_poly 28296 self"#))]
-    #[ensures(|_| fstar!(r#"is_bounded_poly 3328 self_e_future"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly 28296 self"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| fstar!(r#"is_bounded_poly 3328 self_e_future"#)))]
     pub(crate) fn poly_barrett_reduce(&mut self) {
         poly_barrett_reduce(self);
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"is_bounded_poly (pow2 12 - 1) self"#))]
-    #[ensures(|result| fstar!(r#"is_bounded_poly 3328 ${result}"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly (pow2 12 - 1) self"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"is_bounded_poly 3328 ${result}"#)))]
     pub(crate) fn subtract_reduce(&self, b: Self) -> Self {
         subtract_reduce(self, b)
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"is_bounded_poly 3328 self /\ 
-                         is_bounded_poly 3328 ${message}"#))]
-    #[ensures(|output| fstar!(r#"is_bounded_poly 3328 ${output}"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly 3328 self /\ 
+                         is_bounded_poly 3328 ${message}"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|output| fstar!(r#"is_bounded_poly 3328 ${output}"#)))]
     pub(crate) fn add_message_error_reduce(&self, message: &Self, result: Self) -> Self {
         add_message_error_reduce(self, message, result)
     }
 
     #[inline(always)]
-    #[requires(fstar!("is_bounded_poly 7 ${error}"))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!("is_bounded_poly 7 ${error}")))]
     pub(crate) fn add_error_reduce(&mut self, error: &Self) {
         add_error_reduce(self, error);
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"is_bounded_poly #$:Vector 3328 ${error}"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly #$:Vector 3328 ${error}"#)))]
     pub(crate) fn add_standard_error_reduce(&mut self, error: &Self) {
         add_standard_error_reduce(self, error);
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"is_bounded_poly 3328 self /\
-                         is_bounded_poly 3328 ${rhs}"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"is_bounded_poly 3328 self /\
+                         is_bounded_poly 3328 ${rhs}"#)))]
     pub(crate) fn ntt_multiply(&self, rhs: &Self) -> Self {
         ntt_multiply(self, rhs)
     }
@@ -687,10 +719,10 @@ impl<Vector: Operations> PolynomialRingElement<Vector> {
 
 #[cfg(test)]
 mod tests {
-    use crate::vector::portable::PortableVector;
+    use libcrux_secrets::*;
 
     use super::PolynomialRingElement;
-    use libcrux_secrets::*;
+    use crate::vector::portable::PortableVector;
 
     #[test]
     fn encoding_portable() {

--- a/libcrux-ml-kem/src/sampling.rs
+++ b/libcrux-ml-kem/src/sampling.rs
@@ -71,7 +71,7 @@ fn sample_from_uniform_distribution_next<Vector: Operations, const K: usize, con
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash<K>>(
     seeds: &[[u8; 34]; K],
 ) -> [PolynomialRingElement<Vector>; K] {
@@ -152,17 +152,18 @@ pub(super) fn sample_from_xof<const K: usize, Vector: Operations, Hasher: Hash<K
 ///
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
-#[hax_lib::requires(randomness.len() == 2 * 64)]
+#[cfg_attr(hax, hax_lib::requires(randomness.len() == 2 * 64))]
 // TODO: Remove or replace with something that works and is useful for the proof.
 // #[cfg_attr(hax, hax_lib::ensures(|result|
 //     hax_lib::forall(|i:usize|
 //         hax_lib::implies(i < result.coefficients.len(), || result.coefficients[i].abs() <= 2
 // ))))]
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800"))]
 fn sample_from_binomial_distribution_2<Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v (sz 2 *! sz 64) == 128);
         assert (Seq.length $randomness == 128)"
@@ -178,6 +179,7 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
 
             let even_bits = random_bits_as_u32 & 0x55555555;
             let odd_bits = (random_bits_as_u32 >> 1) & 0x55555555;
+            #[cfg(hax)]
             hax_lib::fstar!(r#"logand_lemma $random_bits_as_u32 (mk_u32 1431655765);
                 logand_lemma ($random_bits_as_u32 >>! (mk_i32 1)) (mk_u32 1431655765)"#);
             let coin_toss_outcomes = even_bits + odd_bits;
@@ -186,6 +188,7 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
                 for outcome_set in (0..32u32).step_by(4) { // u32::BITS
                     let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x3) as i16;
                     let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 2)) & 0x3) as i16;
+                    #[cfg(hax)]
                     hax_lib::fstar!(r#"logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) (mk_u32 3);
                         logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! (mk_u32 2) <: u32) <: u32) (mk_u32 3);
                         assert (v $outcome_1 >= 0 /\ v $outcome_1 <= 3);
@@ -203,17 +206,18 @@ fn sample_from_binomial_distribution_2<Vector: Operations>(
     PolynomialRingElement::from_i16_array(&sampled_i16s)
 }
 
-#[hax_lib::requires(randomness.len() == 3 * 64)]
+#[cfg_attr(hax, hax_lib::requires(randomness.len() == 3 * 64))]
 // TODO: Remove or replace with something that works and is useful for the proof.
 // #[cfg_attr(hax, hax_lib::ensures(|result|
 //     hax_lib::forall(|i:usize|
 //         hax_lib::implies(i < result.coefficients.len(), || result.coefficients[i].abs() <= 3
 // ))))]
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800"))]
 fn sample_from_binomial_distribution_3<Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v (sz 3 *! sz 64) == 192);
         assert (Seq.length $randomness == 192)"
@@ -228,6 +232,7 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
             let first_bits = random_bits_as_u24 & 0x00249249;
             let second_bits = (random_bits_as_u24 >> 1) & 0x00249249;
             let third_bits = (random_bits_as_u24 >> 2) & 0x00249249;
+            #[cfg(hax)]
             hax_lib::fstar!(r#"logand_lemma $random_bits_as_u24 (mk_u32 2396745);
                 logand_lemma ($random_bits_as_u24 >>! (mk_i32 1) <: u32) (mk_u32 2396745);
                 logand_lemma ($random_bits_as_u24 >>! (mk_i32 2) <: u32) (mk_u32 2396745)"#);
@@ -238,6 +243,7 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
                 for outcome_set in (0..24).step_by(6) {
                     let outcome_1 = ((coin_toss_outcomes >> outcome_set) & 0x7) as i16;
                     let outcome_2 = ((coin_toss_outcomes >> (outcome_set + 3)) & 0x7) as i16;
+                    #[cfg(hax)]
                     hax_lib::fstar!(r#"logand_lemma ($coin_toss_outcomes >>! $outcome_set <: u32) (mk_u32 7);
                         logand_lemma ($coin_toss_outcomes >>! ($outcome_set +! (mk_i32 3) <: i32) <: u32) (mk_u32 7);
                         assert (v $outcome_1 >= 0 /\ v $outcome_1 <= 7);
@@ -256,16 +262,17 @@ fn sample_from_binomial_distribution_3<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires((ETA == 2 || ETA == 3) && randomness.len() == ETA * 64)]
-#[hax_lib::ensures(|result| fstar!(r#"(forall (i:nat). i < 8 ==> Libcrux_ml_kem.Ntt.ntt_layer_7_pre
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires((ETA == 2 || ETA == 3) && randomness.len() == ETA * 64))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"(forall (i:nat). i < 8 ==> Libcrux_ml_kem.Ntt.ntt_layer_7_pre
     (${result}.f_coefficients.[ sz i ]) (${result}.f_coefficients.[ sz i +! sz 8 ])) /\
     Libcrux_ml_kem.Polynomial.is_bounded_poly 7 ${result} /\
     Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result ==
-        Spec.MLKEM.sample_poly_cbd $ETA $randomness"#))]
+        Spec.MLKEM.sample_poly_cbd $ETA $randomness"#)))]
 pub(super) fn sample_from_binomial_distribution<const ETA: usize, Vector: Operations>(
     randomness: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (
         (v (cast $ETA <: u32) == 2) \/

--- a/libcrux-ml-kem/src/serialize.rs
+++ b/libcrux-ml-kem/src/serialize.rs
@@ -6,30 +6,32 @@ use crate::{
 };
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_vector 3328 $a"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_vector 3328 $a"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
     v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $result) i) >= 0 /\
-    v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $result) i) < v ${crate::vector::FIELD_MODULUS}"#))]
+    v (Seq.index (Libcrux_ml_kem.Vector.Traits.f_to_i16_array $result) i) < v ${crate::vector::FIELD_MODULUS}"#)))]
 pub(super) fn to_unsigned_field_modulus<Vector: Operations>(a: Vector) -> Vector {
     Vector::to_unsigned_representative(a)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#))]
-#[hax_lib::ensures(|result|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result ==
         Spec.MLKEM.compress_then_encode_message (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#)
-)]
+))]
 pub(super) fn compress_then_serialize_message<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
 ) -> [u8; SHARED_SECRET_SIZE] {
     let mut serialized = [0u8; SHARED_SECRET_SIZE];
     for i in 0..16 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!("v $i < 16 ==> Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re")
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (2 * v $i + 2 <= 32)"#);
 
         let coefficient = to_unsigned_field_modulus(re.coefficients[i]);
@@ -43,11 +45,11 @@ pub(super) fn compress_then_serialize_message<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result ==
         Spec.MLKEM.decode_then_decompress_message $serialized"#)
-)]
+))]
 pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
     serialized: &[u8; SHARED_SECRET_SIZE],
 ) -> PolynomialRingElement<Vector> {
@@ -60,24 +62,27 @@ pub(super) fn deserialize_then_decompress_message<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#))]
-#[hax_lib::ensures(|result|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result ==
         Spec.MLKEM.byte_encode 12 (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#)
-)]
+))]
 pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; BYTES_PER_RING_ELEMENT] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (pow2 12 == 4096)"#);
     let mut serialized = [0u8; BYTES_PER_RING_ELEMENT];
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i >= 0 /\ v $i <= 16 /\
             v $i < 16 ==> Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (24 * v $i + 24 <= 384)"#);
         let coefficient = to_unsigned_field_modulus(re.coefficients[i]);
 
@@ -88,17 +93,18 @@ pub(super) fn serialize_uncompressed_ring_element<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == BYTES_PER_RING_ELEMENT
-)]
-#[hax_lib::ensures(|result|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
         Spec.MLKEM.byte_decode 12 $serialized"#)
-)]
+))]
 pub(super) fn deserialize_to_uncompressed_ring_element<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $BYTES_PER_RING_ELEMENT / 24 == 16)"#);
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
@@ -115,13 +121,14 @@ pub(super) fn deserialize_to_uncompressed_ring_element<Vector: Operations>(
 ///
 /// This MUST NOT be used with secret inputs, like its caller `deserialize_ring_elements_reduced`.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == BYTES_PER_RING_ELEMENT
-)]
+))]
 fn deserialize_to_reduced_ring_element<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $BYTES_PER_RING_ELEMENT / 24 == 16)"#);
     let mut re = PolynomialRingElement::<Vector>::ZERO();
 
@@ -139,15 +146,15 @@ fn deserialize_to_reduced_ring_element<Vector: Operations>(
 ///
 /// This function MUST NOT be used on secret inputs.
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(r#"Spec.MLKEM.is_rank v_K /\ 
             Seq.length public_key == v (Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K)"#)
-)]
-#[hax_lib::ensures(|result|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"forall (i:nat). i < v $K ==>
         Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 (Seq.index $result i)"#)
-)]
+))]
 pub(super) fn deserialize_ring_elements_reduced_out<const K: usize, Vector: Operations>(
     public_key: &[u8],
 ) -> [PolynomialRingElement<Vector>; K] {
@@ -158,15 +165,15 @@ pub(super) fn deserialize_ring_elements_reduced_out<const K: usize, Vector: Oper
 
 /// See [deserialize_ring_elements_reduced_out].
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(r#"Spec.MLKEM.is_rank v_K /\ 
             Seq.length public_key == v (Spec.MLKEM.v_T_AS_NTT_ENCODED_SIZE v_K)"#)
-)]
-#[hax_lib::ensures(|_|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_vector_t #$K #$:Vector ${deserialized_pk}_future == 
         Spec.MLKEM.vector_decode_12 #$K $public_key"#)
-)]
+))]
 pub(super) fn deserialize_ring_elements_reduced<const K: usize, Vector: Operations>(
     public_key: &[u8],
     deserialized_pk: &mut [PolynomialRingElement<Vector>; K],
@@ -183,20 +190,23 @@ pub(super) fn deserialize_ring_elements_reduced<const K: usize, Vector: Operatio
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"v $OUT_LEN == 320 /\ Libcrux_ml_kem.Polynomial.is_bounded_poly 3328  $re"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $OUT_LEN == 320 /\ Libcrux_ml_kem.Polynomial.is_bounded_poly 3328  $re"#)))]
 fn compress_then_serialize_10<const OUT_LEN: usize, Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (pow2 10 == 1024)"#);
     let mut serialized = [0u8; OUT_LEN];
     for i in 0..VECTORS_IN_RING_ELEMENT {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i >= 0 /\ v $i <= 16 /\
             v $i < 16 ==> Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (20 * v $i + 20 <= 320)"#);
         let coefficient = Vector::compress::<10>(to_unsigned_field_modulus(re.coefficients[i]));
 
@@ -207,7 +217,7 @@ fn compress_then_serialize_10<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 fn compress_then_serialize_11<const OUT_LEN: usize, Vector: Operations>(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
@@ -223,13 +233,13 @@ fn compress_then_serialize_11<const OUT_LEN: usize, Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"(v $COMPRESSION_FACTOR == 10 \/ v $COMPRESSION_FACTOR == 11) /\
-    v $OUT_LEN == 32 * v $COMPRESSION_FACTOR /\ Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#))]
-#[hax_lib::ensures(|result|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COMPRESSION_FACTOR == 10 \/ v $COMPRESSION_FACTOR == 11) /\
+    v $OUT_LEN == 32 * v $COMPRESSION_FACTOR /\ Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"$result == Spec.MLKEM.compress_then_byte_encode (v $COMPRESSION_FACTOR)
         (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#)
-)]
+))]
 pub(super) fn compress_then_serialize_ring_element_u<
     const COMPRESSION_FACTOR: usize,
     const OUT_LEN: usize,
@@ -237,6 +247,7 @@ pub(super) fn compress_then_serialize_ring_element_u<
 >(
     re: &PolynomialRingElement<Vector>,
 ) -> [u8; OUT_LEN] {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (
         (v (cast $COMPRESSION_FACTOR <: u32) == 10) \/
@@ -250,19 +261,21 @@ pub(super) fn compress_then_serialize_ring_element_u<
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Seq.length $serialized == 128 /\
-    Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#))]
-#[hax_lib::ensures(|_|
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length $serialized == 128 /\
+    Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     fstar!(r#"${serialized_future.len()} == ${serialized.len()}"#)
-)]
+))]
 fn compress_then_serialize_4<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
     serialized: &mut [u8],
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (pow2 4 == 16)"#);
     for i in 0..VECTORS_IN_RING_ELEMENT {
         // NOTE: Using `$serialized` in loop_invariant doesn't work here
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $i >= 0 /\ v $i <= 16 /\
@@ -270,6 +283,7 @@ fn compress_then_serialize_4<Vector: Operations>(
                            Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re)"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (8 * v $i + 8 <= 128)"#);
         let coefficient = Vector::compress::<4>(to_unsigned_field_modulus(re.coefficients[i]));
 
@@ -279,13 +293,13 @@ fn compress_then_serialize_4<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == 160
-)]
-#[hax_lib::ensures(|_|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     fstar!(r#"${serialized_future.len()} == ${serialized.len()}"#)
-)]
+))]
 fn compress_then_serialize_5<Vector: Operations>(
     re: PolynomialRingElement<Vector>,
     serialized: &mut [u8],
@@ -300,16 +314,16 @@ fn compress_then_serialize_5<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank v_K /\ 
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank v_K /\ 
     $COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR v_K /\
     Seq.length $out == v $OUT_LEN /\ v $OUT_LEN == 32 * v $COMPRESSION_FACTOR /\
-    Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#))]
-#[hax_lib::ensures(|_|
+    Libcrux_ml_kem.Polynomial.is_bounded_poly 3328 $re"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|_|
     fstar!(r#"${out_future.len()} == ${out.len()} /\
         ${out}_future == Spec.MLKEM.compress_then_encode_v #v_K
             (Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $re)"#)
-)]
+))]
 pub(super) fn compress_then_serialize_ring_element_v<
     const K: usize,
     const COMPRESSION_FACTOR: usize,
@@ -319,6 +333,7 @@ pub(super) fn compress_then_serialize_ring_element_v<
     re: PolynomialRingElement<Vector>,
     out: &mut [u8],
 ) {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (
         (v (cast $COMPRESSION_FACTOR <: u32) == 4) \/
@@ -332,12 +347,13 @@ pub(super) fn compress_then_serialize_ring_element_v<
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == 320
-)]
+))]
 fn deserialize_then_decompress_10<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v ((${crate::constants::COEFFICIENTS_IN_RING_ELEMENT} *! sz 10) /! sz 8) == 320)"#
     );
@@ -353,13 +369,14 @@ fn deserialize_then_decompress_10<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == 352
-)]
+))]
 fn deserialize_then_decompress_11<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v ((${crate::constants::COEFFICIENTS_IN_RING_ELEMENT} *! sz 11) /! sz 8) == 352)"#
     );
@@ -376,21 +393,22 @@ fn deserialize_then_decompress_11<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(
     (COMPRESSION_FACTOR == 10 || COMPRESSION_FACTOR == 11) &&
     serialized.len() == 32 * COMPRESSION_FACTOR
-)]
-#[hax_lib::ensures(|result|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
         Spec.MLKEM.byte_decode_then_decompress (v $COMPRESSION_FACTOR) $serialized"#)
-)]
+))]
 pub(super) fn deserialize_then_decompress_ring_element_u<
     const COMPRESSION_FACTOR: usize,
     Vector: Operations,
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (
         (v (cast $COMPRESSION_FACTOR <: u32) == 10) \/
@@ -404,12 +422,13 @@ pub(super) fn deserialize_then_decompress_ring_element_u<
 }
 
 #[inline(always)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == 128
-)]
+))]
 fn deserialize_then_decompress_4<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v ((${crate::constants::COEFFICIENTS_IN_RING_ELEMENT} *! sz 4) /! sz 8) == 128)"#
     );
@@ -425,13 +444,14 @@ fn deserialize_then_decompress_4<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(
     serialized.len() == 160
-)]
+))]
 fn deserialize_then_decompress_5<Vector: Operations>(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v ((${crate::constants::COEFFICIENTS_IN_RING_ELEMENT} *! sz 5) /! sz 8) == 160)"#
     );
@@ -447,15 +467,15 @@ fn deserialize_then_decompress_5<Vector: Operations>(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\ 
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.is_rank $K /\ 
     $COMPRESSION_FACTOR == Spec.MLKEM.v_VECTOR_V_COMPRESSION_FACTOR $K /\
     Seq.length $serialized == 32 * v $COMPRESSION_FACTOR"#)
-)]
-#[hax_lib::ensures(|result|
+))]
+#[cfg_attr(hax, hax_lib::ensures(|result|
     fstar!(r#"Libcrux_ml_kem.Polynomial.to_spec_poly_t #$:Vector $result == 
         Spec.MLKEM.decode_then_decompress_v #${K} $serialized"#)
-)]
+))]
 pub(super) fn deserialize_then_decompress_ring_element_v<
     const K: usize,
     const COMPRESSION_FACTOR: usize,
@@ -463,6 +483,7 @@ pub(super) fn deserialize_then_decompress_ring_element_v<
 >(
     serialized: &[u8],
 ) -> PolynomialRingElement<Vector> {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (
         (v (cast $COMPRESSION_FACTOR <: u32) == 4) \/

--- a/libcrux-ml-kem/src/types.rs
+++ b/libcrux-ml-kem/src/types.rs
@@ -12,17 +12,17 @@ macro_rules! impl_generic_struct {
             }
         }
 
-        #[hax_lib::attributes]
+        #[cfg_attr(hax, hax_lib::attributes)]
         impl<const SIZE: usize> AsRef<[u8]> for $name<SIZE> {
-            #[ensures(|result| fstar!(r#"$result = ${self_}.f_value"#))]
+            #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"$result = ${self_}.f_value"#)))]
             fn as_ref(&self) -> &[u8] {
                 &self.value
             }
         }
 
-        #[hax_lib::attributes]
+        #[cfg_attr(hax, hax_lib::attributes)]
         impl<const SIZE: usize> From<[u8; SIZE]> for $name<SIZE> {
-            #[ensures(|result| fstar!(r#"${result}.f_value = $value"#))]
+            #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_value = $value"#)))]
             fn from(value: [u8; SIZE]) -> Self {
                 Self { value }
             }
@@ -53,10 +53,10 @@ macro_rules! impl_generic_struct {
             }
         }
 
-        #[hax_lib::attributes]
+        #[cfg_attr(hax, hax_lib::attributes)]
         impl<const SIZE: usize> $name<SIZE> {
             /// A reference to the raw byte slice.
-            #[ensures(|result| fstar!(r#"$result == self.f_value"#))]
+            #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"$result == self.f_value"#)))]
             pub fn as_slice(&self) -> &[u8; SIZE] {
                 &self.value
             }
@@ -269,7 +269,7 @@ pub struct MlKemKeyPair<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: us
     pub(crate) pk: MlKemPublicKey<PUBLIC_KEY_SIZE>,
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize>
     MlKemKeyPair<PRIVATE_KEY_SIZE, PUBLIC_KEY_SIZE>
 {
@@ -282,7 +282,7 @@ impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize>
     }
 
     /// Create a new [`MlKemKeyPair`] from the secret and public key.
-    #[ensures(|result| fstar!(r#"${result}.f_sk == $sk /\ ${result}.f_pk == $pk"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_sk == $sk /\ ${result}.f_pk == $pk"#)))]
     pub fn from(
         sk: MlKemPrivateKey<PRIVATE_KEY_SIZE>,
         pk: MlKemPublicKey<PUBLIC_KEY_SIZE>,
@@ -324,10 +324,10 @@ impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize>
 /// Unpack an incoming private key into it's different parts.
 ///
 /// We have this here in types to extract into a common core for C.
-#[hax_lib::requires(fstar!(r#"Seq.length private_key >= 
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length private_key >= 
                             v v_CPA_SECRET_KEY_SIZE + v v_PUBLIC_KEY_SIZE + 
-                            v Libcrux_ml_kem.Constants.v_H_DIGEST_SIZE"#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+                            v Libcrux_ml_kem.Constants.v_H_DIGEST_SIZE"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
            let (ind_cpa_secret_key_s,rest) = split $private_key $CPA_SECRET_KEY_SIZE in
            let (ind_cpa_public_key_s,rest) = split rest $PUBLIC_KEY_SIZE in
            let (ind_cpa_public_key_hash_s,implicit_rejection_value_s) = split rest Libcrux_ml_kem.Constants.v_H_DIGEST_SIZE in
@@ -343,7 +343,7 @@ impl<const PRIVATE_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize>
            Seq.length implicit_rejection_value == 
            Seq.length private_key - 
              (v v_CPA_SECRET_KEY_SIZE + v v_PUBLIC_KEY_SIZE + v Libcrux_ml_kem.Constants.v_H_DIGEST_SIZE)
-           "#))]
+           "#)))]
 pub(crate) fn unpack_private_key<const CPA_SECRET_KEY_SIZE: usize, const PUBLIC_KEY_SIZE: usize>(
     private_key: &[u8], // len: SECRET_KEY_SIZE
 ) -> (&[u8], &[u8], &[u8], &[u8]) {

--- a/libcrux-ml-kem/src/utils.rs
+++ b/libcrux-ml-kem/src/utils.rs
@@ -15,16 +15,21 @@ type PaddedArray<const N: usize> = [u8; N];
 pub(crate) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> PaddedArray<LEN> {
     let mut out = [0u8; LEN];
     out[0..slice.len()].copy_from_slice(slice);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Seq.slice out 0 (Seq.length slice) == slice)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Seq.slice out (Seq.length slice) (v v_LEN) == Seq.slice (Seq.create (v v_LEN) (mk_u8 0)) (Seq.length slice) (v v_LEN))"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. i < Seq.length slice ==> Seq.index out i == Seq.index slice i)"
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. (i >= Seq.length slice && i < v v_LEN) ==> Seq.index out i == Seq.index (Seq.slice out (Seq.length slice) (v v_LEN)) (i - Seq.length slice))"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         "Seq.lemma_eq_intro out (Seq.append slice (Seq.create (v v_LEN - Seq.length slice) (mk_u8 0)))"
     );
@@ -32,14 +37,14 @@ pub(crate) fn into_padded_array<const LEN: usize>(slice: &[u8]) -> PaddedArray<L
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::requires(fstar!(r#"range (v $domain_separator + v $K) u8_inttype"#))]
-#[hax_lib::ensures(|ds|
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"range (v $domain_separator + v $K) u8_inttype"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|ds|
     fstar!(r#"v $ds == v $domain_separator + v $K /\
             (forall (i:nat). i < v $K ==>
                 v (Seq.index (Seq.index ${prf_inputs}_future i) 32) == v $domain_separator + i /\
                 Seq.slice (Seq.index ${prf_inputs}_future i) 0 32 == Seq.slice (Seq.index $prf_inputs i) 0 32)"#)
-)]
+))]
 pub(crate) fn prf_input_inc<const K: usize>(
     prf_inputs: &mut [[u8; 33]; K],
     mut domain_separator: u8,
@@ -50,6 +55,7 @@ pub(crate) fn prf_input_inc<const K: usize>(
     let _prf_inputs_init = prf_inputs.clone();
 
     for i in 0..K {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"v $domain_separator == v $_domain_separator_init + v $i /\

--- a/libcrux-ml-kem/src/variant.rs
+++ b/libcrux-ml-kem/src/variant.rs
@@ -9,21 +9,21 @@ use crate::{constants::CPA_PKE_KEY_GENERATION_SEED_SIZE, hash_functions::Hash};
 /// NIST PQ competition.
 ///
 /// cf. FIPS 203, Appendix C
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub(crate) trait Variant {
-    #[requires(shared_secret.len() == 32)]
-    #[ensures(|res| fstar!(r#"$res == $shared_secret"#))] // We only have post-conditions for ML-KEM, not Kyber
+    #[cfg_attr(hax, hax_lib::requires(shared_secret.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"$res == $shared_secret"#)))] // We only have post-conditions for ML-KEM, not Kyber
     fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
         shared_secret: &[u8],
         ciphertext: &[u8; CIPHERTEXT_SIZE],
     ) -> [u8; 32];
-    #[requires(randomness.len() == 32)]
-    #[ensures(|res| fstar!(r#"$res == $randomness"#))] // We only have post-conditions for ML-KEM, not Kyber
+    #[cfg_attr(hax, hax_lib::requires(randomness.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"$res == $randomness"#)))] // We only have post-conditions for ML-KEM, not Kyber
     fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32];
-    #[requires(seed.len() == 32)]
-    #[ensures(|res| fstar!(r#"Seq.length $seed == 32 ==> $res == Spec.Utils.v_G
+    #[cfg_attr(hax, hax_lib::requires(seed.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"Seq.length $seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $seed (Seq.create 1 (cast $K <: u8)))"#)
-    )]
+    ))]
     fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(seed: &[u8]) -> [u8; 64];
 }
 
@@ -69,11 +69,11 @@ impl Variant for Kyber {
 /// * the derivation of the shared secret does not include a hash of the ML-KEM ciphertext.
 pub(crate) struct MlKem {}
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Variant for MlKem {
     #[inline(always)]
-    #[requires(shared_secret.len() == 32)]
-    #[ensures(|res| fstar!(r#"$res == $shared_secret"#))]
+    #[cfg_attr(hax, hax_lib::requires(shared_secret.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"$res == $shared_secret"#)))]
     fn kdf<const K: usize, const CIPHERTEXT_SIZE: usize, Hasher: Hash<K>>(
         shared_secret: &[u8],
         _: &[u8; CIPHERTEXT_SIZE],
@@ -84,8 +84,8 @@ impl Variant for MlKem {
     }
 
     #[inline(always)]
-    #[requires(randomness.len() == 32)]
-    #[ensures(|res| fstar!(r#"$res == $randomness"#))]
+    #[cfg_attr(hax, hax_lib::requires(randomness.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"$res == $randomness"#)))]
     fn entropy_preprocess<const K: usize, Hasher: Hash<K>>(randomness: &[u8]) -> [u8; 32] {
         let mut out = [0u8; 32];
         out.copy_from_slice(randomness);
@@ -93,14 +93,15 @@ impl Variant for MlKem {
     }
 
     #[inline(always)]
-    #[requires(key_generation_seed.len() == 32)]
-    #[ensures(|res| fstar!(r#"Seq.length $key_generation_seed == 32 ==> $res == Spec.Utils.v_G
+    #[cfg_attr(hax, hax_lib::requires(key_generation_seed.len() == 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|res| fstar!(r#"Seq.length $key_generation_seed == 32 ==> $res == Spec.Utils.v_G
         (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"#)
-    )]
+    ))]
     fn cpa_keygen_seed<const K: usize, Hasher: Hash<K>>(key_generation_seed: &[u8]) -> [u8; 64] {
         let mut seed = [0u8; CPA_PKE_KEY_GENERATION_SEED_SIZE + 1];
         seed[0..CPA_PKE_KEY_GENERATION_SEED_SIZE].copy_from_slice(key_generation_seed);
         seed[CPA_PKE_KEY_GENERATION_SEED_SIZE] = K as u8;
+        #[cfg(hax)]
         hax_lib::fstar!(
             "eq_intro $seed
             (Seq.append $key_generation_seed (Seq.create 1 (cast $K <: u8)))"

--- a/libcrux-ml-kem/src/vector/avx2.rs
+++ b/libcrux-ml-kem/src/vector/avx2.rs
@@ -1,5 +1,6 @@
-use super::traits::Operations;
 pub(crate) use libcrux_intrinsics::avx2::*;
+
+use super::traits::Operations;
 
 mod arithmetic;
 mod compress;
@@ -8,15 +9,15 @@ mod sampling;
 mod serialize;
 
 #[derive(Clone, Copy)]
-#[hax_lib::fstar::before(interface, "noeq")]
-#[hax_lib::fstar::after(interface,"let repr (x:t_SIMD256Vector) : t_Array i16 (sz 16) = Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 x.f_elements")]
+#[cfg_attr(hax, hax_lib::fstar::before(interface, "noeq"))]
+#[cfg_attr(hax, hax_lib::fstar::after(interface,"let repr (x:t_SIMD256Vector) : t_Array i16 (sz 16) = Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 x.f_elements"))]
 pub struct SIMD256Vector {
     elements: Vec256,
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result| fstar!(r#"repr ${result} == Seq.create 16 (mk_i16 0)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"repr ${result} == Seq.create 16 (mk_i16 0)"#)))]
 fn vec_zero() -> SIMD256Vector {
     SIMD256Vector {
         elements: mm256_setzero_si256(),
@@ -24,8 +25,8 @@ fn vec_zero() -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result| fstar!(r#"${result} == repr ${v}"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result} == repr ${v}"#)))]
 fn vec_to_i16_array(v: SIMD256Vector) -> [i16; 16] {
     let mut output = [0i16; 16];
     mm256_storeu_si256_i16(&mut output, v.elements);
@@ -34,8 +35,8 @@ fn vec_to_i16_array(v: SIMD256Vector) -> [i16; 16] {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
-#[hax_lib::ensures(|result| fstar!(r#"repr ${result} == ${array}"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"repr ${result} == ${array}"#)))]
 fn vec_from_i16_array(array: &[i16]) -> SIMD256Vector {
     SIMD256Vector {
         elements: mm256_loadu_si256_i16(array),
@@ -43,9 +44,9 @@ fn vec_from_i16_array(array: &[i16]) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (repr $vector)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (repr $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (repr $vector)"#)))]
 fn cond_subtract_3329(vector: SIMD256Vector) -> SIMD256Vector {
     SIMD256Vector {
         elements: arithmetic::cond_subtract_3329(vector.elements),
@@ -53,10 +54,10 @@ fn cond_subtract_3329(vector: SIMD256Vector) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (repr $vector) i) >= 0 /\
-    v (Seq.index (repr $vector) i) < 3329"#))]
-#[hax_lib::ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (repr $out) i) 1"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (repr $vector) i) >= 0 /\
+    v (Seq.index (repr $vector) i) < 3329"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (repr $out) i) 1"#)))]
 fn compress_1(vector: SIMD256Vector) -> SIMD256Vector {
     SIMD256Vector {
         elements: compress::compress_message_coefficient(vector.elements),
@@ -64,18 +65,18 @@ fn compress_1(vector: SIMD256Vector) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
     v $COEFFICIENT_BITS == 5 \/
     v $COEFFICIENT_BITS == 10 \/
     v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (repr $vector) i) >= 0 /\
-    v (Seq.index (repr $vector) i) < 3329)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    v (Seq.index (repr $vector) i) < 3329)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
     v $COEFFICIENT_BITS == 5 \/
     v $COEFFICIENT_BITS == 10 \/
     v $COEFFICIENT_BITS == 11) ==>
-        (forall (i:nat). i < 16 ==> bounded (Seq.index (repr $out) i) (v $COEFFICIENT_BITS))"#))]
+        (forall (i:nat). i < 16 ==> bounded (Seq.index (repr $out) i) (v $COEFFICIENT_BITS))"#)))]
 fn compress<const COEFFICIENT_BITS: i32>(vector: SIMD256Vector) -> SIMD256Vector {
     SIMD256Vector {
         elements: compress::compress_ciphertext_coefficient::<COEFFICIENT_BITS>(vector.elements),
@@ -83,11 +84,11 @@ fn compress<const COEFFICIENT_BITS: i32>(vector: SIMD256Vector) -> SIMD256Vector
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                     Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                    Spec.Utils.is_i16b_array (11207+5*3328) (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (repr $out)"#))]
+                    Spec.Utils.is_i16b_array (11207+5*3328) (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (repr $out)"#)))]
 fn ntt_layer_1_step(
     vector: SIMD256Vector,
     zeta0: i16,
@@ -101,10 +102,10 @@ fn ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                    Spec.Utils.is_i16b_array (11207+4*3328) (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                    Spec.Utils.is_i16b_array (11207+4*3328) (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (repr $out)"#)))]
 fn ntt_layer_2_step(vector: SIMD256Vector, zeta0: i16, zeta1: i16) -> SIMD256Vector {
     SIMD256Vector {
         elements: ntt::ntt_layer_2_step(vector.elements, zeta0, zeta1),
@@ -112,10 +113,10 @@ fn ntt_layer_2_step(vector: SIMD256Vector, zeta0: i16, zeta1: i16) -> SIMD256Vec
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                    Spec.Utils.is_i16b_array (11207+3*3328) (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                    Spec.Utils.is_i16b_array (11207+3*3328) (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (repr $out)"#)))]
 fn ntt_layer_3_step(vector: SIMD256Vector, zeta: i16) -> SIMD256Vector {
     SIMD256Vector {
         elements: ntt::ntt_layer_3_step(vector.elements, zeta),
@@ -123,11 +124,11 @@ fn ntt_layer_3_step(vector: SIMD256Vector, zeta: i16) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                     Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3  /\
-                    Spec.Utils.is_i16b_array (4*3328) (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#))]
+                    Spec.Utils.is_i16b_array (4*3328) (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#)))]
 fn inv_ntt_layer_1_step(
     vector: SIMD256Vector,
     zeta0: i16,
@@ -141,10 +142,10 @@ fn inv_ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                    Spec.Utils.is_i16b_array 3328 (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                    Spec.Utils.is_i16b_array 3328 (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#)))]
 fn inv_ntt_layer_2_step(vector: SIMD256Vector, zeta0: i16, zeta1: i16) -> SIMD256Vector {
     SIMD256Vector {
         elements: ntt::inv_ntt_layer_2_step(vector.elements, zeta0, zeta1),
@@ -152,10 +153,10 @@ fn inv_ntt_layer_2_step(vector: SIMD256Vector, zeta0: i16, zeta1: i16) -> SIMD25
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                    Spec.Utils.is_i16b_array 3328 (repr ${vector})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                    Spec.Utils.is_i16b_array 3328 (repr ${vector})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#)))]
 fn inv_ntt_layer_3_step(vector: SIMD256Vector, zeta: i16) -> SIMD256Vector {
     SIMD256Vector {
         elements: ntt::inv_ntt_layer_3_step(vector.elements, zeta),
@@ -163,12 +164,12 @@ fn inv_ntt_layer_3_step(vector: SIMD256Vector, zeta: i16) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                     Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                     Spec.Utils.is_i16b_array 3328 (repr ${lhs}) /\
-                    Spec.Utils.is_i16b_array 3328 (repr ${rhs})"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#))]
+                    Spec.Utils.is_i16b_array 3328 (repr ${rhs})"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (repr $out)"#)))]
 fn ntt_multiply(
     lhs: &SIMD256Vector,
     rhs: &SIMD256Vector,
@@ -183,17 +184,17 @@ fn ntt_multiply(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (repr $vector) ==> Spec.MLKEM.serialize_post 1 (repr $vector) $out"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (repr $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (repr $vector) ==> Spec.MLKEM.serialize_post 1 (repr $vector) $out"#)))]
 fn serialize_1(vector: SIMD256Vector) -> [u8; 2] {
     serialize::serialize_1(vector.elements)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(bytes.len() == 2)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $bytes (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 2))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $bytes (repr $out)"#)))]
 fn deserialize_1(bytes: &[u8]) -> SIMD256Vector {
     SIMD256Vector {
         elements: serialize::deserialize_1(bytes),
@@ -201,17 +202,17 @@ fn deserialize_1(bytes: &[u8]) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (repr $vector) ==> Spec.MLKEM.serialize_post 4 (repr $vector) $out"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (repr $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (repr $vector) ==> Spec.MLKEM.serialize_post 4 (repr $vector) $out"#)))]
 fn serialize_4(vector: SIMD256Vector) -> [u8; 8] {
     serialize::serialize_4(vector.elements)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(bytes.len() == 8)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $bytes (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 8))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $bytes (repr $out)"#)))]
 fn deserialize_4(bytes: &[u8]) -> SIMD256Vector {
     SIMD256Vector {
         elements: serialize::deserialize_4(bytes),
@@ -219,17 +220,17 @@ fn deserialize_4(bytes: &[u8]) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (repr $vector) ==> Spec.MLKEM.serialize_post 10 (repr $vector) $out"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (repr $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (repr $vector) ==> Spec.MLKEM.serialize_post 10 (repr $vector) $out"#)))]
 fn serialize_10(vector: SIMD256Vector) -> [u8; 20] {
     serialize::serialize_10(vector.elements)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(bytes.len() == 20)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $bytes (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 20))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $bytes (repr $out)"#)))]
 fn deserialize_10(bytes: &[u8]) -> SIMD256Vector {
     SIMD256Vector {
         elements: serialize::deserialize_10(bytes),
@@ -237,17 +238,17 @@ fn deserialize_10(bytes: &[u8]) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (repr $vector)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (repr $vector) ==> Spec.MLKEM.serialize_post 12 (repr $vector) $out"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (repr $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (repr $vector) ==> Spec.MLKEM.serialize_post 12 (repr $vector) $out"#)))]
 fn serialize_12(vector: SIMD256Vector) -> [u8; 24] {
     serialize::serialize_12(vector.elements)
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(bytes.len() == 24)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $bytes (repr $out)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 24))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $bytes (repr $out)"#)))]
 fn deserialize_12(bytes: &[u8]) -> SIMD256Vector {
     SIMD256Vector {
         elements: serialize::deserialize_12(bytes),
@@ -265,7 +266,7 @@ impl crate::vector::traits::Repr for SIMD256Vector {
 impl crate::vector::traits::Repr for SIMD256Vector {}
 
 #[inline(always)]
-#[hax_lib::requires(array.len() >= 32)]
+#[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
 pub(super) fn from_bytes(array: &[u8]) -> SIMD256Vector {
     SIMD256Vector {
         elements: mm256_loadu_si256_u8(&array[0..32]),
@@ -273,52 +274,52 @@ pub(super) fn from_bytes(array: &[u8]) -> SIMD256Vector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(bytes.len() >= 32)]
-#[hax_lib::ensures(|_| future(bytes).len() == bytes.len())]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(bytes).len() == bytes.len()))]
 pub(super) fn to_bytes(x: SIMD256Vector, bytes: &mut [u8]) {
     mm256_storeu_si256_u8(&mut bytes[0..32], x.elements)
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Operations for SIMD256Vector {
     #[inline(always)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#)))]
     fn ZERO() -> Self {
         vec_zero()
     }
 
-    #[requires(array.len() == 16)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == $array"#)))]
     #[inline(always)]
     fn from_i16_array(array: &[i16]) -> Self {
         vec_from_i16_array(array)
     }
 
-    #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"out == impl.f_repr $x"#)))]
     #[inline(always)]
     fn to_i16_array(x: Self) -> [i16; 16] {
         vec_to_i16_array(x)
     }
 
-    #[requires(array.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
     #[inline(always)]
     fn from_bytes(array: &[u8]) -> Self {
         from_bytes(array)
     }
 
-    #[requires(bytes.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
     #[inline(always)]
-    #[ensures(|_| future(bytes).len() == bytes.len())]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(bytes).len() == bytes.len()))]
     fn to_bytes(x: Self, bytes: &mut [u8]) {
         to_bytes(x, bytes)
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${lhs}) i) + v (Seq.index (impl.f_repr ${rhs}) i))"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${lhs}) i) + v (Seq.index (impl.f_repr ${rhs}) i))"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (impl.f_repr ${result}) i) == 
-         v (Seq.index (impl.f_repr ${lhs}) i) + v (Seq.index (impl.f_repr ${rhs}) i))"#))]
+         v (Seq.index (impl.f_repr ${lhs}) i) + v (Seq.index (impl.f_repr ${rhs}) i))"#)))]
     #[inline(always)]
     fn add(lhs: Self, rhs: &Self) -> Self {
         Self {
@@ -326,11 +327,11 @@ impl Operations for SIMD256Vector {
         }
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${lhs}) i) - v (Seq.index (impl.f_repr ${rhs}) i))"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${lhs}) i) - v (Seq.index (impl.f_repr ${rhs}) i))"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (impl.f_repr ${result}) i) == 
-         v (Seq.index (impl.f_repr ${lhs}) i) - v (Seq.index (impl.f_repr ${rhs}) i))"#))]
+         v (Seq.index (impl.f_repr ${lhs}) i) - v (Seq.index (impl.f_repr ${rhs}) i))"#)))]
     #[inline(always)]
     fn sub(lhs: Self, rhs: &Self) -> Self {
         Self {
@@ -338,11 +339,11 @@ impl Operations for SIMD256Vector {
         }
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${vec}) i) * v c)"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (impl.f_repr ${vec}) i) * v c)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (impl.f_repr ${result}) i) == 
-         v (Seq.index (impl.f_repr ${vec}) i) * v c)"#))]
+         v (Seq.index (impl.f_repr ${vec}) i) * v c)"#)))]
     #[inline(always)]
     fn multiply_by_constant(vec: Self, c: i16) -> Self {
         Self {
@@ -350,17 +351,17 @@ impl Operations for SIMD256Vector {
         }
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $vector)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $vector)"#)))]
     #[inline(always)]
     fn cond_subtract_3329(vector: Self) -> Self {
         cond_subtract_3329(vector)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${vector})"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
                 (forall i. (v (Seq.index (impl.f_repr ${result}) i) % 3329) == 
-                           (v (Seq.index (impl.f_repr ${vector})i) % 3329))"#))]
+                           (v (Seq.index (impl.f_repr ${vector})i) % 3329))"#)))]
     #[inline(always)]
     fn barrett_reduce(vector: Self) -> Self {
         Self {
@@ -369,66 +370,66 @@ impl Operations for SIMD256Vector {
     }
 
     #[inline(always)]
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 $constant"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $constant"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
                 (forall i. i < 16 ==> ((v (Seq.index (impl.f_repr ${result}) i) % 3329)==
-                                       (v (Seq.index (impl.f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#))]
+                                       (v (Seq.index (impl.f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#)))]
     fn montgomery_multiply_by_constant(vector: Self, constant: i16) -> Self {
         Self {
             elements: arithmetic::montgomery_multiply_by_constant(vector.elements, constant),
         }
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
                                 (let x = Seq.index (impl.f_repr ${a}) i in
                                  let y = Seq.index (impl.f_repr ${result}) i in
-                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
+                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#)))]
     fn to_unsigned_representative(a: Self) -> Self {
         Self {
             elements: arithmetic::to_unsigned_representative(a.elements),
         }
     }
 
-    #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $vector) i) >= 0 /\
-        v (Seq.index (impl.f_repr $vector) i) < 3329"#))]
-    #[ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $vector) i) >= 0 /\
+        v (Seq.index (impl.f_repr $vector) i) < 3329"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#)))]
     #[inline(always)]
     fn compress_1(vector: Self) -> Self {
         compress_1(vector)
     }
 
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) /\
         (forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $vector) i) >= 0 /\
-            v (Seq.index (impl.f_repr $vector) i) < 3329)"#))]
-    #[ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+            v (Seq.index (impl.f_repr $vector) i) < 3329)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) ==>
-                (forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) (v $COEFFICIENT_BITS))"#))]
+                (forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) (v $COEFFICIENT_BITS))"#)))]
     #[inline(always)]
     fn compress<const COEFFICIENT_BITS: i32>(vector: Self) -> Self {
         compress::<COEFFICIENT_BITS>(vector)
     }
 
-    #[requires(fstar!(r#"forall (i:nat). i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> 
                                     (let x = Seq.index (impl.f_repr $a) i in 
-                                     (x == mk_i16 0 \/ x == mk_i16 1))"#))]
+                                     (x == mk_i16 0 \/ x == mk_i16 1))"#)))]
     fn decompress_1(a: Self) -> Self {
         Self {
             elements: compress::decompress_1(a.elements),
         }
     }
 
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $vector) i) >= 0 /\
-        v (Seq.index (impl.f_repr $vector) i) < pow2 (v $COEFFICIENT_BITS))"#))]
+        v (Seq.index (impl.f_repr $vector) i) < pow2 (v $COEFFICIENT_BITS))"#)))]
     #[inline(always)]
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(vector: Self) -> Self {
         Self {
@@ -438,61 +439,61 @@ impl Operations for SIMD256Vector {
         }
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn ntt_layer_1_step(vector: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         ntt_layer_1_step(vector, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn ntt_layer_2_step(vector: Self, zeta0: i16, zeta1: i16) -> Self {
         ntt_layer_2_step(vector, zeta0, zeta1)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                       Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                       Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn ntt_layer_3_step(vector: Self, zeta: i16) -> Self {
         ntt_layer_3_step(vector, zeta)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3  /\
-                       Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn inv_ntt_layer_1_step(vector: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         inv_ntt_layer_1_step(vector, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn inv_ntt_layer_2_step(vector: Self, zeta0: i16, zeta1: i16) -> Self {
         inv_ntt_layer_2_step(vector, zeta0, zeta1)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${vector})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn inv_ntt_layer_3_step(vector: Self, zeta: i16) -> Self {
         inv_ntt_layer_3_step(vector, zeta)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${lhs}) /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn ntt_multiply(
         lhs: &Self,
@@ -505,29 +506,29 @@ impl Operations for SIMD256Vector {
         ntt_multiply(lhs, rhs, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $vector) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $vector) $out"#)))]
     #[inline(always)]
     fn serialize_1(vector: Self) -> [u8; 2] {
         serialize_1(vector)
     }
 
-    #[requires(bytes.len() == 2)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $bytes (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 2))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $bytes (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn deserialize_1(bytes: &[u8]) -> Self {
         deserialize_1(bytes)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $vector) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $vector) $out"#)))]
     #[inline(always)]
     fn serialize_4(vector: Self) -> [u8; 8] {
         serialize_4(vector)
     }
 
-    #[requires(bytes.len() == 8)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $bytes (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 8))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $bytes (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn deserialize_4(bytes: &[u8]) -> Self {
         deserialize_4(bytes)
@@ -538,24 +539,25 @@ impl Operations for SIMD256Vector {
         serialize::serialize_5(vector.elements)
     }
 
-    #[requires(bytes.len() == 10)]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 10))]
     #[inline(always)]
     fn deserialize_5(bytes: &[u8]) -> Self {
+        #[cfg(hax)]
         hax_lib::fstar!(r#"assert (v (Core_models.Slice.impl__len $bytes) == Seq.length $bytes)"#);
         Self {
             elements: serialize::deserialize_5(bytes),
         }
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $vector) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $vector) $out"#)))]
     #[inline(always)]
     fn serialize_10(vector: Self) -> [u8; 20] {
         serialize_10(vector)
     }
 
-    #[requires(bytes.len() == 20)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $bytes (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 20))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $bytes (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn deserialize_10(bytes: &[u8]) -> Self {
         deserialize_10(bytes)
@@ -566,7 +568,7 @@ impl Operations for SIMD256Vector {
         serialize::serialize_11(vector.elements)
     }
 
-    #[requires(bytes.len() == 22)]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 22))]
     #[inline(always)]
     fn deserialize_11(bytes: &[u8]) -> Self {
         Self {
@@ -574,24 +576,24 @@ impl Operations for SIMD256Vector {
         }
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $vector)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $vector) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $vector) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $vector) $out"#)))]
     #[inline(always)]
     fn serialize_12(vector: Self) -> [u8; 24] {
         serialize_12(vector)
     }
 
-    #[requires(bytes.len() == 24)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $bytes (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() == 24))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $bytes) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $bytes (impl.f_repr $out)"#)))]
     #[inline(always)]
     fn deserialize_12(bytes: &[u8]) -> Self {
         deserialize_12(bytes)
     }
 
-    #[requires(input.len() == 24 && output.len() == 16)]
-    #[ensures(|result|
+    #[cfg_attr(hax, hax_lib::requires(input.len() == 24 && output.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"Seq.length $output_future == Seq.length $output /\ v $result <= 16"#)
-    )]
+    ))]
     #[inline(always)]
     fn rej_sample(input: &[u8], output: &mut [i16]) -> usize {
         sampling::rejection_sample(input, output)

--- a/libcrux-ml-kem/src/vector/avx2/arithmetic.rs
+++ b/libcrux-ml-kem/src/vector/avx2/arithmetic.rs
@@ -1,24 +1,30 @@
+use super::*;
 use crate::vector::{traits::INVERSE_OF_MODULUS_MOD_MONTGOMERY_R, FIELD_MODULUS};
 
-use super::*;
-
 #[inline(always)]
-#[hax_lib::fstar::before(interface, "open Libcrux_intrinsics.Avx2_extract")]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(interface, "open Libcrux_intrinsics.Avx2_extract")
+)]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let lemma_add_i (lhs rhs: t_Vec256) (i:nat): Lemma 
   (requires (i < 16 /\ Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane lhs i) + v (get_lane rhs i))))
   (ensures (v (add_mod (get_lane lhs i) (get_lane rhs i)) ==
             (v (get_lane lhs i) + v (get_lane rhs i))))
   [SMTPat (v (add_mod (get_lane lhs i) (get_lane rhs i)))] = ()"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $lhs i) + v (get_lane $rhs i))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
-    v (get_lane $result i) == (v (get_lane $lhs i) + v (get_lane $rhs i))"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $lhs i) + v (get_lane $rhs i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    v (get_lane $result i) == (v (get_lane $lhs i) + v (get_lane $rhs i))"#)))]
 pub(crate) fn add(lhs: Vec256, rhs: Vec256) -> Vec256 {
     let result = mm256_add_epi16(lhs, rhs);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane result i == get_lane lhs i +. get_lane rhs i);
                      assert (forall i. v (get_lane result i) == v (get_lane lhs i) + v (get_lane rhs i))"#
@@ -28,21 +34,25 @@ pub(crate) fn add(lhs: Vec256, rhs: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let lemma_sub_i (lhs rhs: t_Vec256) (i:nat):  Lemma 
   (requires (i < 16 /\ Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane lhs i) - v (get_lane rhs i))))
   (ensures (v (sub_mod (get_lane lhs i) (get_lane rhs i)) ==
             (v (get_lane lhs i) - v (get_lane rhs i))))
   [SMTPat (v (sub_mod (get_lane lhs i) (get_lane rhs i)))] = ()"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $lhs i) - v (get_lane $rhs i))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
-    v (get_lane $result i) == (v (get_lane $lhs i) - v (get_lane $rhs i))"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $lhs i) - v (get_lane $rhs i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    v (get_lane $result i) == (v (get_lane $lhs i) - v (get_lane $rhs i))"#)))]
 pub(crate) fn sub(lhs: Vec256, rhs: Vec256) -> Vec256 {
     let result = mm256_sub_epi16(lhs, rhs);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane result i == get_lane lhs i -. get_lane rhs i);
                      assert (forall i. v (get_lane result i) == v (get_lane lhs i) - v (get_lane rhs i))"#
@@ -52,27 +62,32 @@ pub(crate) fn sub(lhs: Vec256, rhs: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before(
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        r#"
 let lemma_mul_i (lhs: t_Vec256) (i:nat) (c:i16):  Lemma 
   (requires (i < 16 /\ Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane lhs i) * v c)))
   (ensures (v (mul_mod (get_lane lhs i) c) ==
             (v (get_lane lhs i) * v c)))
   [SMTPat (v (mul_mod (get_lane lhs i) c))] = ()"#
+    )
 )]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $vector i) * v constant)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
-    v (get_lane $result i) == (v (get_lane $vector i) * v constant)"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (get_lane $vector i) * v constant)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    v (get_lane $result i) == (v (get_lane $vector i) * v constant)"#)))]
 pub(crate) fn multiply_by_constant(vector: Vec256, constant: i16) -> Vec256 {
     let cv = mm256_set1_epi16(constant);
     let result = mm256_mullo_epi16(vector, cv);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro (vec256_as_i16x16 ${result})
                         (Spec.Utils.map_array (fun x -> x *. $constant) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector))"#
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane result i == get_lane vector i *. constant);
                      assert (forall i. v (get_lane vector i *. constant) == v (get_lane vector i) * v constant);
@@ -83,12 +98,13 @@ pub(crate) fn multiply_by_constant(vector: Vec256, constant: i16) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $result == 
-                           Spec.Utils.map_array (fun x -> x &. $constant) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $result == 
+                           Spec.Utils.map_array (fun x -> x &. $constant) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#)))]
 pub(crate) fn bitwise_and_with_constant(vector: Vec256, constant: i16) -> Vec256 {
     let cv = mm256_set1_epi16(constant);
     let result = mm256_and_si256(vector, cv);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${result})
                         (Spec.Utils.map_array (fun x -> x &. $constant) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector))"#
@@ -98,13 +114,14 @@ pub(crate) fn bitwise_and_with_constant(vector: Vec256, constant: i16) -> Vec256
 }
 
 #[inline(always)]
-#[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
+#[cfg_attr(hax, hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
                             Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $result == 
-                            Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#))]
+                            Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#)))]
 pub(crate) fn shift_right<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
     let result = mm256_srai_epi16::<{ SHIFT_BY }>(vector);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "Seq.lemma_eq_intro (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${result})
                         (Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) 
@@ -116,25 +133,28 @@ pub(crate) fn shift_right<const SHIFT_BY: i32>(vector: Vec256) -> Vec256 {
 
 #[inline(always)]
 #[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vector)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
                 get_lane $result i == 
-                (if (get_lane $vector i) >=. (mk_i16 3329) then get_lane $vector i -! (mk_i16 3329) else get_lane $vector i)"#))]
+                (if (get_lane $vector i) >=. (mk_i16 3329) then get_lane $vector i -! (mk_i16 3329) else get_lane $vector i)"#)))]
 pub(crate) fn cond_subtract_3329(vector: Vec256) -> Vec256 {
     let field_modulus = mm256_set1_epi16(FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $field_modulus i == (mk_i16 3329))"#);
 
     // Compute v_i - Q and crate a mask from the sign bit of each of these
     // quantities.
     let v_minus_field_modulus = mm256_sub_epi16(vector, field_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane $v_minus_field_modulus i == get_lane $vector i -. (mk_i16 3329))"
     );
 
     let sign_mask = mm256_srai_epi16::<15>(v_minus_field_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane $sign_mask i == (get_lane $v_minus_field_modulus i >>! (mk_i32 15)))"
     );
@@ -142,12 +162,14 @@ pub(crate) fn cond_subtract_3329(vector: Vec256) -> Vec256 {
     // If v_i - Q < 0 then add back Q to (v_i - Q).
     let conditional_add_field_modulus = mm256_and_si256(sign_mask, field_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $conditional_add_field_modulus i == (get_lane $sign_mask i &. (mk_i16 3329)))"#
     );
 
     let result = mm256_add_epi16(v_minus_field_modulus, conditional_add_field_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $result i == (get_lane $v_minus_field_modulus i +. get_lane $conditional_add_field_modulus i));
                      assert (forall i. get_lane $result i == Spec.Utils.cond_sub (get_lane $vector i));
@@ -170,32 +192,38 @@ const BARRETT_MULTIPLIER: i16 = 20159;
 pub(crate) fn barrett_reduce(vector: Vec256) -> Vec256 {
     let t0 = mm256_mulhi_epi16(vector, mm256_set1_epi16(BARRETT_MULTIPLIER));
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $t0 i == (cast (((cast (get_lane $vector i) <: i32) *. (cast v_BARRETT_MULTIPLIER <: i32)) >>! (mk_i32 16)) <: i16))"#
     );
 
     let t512 = mm256_set1_epi16(512);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $t512 i == (mk_i16 512))"#);
 
     let t1 = mm256_add_epi16(t0, t512);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $t1 i == get_lane $t0 i +. (mk_i16 512))"#);
 
     let quotient = mm256_srai_epi16::<10>(t1);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane $quotient i == (((get_lane $t1 i) <: i16) >>! ((mk_i32 10) <: i32)))"
     );
 
     let quotient_times_field_modulus = mm256_mullo_epi16(quotient, mm256_set1_epi16(FIELD_MODULUS));
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane $quotient_times_field_modulus i ==
                      get_lane $quotient i *. Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS)"
     );
     let result = mm256_sub_epi16(vector, quotient_times_field_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $result i ==
                                        get_lane $vector i -.  get_lane $quotient_times_field_modulus i);
@@ -218,9 +246,11 @@ pub(crate) fn barrett_reduce(vector: Vec256) -> Vec256 {
 pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> Vec256 {
     let vec_constant = mm256_set1_epi16(constant);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $vec_constant i == $constant)"#);
     let value_low = mm256_mullo_epi16(vector, vec_constant);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $value_low i == get_lane $vector i *. $constant)"#
     );
@@ -229,16 +259,19 @@ pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> 
         mm256_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg (mk_i16 3327)))"#
     );
 
     let modulus = mm256_set1_epi16(FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == (mk_i16 3329))"#);
 
     let k_times_modulus = mm256_mulhi_epi16(k, modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k_times_modulus == 
                         Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
@@ -250,6 +283,7 @@ pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> 
 
     let value_high = mm256_mulhi_epi16(vector, vec_constant);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $value_high i == 
         (cast (((cast (get_lane $vector i) <: i32) *. (cast (get_lane $vec_constant i) <: i32)) >>! (mk_i32 16)) <: i16))"#
@@ -257,6 +291,7 @@ pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> 
 
     let result = mm256_sub_epi16(value_high, k_times_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
                     assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
@@ -281,6 +316,7 @@ pub(crate) fn montgomery_multiply_by_constant(vector: Vec256, constant: i16) -> 
 pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -> Vec256 {
     let value_low = mm256_mullo_epi16(vec, constants);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane $value_low i == get_lane $vec i *. get_lane $constants i)"
     );
@@ -290,15 +326,18 @@ pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -
         mm256_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $k i == get_lane $value_low i *. (neg (mk_i16 3327)))"#
     );
 
     let modulus = mm256_set1_epi16(FIELD_MODULUS);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane $modulus i == (mk_i16 3329))"#);
 
     let k_times_modulus = mm256_mulhi_epi16(k, modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $k_times_modulus == 
                         Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
@@ -309,6 +348,7 @@ pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -
     );
 
     let value_high = mm256_mulhi_epi16(vec, constants);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane $value_high i == 
             (cast (((cast (get_lane $vec i) <: i32) *. (cast (get_lane $constants i) <: i32)) >>! (mk_i32 16)) <: i16))"#
@@ -316,6 +356,7 @@ pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -
 
     let result = mm256_sub_epi16(value_high, k_times_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
                     assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
@@ -333,7 +374,7 @@ pub(crate) fn montgomery_multiply_by_constants(vec: Vec256, constants: Vec256) -
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(panic_free))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (3328 * pow2 16) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vec))"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (3328 + 1665) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${result}) /\
                 (Spec.Utils.is_i16b_array (3328 * pow2 15) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $vec) ==>
@@ -365,6 +406,7 @@ pub(crate) fn montgomery_reduce_i32s(vec: Vec256) -> Vec256 {
 pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec128) -> Vec128 {
     let value_low = mm_mullo_epi16(vec, constants);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane128 $value_low i == get_lane128 $vec i *. get_lane128 $constants i)"#
     );
@@ -374,16 +416,19 @@ pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec
         mm_set1_epi16(INVERSE_OF_MODULUS_MOD_MONTGOMERY_R as i16),
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. get_lane128 $k i == get_lane128 $value_low i *. (neg (mk_i16 3327)))"
     );
 
     let modulus = mm_set1_epi16(FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (forall i. get_lane128 $modulus i == (mk_i16 3329))"#);
 
     let k_times_modulus = mm_mulhi_epi16(k, modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Libcrux_intrinsics.Avx2_extract.vec128_as_i16x8 $k_times_modulus == 
                         Spec.Utils.map2 (fun x y -> cast (((cast x <: i32) *. (cast y <: i32)) >>! (mk_i32 16)) <: i16)
@@ -395,6 +440,7 @@ pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec
 
     let value_high = mm_mulhi_epi16(vec, constants);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. get_lane128 $value_high i == 
                         (cast (((cast (get_lane128 $vec i) <: i32) *. (cast (get_lane128 $constants i) <: i32)) >>! (mk_i32 16)) <: i16))"#
@@ -402,6 +448,7 @@ pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec
 
     let result = mm_sub_epi16(value_high, k_times_modulus);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Spec.Utils.lemma_range_at_percent 3329 (pow2 32);
                     assert (v (cast (mk_i16 3329) <: i32) == (3329 @% pow2 32));
@@ -418,16 +465,17 @@ pub(crate) fn montgomery_multiply_m128i_by_constants(vec: Vec128, constants: Vec
     result
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $a)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i.
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $a)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i.
                                        (let x = Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $a) i in
                                         let y = Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $result) i in
-                                        (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
+                                        (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#)))]
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn to_unsigned_representative(a: Vec256) -> Vec256 {
     let t = shift_right::<15>(a);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
   assert (forall i. Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $t) i == 
@@ -439,6 +487,7 @@ pub(crate) fn to_unsigned_representative(a: Vec256) -> Vec256 {
 
     let fm = bitwise_and_with_constant(t, FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
   assert (forall i. Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${fm}) i == (Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $t) i &. Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS));

--- a/libcrux-ml-kem/src/vector/avx2/compress.rs
+++ b/libcrux-ml-kem/src/vector/avx2/compress.rs
@@ -1,6 +1,5 @@
-use crate::vector::FIELD_MODULUS;
-
 use super::*;
+use crate::vector::FIELD_MODULUS;
 
 // Multiply the 32-bit numbers contained in |lhs| and |rhs|, and store only
 // the upper 32 bits of the resulting product.
@@ -38,8 +37,8 @@ pub(crate) fn compress_message_coefficient(vector: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"v $COEFFICIENT_BITS >= 0 /\ v $COEFFICIENT_BITS < bits i32_inttype /\
-    range (v ((mk_i32 1) <<! $COEFFICIENT_BITS) - 1) i32_inttype"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $COEFFICIENT_BITS >= 0 /\ v $COEFFICIENT_BITS < bits i32_inttype /\
+    range (v ((mk_i32 1) <<! $COEFFICIENT_BITS) - 1) i32_inttype"#)))]
 pub(crate) fn compress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
     vector: Vec256,
 ) -> Vec256 {
@@ -105,11 +104,12 @@ pub(crate) fn compress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"forall i. let x = Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $a) i in 
-                                      (x == mk_i16 0 \/ x == mk_i16 1)"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. let x = Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $a) i in 
+                                      (x == mk_i16 0 \/ x == mk_i16 1)"#)))]
 pub fn decompress_1(a: Vec256) -> Vec256 {
     let z = mm256_setzero_si256();
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
         assert(Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $z == Seq.create 16 (mk_i16 0));
@@ -124,6 +124,7 @@ pub fn decompress_1(a: Vec256) -> Vec256 {
 
     let s = arithmetic::sub(z, a);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall i. Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $s) i == mk_i16 0 \/ 
                             Seq.index (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 $s) i == mk_i16 (-1))"#
@@ -133,7 +134,7 @@ pub fn decompress_1(a: Vec256) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"v $COEFFICIENT_BITS >= 0 /\ v $COEFFICIENT_BITS < bits i32_inttype"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v $COEFFICIENT_BITS >= 0 /\ v $COEFFICIENT_BITS < bits i32_inttype"#)))]
 pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
     vector: Vec256,
 ) -> Vec256 {

--- a/libcrux-ml-kem/src/vector/avx2/ntt.rs
+++ b/libcrux-ml-kem/src/vector/avx2/ntt.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3"#)))]
 pub(crate) fn ntt_layer_1_step(
     vector: Vec256,
     zeta0: i16,
@@ -23,7 +23,7 @@ pub(crate) fn ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1"#)))]
 pub(crate) fn ntt_layer_2_step(vector: Vec256, zeta0: i16, zeta1: i16) -> Vec256 {
     let zetas = mm256_set_epi16(
         -zeta1, -zeta1, -zeta1, -zeta1, zeta1, zeta1, zeta1, zeta1, -zeta0, -zeta0, -zeta0, -zeta0,
@@ -39,7 +39,7 @@ pub(crate) fn ntt_layer_2_step(vector: Vec256, zeta0: i16, zeta1: i16) -> Vec256
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta"#)))]
 pub(crate) fn ntt_layer_3_step(vector: Vec256, zeta: i16) -> Vec256 {
     let rhs = mm256_extracti128_si256::<1>(vector);
     let rhs = arithmetic::montgomery_multiply_m128i_by_constants(rhs, mm_set1_epi16(zeta));
@@ -56,10 +56,10 @@ pub(crate) fn ntt_layer_3_step(vector: Vec256, zeta: i16) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                             Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                            Spec.Utils.is_i16b_array (4*3328) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${vector})"#))]
+                            Spec.Utils.is_i16b_array (4*3328) (Libcrux_intrinsics.Avx2_extract.vec256_as_i16x16 ${vector})"#)))]
 pub(crate) fn inv_ntt_layer_1_step(
     vector: Vec256,
     zeta0: i16,
@@ -89,7 +89,7 @@ pub(crate) fn inv_ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1"#)))]
 pub(crate) fn inv_ntt_layer_2_step(vector: Vec256, zeta0: i16, zeta1: i16) -> Vec256 {
     let lhs = mm256_permute4x64_epi64::<0b11_11_01_01>(vector);
 
@@ -111,7 +111,7 @@ pub(crate) fn inv_ntt_layer_2_step(vector: Vec256, zeta0: i16, zeta1: i16) -> Ve
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta"#)))]
 pub(crate) fn inv_ntt_layer_3_step(vector: Vec256, zeta: i16) -> Vec256 {
     let lhs = mm256_extracti128_si256::<1>(vector);
     let rhs = mm256_castsi256_si128(vector);
@@ -129,8 +129,8 @@ pub(crate) fn inv_ntt_layer_3_step(vector: Vec256, zeta: i16) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3"#)))]
 pub(crate) fn ntt_multiply(
     lhs: Vec256,
     rhs: Vec256,

--- a/libcrux-ml-kem/src/vector/avx2/sampling.rs
+++ b/libcrux-ml-kem/src/vector/avx2/sampling.rs
@@ -5,10 +5,10 @@ use super::{
 };
 
 #[inline(always)]
-#[hax_lib::requires(input.len() == 24 && output.len() == 16)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::requires(input.len() == 24 && output.len() == 16))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
         fstar!(r#"Seq.length $output_future == Seq.length $output /\ v $res <= 16"#)
-    )]
+))]
 pub(crate) fn rejection_sample(input: &[u8], output: &mut [i16]) -> usize {
     let field_modulus = mm256_set1_epi16(FIELD_MODULUS);
 
@@ -30,6 +30,7 @@ pub(crate) fn rejection_sample(input: &[u8], output: &mut [i16]) -> usize {
     // each lane in the register to tell us what coefficients to keep and what
     // to throw-away. Combine all the bits (there are 16) into two bytes.
     let good = serialize_1(compare_with_field_modulus);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v (cast (${good}.[ sz 0 ] <: u8) <: usize) < 256);
         assert (v (cast (${good}.[ sz 1 ] <: u8) <: usize) < 256);

--- a/libcrux-ml-kem/src/vector/avx2/sampling.rs
+++ b/libcrux-ml-kem/src/vector/avx2/sampling.rs
@@ -39,7 +39,7 @@ pub(crate) fn rejection_sample(input: &[u8], output: &mut [i16]) -> usize {
         assume (v (cast (${u8::count_ones} ${good}.[ sz 1 ]) <: usize) <= 8);
         assume (Core_models.Ops.Index.f_index_pre output ({
                     Core_models.Ops.Range.f_start = cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize;
-                    Core_models.Ops.Range.f_end = (cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize) +! sz 8 }))"#
+                    Core_models.Ops.Range.f_end = (cast (${u8::count_ones} ${good}.[ sz 0 ]) <: usize) +! sz 8 } <: Core_models.Ops.Range.t_Range usize))"#
     );
 
     // Each bit (and its corresponding position) represents an element we

--- a/libcrux-ml-kem/src/vector/avx2/serialize.rs
+++ b/libcrux-ml-kem/src/vector/avx2/serialize.rs
@@ -2,10 +2,13 @@ use super::*;
 use crate::vector::portable::PortableVector;
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
-#[hax_lib::fstar::options("--ext context_pruning --compat_pre_core 0")]
-#[hax_lib::requires(fstar!(r#"forall i. i % 16 >= 1 ==> vector i == 0"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. bit_vec_of_int_t_array $result 8 i == $vector (i * 16)"#))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --compat_pre_core 0")
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i % 16 >= 1 ==> vector i == 0"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. bit_vec_of_int_t_array $result 8 i == $vector (i * 16)"#)))]
 pub(crate) fn serialize_1(vector: Vec256) -> [u8; 2] {
     // Suppose |vector| is laid out as follows (superscript number indicates the
     // corresponding bit is duplicated that many times):
@@ -47,6 +50,7 @@ pub(crate) fn serialize_1(vector: Vec256) -> [u8; 2] {
     // 0xFF 0x00 0x00 0x00 | 0xFF 0x00 0x00 0x00 | 0x00 0x00 0x00 0x00 | 0x00 0x00 0x00 0xFF
     let msbs = mm_packs_epi16(low_msbs, high_msbs);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
 let bits_packed' = BitVec.Intrinsics.mm_movemask_epi8_bv msbs in
@@ -66,6 +70,7 @@ let bits_packed' = BitVec.Intrinsics.mm_movemask_epi8_bv msbs in
 
     let result = [bits_packed as u8, (bits_packed >> 8) as u8];
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
 assert (forall (i: nat {i < 8}). get_bit ($bits_packed >>! (mk_i32 8) <: i32) (sz i) == get_bit $bits_packed (sz (i + 8)))
@@ -76,42 +81,42 @@ assert (forall (i: nat {i < 8}). get_bit ($bits_packed >>! (mk_i32 8) <: i32) (s
 }
 
 #[inline(always)]
-#[hax_lib::requires(bytes.len() == 2)]
-#[hax_lib::ensures(|coefficients| fstar!(
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 2))]
+#[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(
         r#"forall (i:nat{i < 256}).
       $coefficients i
     = ( if i % 16 >= 1 then 0
         else let j = (i / 16) * 1 + i % 16 in
              bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 2)) 8 j))
 "#
-))]
-#[hax_lib::fstar::before("#restart-solver")]
+)))]
+#[cfg_attr(hax, hax_lib::fstar::before("#restart-solver"))]
 pub(crate) fn deserialize_1(bytes: &[u8]) -> Vec256 {
-    #[hax_lib::ensures(|coefficients| fstar!(
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(
         r#"forall (i:nat{i < 256}).
       $coefficients i
     = ( if i % 16 >= 1 then 0
         else let j = (i / 16) * 1 + i % 16 in
              if i < 128 then get_bit $a (sz j) else get_bit $b (sz (j - 8)))
 "#
-    ))]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+    )))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     #[inline(always)]
     pub(crate) fn deserialize_1_u8s(a: u8, b: u8) -> Vec256 {
         deserialize_1_i16s(a as i16, b as i16)
     }
 
-    #[hax_lib::ensures(|coefficients| fstar!(
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(
         r#"forall (i:nat{i < 256}).
       $coefficients i
     = ( if i % 16 >= 1 then 0
         else let j = (i / 16) * 1 + i % 16 in
              if i < 128 then get_bit $a (sz j) else get_bit $b (sz (j - 8)))
 "#
-    ))]
+    )))]
     #[inline(always)]
-    #[hax_lib::fstar::options("--ext context_pruning")]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+    #[cfg_attr(hax, hax_lib::fstar::options("--ext context_pruning"))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     pub(crate) fn deserialize_1_i16s(a: i16, b: i16) -> Vec256 {
         // We need to take each bit from the 2 bytes of input and put them
         // into their own 16-bit lane. Ideally, we'd load the two bytes into the vector,
@@ -164,7 +169,10 @@ pub(crate) fn deserialize_1(bytes: &[u8]) -> Vec256 {
 /// of the shape `0b0…0b₁…bₙa₁…aₙ`, if `x` is a sequence of pairs of
 /// 16 bits, of the shape `(0b0…0a₁…aₙ, 0b0…0b₁…bₙ)` (where the last
 /// `n` bits are non-zero).
-#[hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_concat_pairs_n}")]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(interface, "include BitVec.Intrinsics {mm256_concat_pairs_n}")
+)]
 #[inline(always)]
 fn mm256_concat_pairs_n(n: u8, x: Vec256) -> Vec256 {
     let n = 1 << n;
@@ -174,13 +182,16 @@ fn mm256_concat_pairs_n(n: u8, x: Vec256) -> Vec256 {
     )
 }
 
-#[hax_lib::fstar::options("--ext context_pruning --split_queries always")]
-#[hax_lib::requires(
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --split_queries always")
+)]
+#[cfg_attr(hax, hax_lib::requires(
     fstar!(
         r#"forall (i: nat{i < 256}). i % 16 < 4 || $vector i = 0"#
     )
-)]
-#[hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 64}). bit_vec_of_int_t_array $r 8 i == $vector ((i/4) * 16 + i%4)"#))]
+))]
+#[cfg_attr(hax, hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 64}). bit_vec_of_int_t_array $r 8 i == $vector ((i/4) * 16 + i%4)"#)))]
 #[inline(always)]
 pub(crate) fn serialize_4(vector: Vec256) -> [u8; 8] {
     let mut serialized = [0u8; 16];
@@ -221,6 +232,7 @@ pub(crate) fn serialize_4(vector: Vec256) -> [u8; 8] {
     // ... so that we can read them out in one go.
     mm_storeu_bytes_si128(&mut serialized, combined);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
 assert (forall (i: nat{i < 64}). $combined i == bit_vec_of_int_t_array serialized 8 i);
@@ -234,14 +246,14 @@ assert (forall (i: nat{i < 64}). $combined i == bit_vec_of_int_t_array serialize
 }
 
 #[inline(always)]
-#[hax_lib::requires(bytes.len() == 8)]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
+#[cfg_attr(hax, hax_lib::requires(bytes.len() == 8))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
   $result i = (if i % 16 >= 4 then 0
                else let j = (i / 16) * 4 + i % 16 in
-                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 8)) 8 j)"#))]
-#[hax_lib::fstar::before("#restart-solver")]
+                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 8)) 8 j)"#)))]
+#[cfg_attr(hax, hax_lib::fstar::before("#restart-solver"))]
 pub(crate) fn deserialize_4(bytes: &[u8]) -> Vec256 {
-    #[hax_lib::ensures(|coefficients| fstar!(
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(
         r#"forall (i:nat{i < 256}).
       $coefficients i
     = ( if i % 16 < 4
@@ -257,16 +269,16 @@ pub(crate) fn deserialize_4(bytes: &[u8]) -> Vec256 {
              | 7 -> get_bit $b7 (sz (j - 56)))
         else 0)
 "#
-    ))]
+    )))]
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     fn deserialize_4_u8s(b0: u8, b1: u8, b2: u8, b3: u8, b4: u8, b5: u8, b6: u8, b7: u8) -> Vec256 {
         deserialize_4_i16s(
             b0 as i16, b1 as i16, b2 as i16, b3 as i16, b4 as i16, b5 as i16, b6 as i16, b7 as i16,
         )
     }
 
-    #[hax_lib::ensures(|coefficients| fstar!(
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(
         r#"forall (i:nat{i < 256}).
       $coefficients i
     = ( if i % 16 < 4
@@ -282,9 +294,9 @@ pub(crate) fn deserialize_4(bytes: &[u8]) -> Vec256 {
              | 7 -> get_bit $b7 (sz (j - 56)))
         else 0)
 "#
-    ))]
+    )))]
     #[inline(always)]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     fn deserialize_4_i16s(
         b0: i16,
         b1: i16,
@@ -453,16 +465,19 @@ pub(crate) fn serialize_5(vector: Vec256) -> [u8; 10] {
 /// `mm256_inserti128_si256`: this composition sets the upper bits,
 /// making the whole computation pure again.
 #[inline(always)]
-#[hax_lib::fstar::replace(
-    interface,
-    "include BitVec.Intrinsics {mm256_si256_from_two_si128 as ${mm256_si256_from_two_si128}}"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::replace(
+        interface,
+        "include BitVec.Intrinsics {mm256_si256_from_two_si128 as ${mm256_si256_from_two_si128}}"
+    )
 )]
 fn mm256_si256_from_two_si128(lower: Vec128, upper: Vec128) -> Vec256 {
     mm256_inserti128_si256::<1>(mm256_castsi128_si256(lower), upper)
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length bytes == 10"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length bytes == 10"#)))]
 pub(crate) fn deserialize_5(bytes: &[u8]) -> Vec256 {
     let coefficients = mm_set_epi8(
         bytes[9] as i8,
@@ -518,19 +533,25 @@ pub(crate) fn deserialize_5(bytes: &[u8]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--ext context_pruning --split_queries always")]
-#[hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 10 || vector i = 0"#))]
-#[hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 160}). bit_vec_of_int_t_array r 8 i == vector ((i/10) * 16 + i%10)"#))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --split_queries always")
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 10 || vector i = 0"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 160}). bit_vec_of_int_t_array r 8 i == vector ((i/10) * 16 + i%10)"#)))]
 pub(crate) fn serialize_10(vector: Vec256) -> [u8; 20] {
-    #[hax_lib::fstar::options("--ext context_pruning --split_queries always")]
-    #[hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 10 || vector i = 0"#))]
-    #[hax_lib::ensures(|(lower_8, upper_8)| fstar!(
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::options("--ext context_pruning --split_queries always")
+    )]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 10 || vector i = 0"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|(lower_8, upper_8)| fstar!(
         r#"
          forall (i: nat{i < 160}).
            vector ((i/10) * 16 + i%10) == (if i < 80 then $lower_8 i else $upper_8 (i - 80))
       )
     "#
-    ))]
+    )))]
     fn serialize_10_vec(vector: Vec256) -> (Vec128, Vec128) {
         // If |vector| is laid out as follows (superscript number indicates the
         // corresponding bit is duplicated that many times):
@@ -589,6 +610,7 @@ pub(crate) fn serialize_10(vector: Vec256) -> [u8; 20] {
         let lower_8 = mm256_castsi256_si128(adjacent_8_combined);
         // and 64 bits starting at position 0 in the upper 128-bit lane.
         let upper_8 = mm256_extracti128_si256::<1>(adjacent_8_combined);
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
     introduce forall (i:nat{i < 80}). lower_8_ i = vector ((i / 10) * 16 + i % 10)
@@ -610,21 +632,21 @@ pub(crate) fn serialize_10(vector: Vec256) -> [u8; 20] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length bytes == 20"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length bytes == 20"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
   $result i = (if i % 16 >= 10 then 0
                else let j = (i / 16) * 10 + i % 16 in
-                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 20)) 8 j)"#))]
+                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 20)) 8 j)"#)))]
 pub(crate) fn deserialize_10(bytes: &[u8]) -> Vec256 {
     #[inline(always)]
-    #[hax_lib::ensures(|coefficients| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(r#"
 forall (i: nat {i < 256}).
       $coefficients i
     = ( if i % 16 >= 10 then 0
         else let j = (i / 16) * 10 + i % 16 in
              if i < 128 then $lower_coefficients0 j else $upper_coefficients0 (j - 32)))
-"#))]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+"#)))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     fn deserialize_10_vec(lower_coefficients0: Vec128, upper_coefficients0: Vec128) -> Vec256 {
         let lower_coefficients = mm_shuffle_epi8(
             lower_coefficients0,
@@ -661,6 +683,7 @@ forall (i: nat {i < 256}).
         let coefficients = mm256_srli_epi16::<6>(coefficients);
         // Here I can prove this `and` is not useful
         let coefficients = mm256_and_si256(coefficients, mm256_set1_epi16((1 << 10) - 1));
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
 assert_norm(BitVec.Utils.forall256 (fun i -> 
@@ -683,7 +706,7 @@ assert_norm(BitVec.Utils.forall256 (fun i ->
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn serialize_11(vector: Vec256) -> [u8; 22] {
     let mut array = [0i16; 16];
     mm256_storeu_si256_i16(&mut array, vector);
@@ -692,7 +715,7 @@ pub(crate) fn serialize_11(vector: Vec256) -> [u8; 22] {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub(crate) fn deserialize_11(bytes: &[u8]) -> Vec256 {
     let output = PortableVector::deserialize_11(bytes);
     let array = PortableVector::to_i16_array(output);
@@ -700,20 +723,26 @@ pub(crate) fn deserialize_11(bytes: &[u8]) -> Vec256 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--ext context_pruning --split_queries always")]
-#[hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 12 || vector i = 0"#))]
-#[hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 192}). bit_vec_of_int_t_array r 8 i == vector ((i/12) * 16 + i%12)"#))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options("--ext context_pruning --split_queries always")
+)]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 12 || vector i = 0"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|r| fstar!(r#"forall (i: nat{i < 192}). bit_vec_of_int_t_array r 8 i == vector ((i/12) * 16 + i%12)"#)))]
 pub(crate) fn serialize_12(vector: Vec256) -> [u8; 24] {
     #[inline(always)]
-    #[hax_lib::fstar::options("--ext context_pruning --split_queries always")]
-    #[hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 12 || vector i = 0"#))]
-    #[hax_lib::ensures(|(lower_8, upper_8)| fstar!(
+    #[cfg_attr(
+        hax,
+        hax_lib::fstar::options("--ext context_pruning --split_queries always")
+    )]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i: nat{i < 256}). i % 16 < 12 || vector i = 0"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|(lower_8, upper_8)| fstar!(
         r#"
          forall (i: nat{i < 192}).
            vector ((i/12) * 16 + i%12) == (if i < 96 then $lower_8 i else $upper_8 (i - 96))
       )
     "#
-    ))]
+    )))]
     fn serialize_12_vec(vector: Vec256) -> (Vec128, Vec128) {
         let adjacent_2_combined = mm256_concat_pairs_n(12, vector);
         let adjacent_4_combined =
@@ -730,6 +759,7 @@ pub(crate) fn serialize_12(vector: Vec256) -> [u8; 24] {
 
         let lower_8 = mm256_castsi256_si128(adjacent_8_combined);
         let upper_8 = mm256_extracti128_si256::<1>(adjacent_8_combined);
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
     introduce forall (i:nat{i < 96}). lower_8_ i = vector ((i / 12) * 16 + i % 12)
@@ -750,21 +780,21 @@ pub(crate) fn serialize_12(vector: Vec256) -> [u8; 24] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"Seq.length bytes == 24"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Seq.length bytes == 24"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i: nat{i < 256}).
   $result i = (if i % 16 >= 12 then 0
                else let j = (i / 16) * 12 + i % 16 in
-                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 24)) 8 j)"#))]
+                     bit_vec_of_int_t_array ($bytes <: t_Array _ (sz 24)) 8 j)"#)))]
 pub(crate) fn deserialize_12(bytes: &[u8]) -> Vec256 {
     #[inline(always)]
-    #[hax_lib::ensures(|coefficients| fstar!(r#"
+    #[cfg_attr(hax, hax_lib::ensures(|coefficients| fstar!(r#"
 forall (i: nat {i < 256}).
       $coefficients i
     = ( if i % 16 >= 12 then 0
         else let j = (i / 16) * 12 + i % 16 in
              if i < 128 then $lower_coefficients0 j else $upper_coefficients0 (j - 64)))
-"#))]
-    #[hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#)]
+"#)))]
+    #[cfg_attr(hax, hax_lib::fstar::before(r#"[@@"opaque_to_smt"]"#))]
     fn deserialize_12_vec(lower_coefficients0: Vec128, upper_coefficients0: Vec128) -> Vec256 {
         let lower_coefficients = mm_shuffle_epi8(
             lower_coefficients0,
@@ -800,6 +830,7 @@ forall (i: nat {i < 256}).
         );
         let coefficients = mm256_srli_epi16::<4>(coefficients);
         let coefficients = mm256_and_si256(coefficients, mm256_set1_epi16((1 << 12) - 1));
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"
 assert_norm(BitVec.Utils.forall256 (fun i -> 

--- a/libcrux-ml-kem/src/vector/neon.rs
+++ b/libcrux-ml-kem/src/vector/neon.rs
@@ -26,31 +26,31 @@ impl crate::vector::traits::Repr for SIMD128Vector {
 #[cfg(any(eurydice, not(hax)))]
 impl crate::vector::traits::Repr for SIMD128Vector {}
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Operations for SIMD128Vector {
     #[inline(always)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#)))]
     fn ZERO() -> Self {
         ZERO()
     }
 
-    #[requires(array.len() == 16)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == $array"#)))]
     fn from_i16_array(array: &[i16]) -> Self {
         from_i16_array(array)
     }
 
-    #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"out == impl.f_repr $x"#)))]
     fn to_i16_array(x: Self) -> [i16; 16] {
         to_i16_array(x)
     }
 
-    #[requires(array.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
     fn from_bytes(array: &[u8]) -> Self {
         from_bytes(array)
     }
 
-    #[requires(bytes.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
     fn to_bytes(x: Self, bytes: &mut [u8]) {
         to_bytes(x, bytes)
     }

--- a/libcrux-ml-kem/src/vector/neon/vector_type.rs
+++ b/libcrux-ml-kem/src/vector/neon/vector_type.rs
@@ -1,14 +1,14 @@
 use libcrux_intrinsics::arm64::*;
 #[derive(Clone, Copy)]
-#[hax_lib::fstar::after(interface, "val repr (x:t_SIMD128Vector) : t_Array i16 (sz 16)")]
-#[hax_lib::fstar::after("let repr (x:t_SIMD128Vector) = admit()")]
+#[cfg_attr(hax, hax_lib::fstar::after(interface, "val repr (x:t_SIMD128Vector) : t_Array i16 (sz 16)"))]
+#[cfg_attr(hax, hax_lib::fstar::after("let repr (x:t_SIMD128Vector) = admit()"))]
 pub struct SIMD128Vector {
     pub low: _int16x8_t,
     pub high: _int16x8_t,
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!("${result} == repr ${v}"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("${result} == repr ${v}")))]
 pub(crate) fn to_i16_array(v: SIMD128Vector) -> [i16; 16] {
     let mut out = [0i16; 16];
     _vst1q_s16(&mut out[0..8], v.low);
@@ -17,7 +17,7 @@ pub(crate) fn to_i16_array(v: SIMD128Vector) -> [i16; 16] {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!("repr ${result} == $array"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("repr ${result} == $array")))]
 pub(crate) fn from_i16_array(array: &[i16]) -> SIMD128Vector {
     SIMD128Vector {
         low: _vld1q_s16(&array[0..8]),
@@ -41,7 +41,7 @@ pub(crate) fn from_bytes(array: &[u8]) -> SIMD128Vector {
 
 #[allow(non_snake_case)]
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!("repr result == Seq.create 16 (mk_i16 0)"))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!("repr result == Seq.create 16 (mk_i16 0)")))]
 pub(crate) fn ZERO() -> SIMD128Vector {
     SIMD128Vector {
         low: _vdupq_n_s16(0),

--- a/libcrux-ml-kem/src/vector/neon/vector_type.rs
+++ b/libcrux-ml-kem/src/vector/neon/vector_type.rs
@@ -1,6 +1,9 @@
 use libcrux_intrinsics::arm64::*;
 #[derive(Clone, Copy)]
-#[cfg_attr(hax, hax_lib::fstar::after(interface, "val repr (x:t_SIMD128Vector) : t_Array i16 (sz 16)"))]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::after(interface, "val repr (x:t_SIMD128Vector) : t_Array i16 (sz 16)")
+)]
 #[cfg_attr(hax, hax_lib::fstar::after("let repr (x:t_SIMD128Vector) = admit()"))]
 pub struct SIMD128Vector {
     pub low: _int16x8_t,

--- a/libcrux-ml-kem/src/vector/portable.rs
+++ b/libcrux-ml-kem/src/vector/portable.rs
@@ -1,5 +1,6 @@
-use super::Operations;
 use libcrux_secrets::*;
+
+use super::Operations;
 
 mod arithmetic;
 mod compress;
@@ -12,9 +13,8 @@ use arithmetic::*;
 use compress::*;
 use ntt::*;
 use sampling::*;
-use vector_type::*;
-
 pub(crate) use vector_type::PortableVector;
+use vector_type::*;
 
 #[cfg(hax)]
 impl crate::vector::traits::Repr for PortableVector {
@@ -26,37 +26,43 @@ impl crate::vector::traits::Repr for PortableVector {
 #[cfg(any(eurydice, not(hax)))]
 impl crate::vector::traits::Repr for PortableVector {}
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> 
-                                 Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> 
+                                 Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#)))]
 fn serialize_1(a: PortableVector) -> [u8; 2] {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. Rust_primitives.bounded (Seq.index ${a}.f_elements i) 1)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_1_lemma $a"#);
     serialize::serialize_1(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 2)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 2))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#)))]
 fn deserialize_1(a: &[u8]) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_1_lemma $a"#);
     serialize::deserialize_1(a.classify_ref())
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#)))]
 fn serialize_4(a: PortableVector) -> [u8; 8] {
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall i. Rust_primitives.bounded (Seq.index ${a}.f_elements i) 4)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_4_lemma $a"#);
     serialize::serialize_4(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 8)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 8))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#)))]
 fn deserialize_4(a: &[u8]) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_4_lemma $a"#);
     serialize::deserialize_4(a.classify_ref())
 }
@@ -65,21 +71,23 @@ fn serialize_5(a: PortableVector) -> [u8; 10] {
     serialize::serialize_5(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 10)]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 10))]
 fn deserialize_5(a: &[u8]) -> PortableVector {
     serialize::deserialize_5(a.classify_ref())
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#)))]
 fn serialize_10(a: PortableVector) -> [u8; 20] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_10_lemma $a"#);
     serialize::serialize_10(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 20)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 20))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#)))]
 fn deserialize_10(a: &[u8]) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_10_lemma $a"#);
     serialize::deserialize_10(a.classify_ref())
 }
@@ -88,52 +96,57 @@ fn serialize_11(a: PortableVector) -> [u8; 22] {
     serialize::serialize_11(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 22)]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 22))]
 fn deserialize_11(a: &[u8]) -> PortableVector {
     serialize::deserialize_11(a.classify_ref())
 }
 
-#[hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
-#[hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#)))]
 fn serialize_12(a: PortableVector) -> [u8; 24] {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.serialize_12_lemma $a"#);
     serialize::serialize_12(a).declassify()
 }
 
-#[hax_lib::requires(a.len() == 24)]
-#[hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
+#[cfg_attr(hax, hax_lib::requires(a.len() == 24))]
+#[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#)))]
 fn deserialize_12(a: &[u8]) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Libcrux_ml_kem.Vector.Portable.Serialize.deserialize_12_lemma $a"#);
     serialize::deserialize_12(a.classify_ref())
 }
 
-#[hax_lib::fstar::before(r#"#push-options "--z3rlimit 400 --split_queries always""#)]
-#[hax_lib::fstar::after(r#"#pop-options"#)]
-#[hax_lib::attributes]
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(r#"#push-options "--z3rlimit 400 --split_queries always""#)
+)]
+#[cfg_attr(hax, hax_lib::fstar::after(r#"#pop-options"#))]
+#[cfg_attr(hax, hax_lib::attributes)]
 impl Operations for PortableVector {
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == Seq.create 16 (mk_i16 0)"#)))]
     fn ZERO() -> Self {
         zero()
     }
 
-    #[requires(array.len() == 16)]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == $array"#))]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == $array"#)))]
     fn from_i16_array(array: &[i16]) -> Self {
         from_i16_array(array.classify_ref())
     }
 
-    #[ensures(|out| fstar!(r#"out == impl.f_repr $x"#))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"out == impl.f_repr $x"#)))]
     fn to_i16_array(x: Self) -> [i16; 16] {
         to_i16_array(x).declassify()
     }
 
-    #[requires(array.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
     fn from_bytes(array: &[u8]) -> Self {
         from_bytes(array.classify_ref())
     }
 
-    #[requires(bytes.len() >= 32)]
-    #[ensures(|_| future(bytes).len() == bytes.len())]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(bytes).len() == bytes.len()))]
     fn to_bytes(x: Self, bytes: &mut [u8]) {
         #[cfg(not(hax))]
         to_bytes(x, classify_mut_slice(bytes));
@@ -143,152 +156,152 @@ impl Operations for PortableVector {
         to_bytes(x, bytes);
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
-         v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
+         v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#)))]
     fn add(lhs: Self, rhs: &Self) -> Self {
         add(lhs, rhs)
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
-         v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
+         v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#)))]
     fn sub(lhs: Self, rhs: &Self) -> Self {
         sub(lhs, rhs)
     }
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index ${result}.f_elements i) == 
-        v (Seq.index ${vec}.f_elements i) * v c)"#))]
+        v (Seq.index ${vec}.f_elements i) * v c)"#)))]
     fn multiply_by_constant(vec: Self, c: i16) -> Self {
         multiply_by_constant(vec, c)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $v)"#))]
-    #[ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $v)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (impl.f_repr $v)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"impl.f_repr out == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (impl.f_repr $v)"#)))]
     fn cond_subtract_3329(v: Self) -> Self {
         cond_subtract_3329(v)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${vector})"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (impl.f_repr ${vector})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
                 (forall i. (v (Seq.index (impl.f_repr ${result}) i) % 3329) == 
-                           (v (Seq.index (impl.f_repr ${vector})i) % 3329))"#))]
+                           (v (Seq.index (impl.f_repr ${vector})i) % 3329))"#)))]
     fn barrett_reduce(vector: Self) -> Self {
         barrett_reduce(vector)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 $constant"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $constant"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr ${result}) /\
                 (forall i. i < 16 ==> ((v (Seq.index (impl.f_repr ${result}) i) % 3329)==
-                                       (v (Seq.index (impl.f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#))]
+                                       (v (Seq.index (impl.f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#)))]
     fn montgomery_multiply_by_constant(vector: Self, constant: i16) -> Self {
         montgomery_multiply_by_constant(vector, constant.classify())
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
                                 (let x = Seq.index (impl.f_repr ${a}) i in
                                  let y = Seq.index (impl.f_repr ${result}) i in
-                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
+                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#)))]
     fn to_unsigned_representative(a: Self) -> Self {
         to_unsigned_representative(a)
     }
 
-    #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
-        v (Seq.index (impl.f_repr $a) i) < 3329"#))]
-    #[ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
+        v (Seq.index (impl.f_repr $a) i) < 3329"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) 1"#)))]
     fn compress_1(a: Self) -> Self {
         compress_1(a)
     }
 
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) /\
         (forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
-            v (Seq.index (impl.f_repr $a) i) < 3329)"#))]
-    #[ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+            v (Seq.index (impl.f_repr $a) i) < 3329)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) ==>
-                (forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) (v $COEFFICIENT_BITS))"#))]
+                (forall (i:nat). i < 16 ==> bounded (Seq.index (impl.f_repr $out) i) (v $COEFFICIENT_BITS))"#)))]
     fn compress<const COEFFICIENT_BITS: i32>(a: Self) -> Self {
         compress::<COEFFICIENT_BITS>(a)
     }
 
-    #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> 
                                     (let x = Seq.index (impl.f_repr $a) i in 
-                                     (x == mk_i16 0 \/ x == mk_i16 1))"#))]
+                                     (x == mk_i16 0 \/ x == mk_i16 1))"#)))]
     fn decompress_1(a: Self) -> Self {
         decompress_1(a)
     }
 
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (impl.f_repr $a) i) >= 0 /\
-        v (Seq.index (impl.f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#))]
+        v (Seq.index (impl.f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#)))]
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self {
         decompress_ciphertext_coefficient::<COEFFICIENT_BITS>(a)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3  /\
-                       Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (impl.f_repr $out)"#)))]
     fn ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (impl.f_repr $out)"#)))]
     fn ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self {
         ntt_layer_2_step(a, zeta0, zeta1)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                       Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                       Spec.Utils.is_i16b_array (11207+3*3328) (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (impl.f_repr $out)"#)))]
     fn ntt_layer_3_step(a: Self, zeta: i16) -> Self {
         ntt_layer_3_step(a, zeta)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (4*3328) (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     fn inv_ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self {
         inv_ntt_layer_1_step(a, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     fn inv_ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self {
         inv_ntt_layer_2_step(a, zeta0, zeta1)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     fn inv_ntt_layer_3_step(a: Self, zeta: i16) -> Self {
         inv_ntt_layer_3_step(a, zeta)
     }
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array 3328 (impl.f_repr ${lhs}) /\
-                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array 3328 (impl.f_repr ${rhs})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (impl.f_repr $out)"#)))]
     fn ntt_multiply(
         lhs: &Self,
         rhs: &Self,
@@ -300,26 +313,26 @@ impl Operations for PortableVector {
         ntt_multiply(lhs, rhs, zeta0, zeta1, zeta2, zeta3)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 1 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 1 (impl.f_repr $a) $out"#)))]
     fn serialize_1(a: Self) -> [u8; 2] {
         serialize_1(a)
     }
 
-    #[requires(a.len() == 2)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 2))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (impl.f_repr $out)"#)))]
     fn deserialize_1(a: &[u8]) -> Self {
         deserialize_1(a)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 4 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 4 (impl.f_repr $a) $out"#)))]
     fn serialize_4(a: Self) -> [u8; 8] {
         serialize_4(a)
     }
 
-    #[requires(a.len() == 8)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 8))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (impl.f_repr $out)"#)))]
     fn deserialize_4(a: &[u8]) -> Self {
         deserialize_4(a)
     }
@@ -328,19 +341,19 @@ impl Operations for PortableVector {
         serialize_5(a)
     }
 
-    #[requires(a.len() == 10)]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 10))]
     fn deserialize_5(a: &[u8]) -> Self {
         deserialize_5(a)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 10 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 10 (impl.f_repr $a) $out"#)))]
     fn serialize_10(a: Self) -> [u8; 20] {
         serialize_10(a)
     }
 
-    #[requires(a.len() == 20)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 20))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (impl.f_repr $out)"#)))]
     fn deserialize_10(a: &[u8]) -> Self {
         deserialize_10(a)
     }
@@ -349,27 +362,27 @@ impl Operations for PortableVector {
         serialize_11(a)
     }
 
-    #[requires(a.len() == 22)]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 22))]
     fn deserialize_11(a: &[u8]) -> Self {
         deserialize_11(a)
     }
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#))]
-    #[ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.MLKEM.serialize_pre 12 (impl.f_repr $a) ==> Spec.MLKEM.serialize_post 12 (impl.f_repr $a) $out"#)))]
     fn serialize_12(a: Self) -> [u8; 24] {
         serialize_12(a)
     }
 
-    #[requires(a.len() == 24)]
-    #[ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 24))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (impl.f_repr $out)"#)))]
     fn deserialize_12(a: &[u8]) -> Self {
         deserialize_12(a)
     }
 
-    #[requires(a.len() == 24 && out.len() == 16)]
-    #[ensures(|result|
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 24 && out.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"Seq.length $out_future == Seq.length $out /\ v $result <= 16"#)
-    )]
+    ))]
     fn rej_sample(a: &[u8], out: &mut [i16]) -> usize {
         rej_sample(a, out)
     }

--- a/libcrux-ml-kem/src/vector/portable/arithmetic.rs
+++ b/libcrux-ml-kem/src/vector/portable/arithmetic.rs
@@ -1,9 +1,10 @@
+use libcrux_secrets::*;
+
 use super::vector_type::*;
 use crate::vector::traits::{
     BARRETT_R, BARRETT_SHIFT, FIELD_ELEMENTS_IN_VECTOR, FIELD_MODULUS,
     INVERSE_OF_MODULUS_MOD_MONTGOMERY_R,
 };
-use libcrux_secrets::*;
 
 /// If 'x' denotes a value of type `fe`, values having this type hold a
 /// representative y ≡ x·MONTGOMERY_R^(-1) (mod FIELD_MODULUS).
@@ -23,13 +24,14 @@ pub(crate) const MONTGOMERY_R: i32 = 1 << MONTGOMERY_SHIFT;
 /// This is calculated as ⌊(BARRETT_R / FIELD_MODULUS) + 1/2⌋
 pub(crate) const BARRETT_MULTIPLIER: i32 = 20159;
 
-#[hax_lib::fstar::options("--z3rlimit 150 --split_queries always")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150 --split_queries always"))]
 #[cfg_attr(hax, hax_lib::requires(n <= 16))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"v result == v value % pow2(v n)"#)))]
 #[inline(always)]
 pub(crate) fn get_n_least_significant_bits(n: u8, value: U32) -> U32 {
     let res = value & ((1 << n) - 1);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "calc (==) {
     v res;
@@ -50,17 +52,18 @@ pub(crate) fn get_n_least_significant_bits(n: u8, value: U32) -> U32 {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
-     v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#))]
+     v (Seq.index ${lhs}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"#)))]
 pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
     #[cfg(hax)]
     let _lhs0 = lhs;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -73,6 +76,7 @@ pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
         lhs.elements[i] += rhs.elements[i];
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. v (Seq.index ${lhs}.f_elements i) ==
     			          v (Seq.index ${_lhs0}.f_elements i) + v (Seq.index ${rhs}.f_elements i))"
@@ -82,16 +86,17 @@ pub fn add(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
-     v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#))]
+     v (Seq.index ${lhs}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"#)))]
 pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
     #[cfg(hax)]
     let _lhs0 = lhs;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -104,6 +109,7 @@ pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
         lhs.elements[i] -= rhs.elements[i];
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. v (Seq.index ${lhs}.f_elements i) ==
     			          v (Seq.index ${_lhs0}.f_elements i) - v (Seq.index ${rhs}.f_elements i))"
@@ -113,16 +119,17 @@ pub fn sub(mut lhs: PortableVector, rhs: &PortableVector) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
-    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+    Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index ${vec}.f_elements i) * v c)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
     (v (Seq.index ${result}.f_elements i) == 
-     v (Seq.index ${vec}.f_elements i) * v c)"#))]
+     v (Seq.index ${vec}.f_elements i) * v c)"#)))]
 pub fn multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
     #[cfg(hax)]
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -135,6 +142,7 @@ pub fn multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
         vec.elements[i] *= c;
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall i. v (Seq.index ${vec}.f_elements i) ==
     			          v (Seq.index ${_vec0}.f_elements i) * v c)"
@@ -144,12 +152,13 @@ pub fn multiply_by_constant(mut vec: PortableVector, c: i16) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array (fun x -> x &. c) (${vec}.f_elements)"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array (fun x -> x &. c) (${vec}.f_elements)"#)))]
 pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVector {
     #[cfg(hax)]
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -162,6 +171,7 @@ pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVec
         vec.elements[i] &= c;
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array (fun x -> x &. c) ${_vec0}.f_elements)"#
     );
@@ -170,14 +180,15 @@ pub fn bitwise_and_with_constant(mut vec: PortableVector, c: i16) -> PortableVec
 }
 
 #[inline(always)]
-#[hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16)]
-#[hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
-        ${result}.f_elements == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (${vec}.f_elements)"#))]
+#[cfg_attr(hax, hax_lib::requires(SHIFT_BY >= 0 && SHIFT_BY < 16))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"(v_SHIFT_BY >=. (mk_i32 0) /\ v_SHIFT_BY <. (mk_i32 16)) ==> 
+        ${result}.f_elements == Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) (${vec}.f_elements)"#)))]
 pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVector {
     #[cfg(hax)]
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -190,6 +201,7 @@ pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVect
         vec.elements[i] = vec.elements[i] >> SHIFT_BY;
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array (fun x -> x >>! ${SHIFT_BY}) ${_vec0}.f_elements)"#
     );
@@ -200,15 +212,16 @@ pub fn shift_right<const SHIFT_BY: i32>(mut vec: PortableVector) -> PortableVect
 /// Note: This function is not secret independent
 /// Only use with public values.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array 
-                (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (${vec}.f_elements)"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Spec.Utils.map_array 
+                (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (${vec}.f_elements)"#)))]
 pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
     #[cfg(hax)]
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -223,6 +236,7 @@ pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
         }
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"Seq.lemma_eq_intro ${vec}.f_elements (Spec.Utils.map_array 
                             (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) ${_vec0}.f_elements)"#
@@ -242,13 +256,13 @@ pub fn cond_subtract_3329(mut vec: PortableVector) -> PortableVector {
 /// `|result| ≤ FIELD_MODULUS / 2 · (|value|/BARRETT_R + 1)
 ///
 /// Note: The input bound is 28296 to prevent overflow in the multiplication of quotient by FIELD_MODULUS
-///
-#[hax_lib::fstar::options("--z3rlimit 150 --ext context_pruning")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150 --ext context_pruning"))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 28296 value"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b 3328 result /\
                 v result % 3329 == v value % 3329"#)))]
 pub(crate) fn barrett_reduce_element(value: FieldElement) -> FieldElement {
     let t = (value.as_i32() * BARRETT_MULTIPLIER) + (BARRETT_R >> 1);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
         assert_norm (v v_BARRETT_MULTIPLIER == (pow2 27 + 3329) / (2*3329));
@@ -256,16 +270,21 @@ pub(crate) fn barrett_reduce_element(value: FieldElement) -> FieldElement {
         assert (v t / pow2 26 < 9);
         assert (v t / pow2 26 > - 9)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v t / pow2 26 < 9)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v t / pow2 26 > - 9)"#);
 
     let quotient = (t >> BARRETT_SHIFT).as_i16();
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v quotient = v t / pow2 26)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 9 quotient)"#);
 
     let result = value - (quotient * FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "calc (==) {
     v result % 3329;
@@ -284,7 +303,7 @@ pub(crate) fn barrett_reduce_element(value: FieldElement) -> FieldElement {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 ${vec}.f_elements"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
                 (forall i. (v (Seq.index ${result}.f_elements i) % 3329) == 
@@ -294,6 +313,7 @@ pub(crate) fn barrett_reduce(mut vec: PortableVector) -> PortableVector {
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -307,6 +327,7 @@ pub(crate) fn barrett_reduce(mut vec: PortableVector) -> PortableVector {
         let vi = barrett_reduce_element(vec.elements[i]);
         vec.elements[i] = vi;
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"assert (v (mk_int #usize_inttype (v i + 1)) == v i + 1);
                          assert (forall j. j < v i ==> Spec.Utils.is_i16b 3328 (Seq.index vec.f_elements j));
@@ -330,8 +351,7 @@ pub(crate) fn barrett_reduce(mut vec: PortableVector) -> PortableVector {
 ///
 /// In particular, if `|value| ≤ FIELD_MODULUS-1 * FIELD_MODULUS-1`, then `|o| <= FIELD_MODULUS-1`.
 /// And, if `|value| ≤ pow2 16 * FIELD_MODULUS-1`, then `|o| <= FIELD_MODULUS + 1664
-///
-#[hax_lib::fstar::options("--z3rlimit 300")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i32b (3328 * pow2 16) value "#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b (3328 + 1665) result /\
                 (Spec.Utils.is_i32b (3328 * pow2 15) value ==> Spec.Utils.is_i16b 3328 result) /\
@@ -345,6 +365,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 
     let k = (value.as_i16()).as_i32() * (INVERSE_OF_MODULUS_MOD_MONTGOMERY_R.classify().as_i32());
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(v (cast (cast (value <: i32) <: i16) <: i32) == v value @% pow2 16);
                      assert(v k == (v value @% pow2 16) * 62209);
@@ -356,6 +377,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 
     let k_times_modulus = (k.as_i16().as_i32()) * (FIELD_MODULUS.classify().as_i32());
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert_norm (pow2 15 * 3329 < pow2 31);
            Spec.Utils.lemma_mul_i16b (pow2 15) (3329) (cast (k <: i32) <: i16) Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS;
@@ -364,6 +386,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 
     let c = (k_times_modulus >> MONTGOMERY_SHIFT).as_i16();
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v k_times_modulus < pow2 31);
                      assert (v k_times_modulus / pow2 16 < pow2 15);
@@ -374,6 +397,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 
     let value_high = (value >> MONTGOMERY_SHIFT).as_i16();
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v value < pow2 31);
                      assert (v value / pow2 16 < pow2 15);
@@ -386,12 +410,14 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 
     let res = value_high - c;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
         assert(Spec.Utils.is_i16b (3328 + 1665) res);
         assert(Spec.Utils.is_i32b (3328 * pow2 15) value ==> Spec.Utils.is_i16b 3328 res)
         "#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"calc ( == ) {
         v k_times_modulus % pow2 16;
@@ -415,6 +441,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
       Math.Lemmas.modulo_add (pow2 16) (- (v k_times_modulus)) (v value) (v k_times_modulus);
       assert ((v value - v k_times_modulus) % pow2 16 == 0)"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"calc ( == ) {
         v res % 3329;
@@ -447,7 +474,7 @@ pub(crate) fn montgomery_reduce_element(value: I32) -> MontgomeryFieldElement {
 /// `montgomery_reduce` takes the value `x · y · MONTGOMERY_R` and outputs a representative
 /// `x · y · MONTGOMERY_R * MONTGOMERY_R^{-1} ≡ x · y (mod FIELD_MODULUS)`.
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 fer"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b 3328 result /\
                 v result % 3329 == (v fe * v fer * 169) % 3329"#)))]
@@ -455,6 +482,7 @@ pub(crate) fn montgomery_multiply_fe_by_fer(
     fe: FieldElement,
     fer: FieldElementTimesMontgomeryR,
 ) -> FieldElement {
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b (pow2 15) (1664) fe fer"#);
 
     let product = (fe.as_i32()) * (fer.as_i32());
@@ -462,7 +490,7 @@ pub(crate) fn montgomery_multiply_fe_by_fer(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 150")]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 150"))]
 #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 c"#)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
 Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
@@ -473,6 +501,7 @@ pub(crate) fn montgomery_multiply_by_constant(mut vec: PortableVector, c: I16) -
     let _vec0 = vec;
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"
@@ -489,16 +518,17 @@ pub(crate) fn montgomery_multiply_by_constant(mut vec: PortableVector, c: I16) -
     vec
 }
 
-#[hax_lib::fstar::options("--z3rlimit 300")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 ${a}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall i.
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 ${a}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i.
                                        (let x = Seq.index ${a}.f_elements i in
                                         let y = Seq.index ${result}.f_elements i in
-                                        (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
+                                        (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#)))]
 #[inline(always)]
 pub(crate) fn to_unsigned_representative(a: PortableVector) -> PortableVector {
     let t = shift_right::<15>(a);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
         assert (forall i. Seq.index ${t}.f_elements i == ((Seq.index ${a}.f_elements i) >>! (mk_i32 15)));
@@ -509,6 +539,7 @@ pub(crate) fn to_unsigned_representative(a: PortableVector) -> PortableVector {
 
     let fm = bitwise_and_with_constant(t, FIELD_MODULUS);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
   assert (forall i. Seq.index ${fm}.f_elements i == (Seq.index ${t}.f_elements i &. Libcrux_ml_kem.Vector.Traits.v_FIELD_MODULUS));

--- a/libcrux-ml-kem/src/vector/portable/compress.rs
+++ b/libcrux-ml-kem/src/vector/portable/compress.rs
@@ -1,8 +1,7 @@
-use super::arithmetic::*;
-use super::vector_type::*;
-use crate::vector::traits::FIELD_ELEMENTS_IN_VECTOR;
-use crate::vector::FIELD_MODULUS;
 use libcrux_secrets::*;
+
+use super::{arithmetic::*, vector_type::*};
+use crate::vector::{traits::FIELD_ELEMENTS_IN_VECTOR, FIELD_MODULUS};
 
 /// The `compress_*` functions implement the `Compress` function specified in the NIST FIPS
 /// 203 standard (Page 18, Expression 4.5), which is defined as:
@@ -24,8 +23,8 @@ use libcrux_secrets::*;
 ///
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#))]
 #[cfg_attr(hax, hax_lib::requires(fe < (FIELD_MODULUS as u16)))]
 #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"((833 <= v fe && v fe <= 2496) ==> v result == 1) /\
 						    (~(833 <=  v fe && v fe <= 2496) ==> v result == 0)"#)))]
@@ -36,6 +35,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
     // If 833 <= fe <= 2496,
     // then -832 <= shifted <= 831
     let shifted: I16 = 1664.classify() - (fe.as_i16());
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (v $shifted == 1664 - v $fe)"#);
 
     // If shifted < 0, then
@@ -47,6 +47,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
     // if 0 <= shifted <= 831 then 0 <= shifted_positive <= 831
     let mask = shifted >> 15;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v $mask = v $shifted / pow2 15);
         assert (if v $shifted < 0 then $mask = ones else $mask = zero)"
@@ -54,6 +55,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
 
     let shifted_to_positive: I16 = mask ^ shifted;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "logxor_lemma $shifted $mask;
         assert (v $shifted < 0 ==> v $shifted_to_positive = v (lognot $shifted));
@@ -68,6 +70,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
 
     let shifted_positive_in_range: I16 = shifted_to_positive - 832;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (1664 - v $fe >= 0 ==> v $shifted_positive_in_range == 832 - v $fe);
         assert (1664 - v $fe < 0 ==> v $shifted_positive_in_range == -2497 + v $fe)"
@@ -79,6 +82,7 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
     let r1: I16 = r0 & 1i16;
     let res = r1.as_u8();
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v $r0 = v $shifted_positive_in_range / pow2 15);
         assert (if v $shifted_positive_in_range < 0 then $r0 = ones else $r0 = zero);
@@ -93,8 +97,8 @@ pub(crate) fn compress_message_coefficient(fe: U16) -> U8 {
     res
 }
 
-#[hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning")]
-#[hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#)]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::fstar::before(r#"[@ "opaque_to_smt"]"#))]
 #[cfg_attr(hax,
     hax_lib::requires(
         (coefficient_bits == 4 ||
@@ -139,19 +143,21 @@ let compress_message_coefficient_range_helper (fe: u16) : Lemma
 "#
     )
 )]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 200")]
-#[hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index ${a}.f_elements i) >= 0 /\
-    v (Seq.index ${a}.f_elements i) < 3329"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 200"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index ${a}.f_elements i) >= 0 /\
+    v (Seq.index ${a}.f_elements i) < 3329"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
     v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
-    v (${result}.f_elements.[ sz i ] <: i16) < 2"#))]
+    v (${result}.f_elements.[ sz i ] <: i16) < 2"#)))]
 pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall (i:nat). i < 16 ==> (cast (${a}.f_elements.[ sz i ]) <: u16) <.
         (cast ($FIELD_MODULUS) <: u16))"
     );
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"(v $i < 16 ==> (forall (j:nat). (j >= v $i /\ j < 16) ==>
@@ -161,18 +167,21 @@ pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
             )
         });
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             "compress_message_coefficient_range_helper (cast (${a}.f_elements.[ $i ]) <: u16)"
         );
 
         a.elements[i] = compress_message_coefficient(a.elements[i].as_u16()).as_i16();
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"assert (v (${a}.f_elements.[ $i ] <: i16) >= 0 /\
             v (${a}.f_elements.[ $i ] <: i16) < 2)"#
         );
     }
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall (i:nat). i < 16 ==> v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
         v (${a}.f_elements.[ sz i ] <: i16) < 2)"#
@@ -182,23 +191,25 @@ pub(crate) fn compress_1(mut a: PortableVector) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 500")]
-#[hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+#[cfg_attr(hax, hax_lib::fstar::options("--fuel 0 --ifuel 0 --z3rlimit 500"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> 
         (v (Seq.index ${a}.f_elements i) >= 0 /\
-         v (Seq.index ${a}.f_elements i) < 3329))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
+         v (Seq.index ${a}.f_elements i) < 3329))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
     (v (${result}.f_elements.[ sz i ] <: i16) >= 0 /\
-     v (${result}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#))]
+     v (${result}.f_elements.[ sz i ] <: i16) < pow2 (v $COEFFICIENT_BITS)))"#)))]
 pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v (cast ($COEFFICIENT_BITS) <: u8) == v $COEFFICIENT_BITS);
         assert (v (cast ($COEFFICIENT_BITS) <: u32) == v $COEFFICIENT_BITS);
         assert (v (cast ($FIELD_MODULUS) <: u16) == 3329)"
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (forall (i:nat). i < 16 ==> 
             (cast (${a}.f_elements.[ sz i ]) <: u16) <.
@@ -206,6 +217,7 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
     );
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"((forall (j:nat). (j >= v $i /\ j < 16) ==>
@@ -219,11 +231,13 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
             compress_ciphertext_coefficient(COEFFICIENT_BITS as u8, a.elements[i].as_u16())
                 .as_i16();
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             r#"assert (v (${a}.f_elements.[ $i ] <: i16) >= 0 /\
             v (${a}.f_elements.[ $i ] <: i16) < pow2 (v $COEFFICIENT_BITS))"#
         );
     }
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (forall (i:nat). i < 16 ==> 
                     (v (${a}.f_elements.[ sz i ] <: i16) >= 0 /\
@@ -233,21 +247,24 @@ pub(crate) fn compress<const COEFFICIENT_BITS: i32>(mut a: PortableVector) -> Po
     a
 }
 
-#[hax_lib::fstar::options("--z3rlimit 200 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"forall i. let x = Seq.index ${a}.f_elements i in 
-                                        (x == mk_i16 0 \/ x == mk_i16 1)"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. let x = Seq.index ${a}.f_elements i in 
+                                        (x == mk_i16 0 \/ x == mk_i16 1)"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
         (let res_i = v (Seq.index ${result}.f_elements i) in
-         res_i == 0 \/ res_i == 1665)"#))]
+         res_i == 0 \/ res_i == 1665)"#)))]
 #[inline(always)]
 pub(crate) fn decompress_1(a: PortableVector) -> PortableVector {
     let z = zero();
 
+    #[cfg(hax)]
     hax_lib::fstar!("assert(forall i. Seq.index ${z}.f_elements i == mk_i16 0)");
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall i. let x = Seq.index ${a}.f_elements i in 
                                       ((0 - v x) == 0 \/ (0 - v x) == -1))"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall i. i < 16 ==>
                                       Spec.Utils.is_intb (pow2 15 - 1) 
@@ -256,6 +273,7 @@ pub(crate) fn decompress_1(a: PortableVector) -> PortableVector {
 
     let s = sub(z, &a);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall i. Seq.index ${s}.f_elements i == mk_i16 0 \/ 
                                       Seq.index ${s}.f_elements i == mk_i16 (-1))"#
@@ -263,6 +281,7 @@ pub(crate) fn decompress_1(a: PortableVector) -> PortableVector {
 
     let res = bitwise_and_with_constant(s, 1665);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert(forall i. Seq.index ${res}.f_elements i == mk_i16 0 \/ 
                                       Seq.index ${res}.f_elements i == mk_i16 1665)"#
@@ -272,19 +291,20 @@ pub(crate) fn decompress_1(a: PortableVector) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 300 --ext context_pruning")]
-#[hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 300 --ext context_pruning"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index ${a}.f_elements i) >= 0 /\
-        v (Seq.index ${a}.f_elements i) < pow2 (v $COEFFICIENT_BITS))"#))]
-#[hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
+        v (Seq.index ${a}.f_elements i) < pow2 (v $COEFFICIENT_BITS))"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> 
         (let res_i = v (Seq.index ${result}.f_elements i) in
-         res_i >= 0 /\ res_i < v $FIELD_MODULUS)"#))]
+         res_i >= 0 /\ res_i < v $FIELD_MODULUS)"#)))]
 pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
     mut a: PortableVector,
 ) -> PortableVector {
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert_norm (pow2 1 == 2);
         assert_norm (pow2 4 == 16);
@@ -294,6 +314,7 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
     );
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(
                 r#"(v $i < 16 ==> (forall (j:nat). (j >= v $i /\ j < 16) ==>
@@ -302,6 +323,7 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
                 (v (Seq.index ${a}.f_elements j) >= 0 /\ v (Seq.index ${a}.f_elements j) < v $FIELD_MODULUS))"#
             )
         });
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (v (${a}.f_elements.[ $i ] <: i16) < pow2 11);
           assert (v (${a}.f_elements.[ $i ] <: i16) ==
@@ -316,6 +338,7 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
 
         let mut decompressed = a.elements[i].as_i32() * FIELD_MODULUS.classify().as_i32();
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (v ($decompressed <<! mk_i32 1) == v $decompressed * 2);
           assert (v (mk_i32 1 <<! $COEFFICIENT_BITS) == pow2 (v $COEFFICIENT_BITS));
@@ -325,6 +348,7 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
 
         decompressed = (decompressed << 1) + (1i32 << COEFFICIENT_BITS);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (v ($COEFFICIENT_BITS +! mk_i32 1) == v $COEFFICIENT_BITS + 1);
           assert (v ($decompressed >>! ($COEFFICIENT_BITS +! mk_i32 1 <: i32)) ==
@@ -333,6 +357,7 @@ pub(crate) fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(
 
         decompressed = decompressed >> (COEFFICIENT_BITS + 1);
 
+        #[cfg(hax)]
         hax_lib::fstar!(
             "assert (v $decompressed < v $FIELD_MODULUS);
           assert (v (cast $decompressed <: i16) < v $FIELD_MODULUS)"

--- a/libcrux-ml-kem/src/vector/portable/ntt.rs
+++ b/libcrux-ml-kem/src/vector/portable/ntt.rs
@@ -1,27 +1,29 @@
-use super::arithmetic::*;
-use super::vector_type::*;
 use libcrux_secrets::*;
 
+use super::{arithmetic::*, vector_type::*};
+
 #[inline(always)]
-#[hax_lib::fstar::before("[@@ \"opaque_to_smt\"]")]
-#[hax_lib::requires(fstar!(r#"v i < 16 /\ v j < 16 /\ v i <> v j /\ 
+#[cfg_attr(hax, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v i < 16 /\ v j < 16 /\ v i <> v j /\ 
                             Spec.Utils.is_i16b 1664 $zeta  /\
                             Spec.Utils.is_i16b_array (11207 + 6 * 3328) vec.f_elements /\
                             Spec.Utils.is_i16b (11207 + 5*3328) vec.f_elements.[i] /\
-                            Spec.Utils.is_i16b (11207 + 5*3328) vec.f_elements.[j]"#))]
-#[hax_lib::ensures(|result| fstar!(r#"(forall k. (k <> v i /\ k <> v j) ==>
+                            Spec.Utils.is_i16b (11207 + 5*3328) vec.f_elements.[j]"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"(forall k. (k <> v i /\ k <> v j) ==>
                                          Seq.index ${vec}_future.f_elements k == Seq.index ${vec}.f_elements k) /\
                                     (forall b. (Spec.Utils.is_i16b b ${vec}.f_elements.[i] /\
                                                Spec.Utils.is_i16b b ${vec}.f_elements.[j]) ==>
                                               (Spec.Utils.is_i16b (b+3328) ${vec}_future.f_elements.[i] /\
                                                Spec.Utils.is_i16b (b+3328) ${vec}_future.f_elements.[j])) /\
-                                    Spec.Utils.ntt_spec ${vec}.f_elements (v $zeta) (v $i) (v $j) ${vec}_future.f_elements"#))]
+                                    Spec.Utils.ntt_spec ${vec}.f_elements (v $zeta) (v $i) (v $j) ${vec}_future.f_elements"#)))]
 pub(crate) fn ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) {
     let t = montgomery_multiply_fe_by_fer(vec.elements[j], zeta.classify());
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (v t % 3329 == ((v (Seq.index vec.f_elements (v j)) * v zeta * 169) % 3329))"
     );
     let a_minus_t = vec.elements[i] - t;
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
     calc (==) {
@@ -37,6 +39,7 @@ pub(crate) fn ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) 
         }"#
     );
     let a_plus_t = vec.elements[i] + t;
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
     calc (==) {
@@ -53,6 +56,7 @@ pub(crate) fn ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) 
     );
     vec.elements[j] = a_minus_t;
     vec.elements[i] = a_plus_t;
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert (Seq.index vec.f_elements (v i) == a_plus_t);
                      assert (Seq.index vec.f_elements (v j) == a_minus_t)"
@@ -60,11 +64,11 @@ pub(crate) fn ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) 
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 100")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                             Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                            Spec.Utils.is_i16b_array (11207+5*3328) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) ${result}.f_elements"#))]
+                            Spec.Utils.is_i16b_array (11207+5*3328) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) ${result}.f_elements"#)))]
 pub(crate) fn ntt_layer_1_step(
     mut vec: PortableVector,
     zeta0: i16,
@@ -84,10 +88,10 @@ pub(crate) fn ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 100")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                            Spec.Utils.is_i16b_array (11207+4*3328) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) ${result}.f_elements"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                            Spec.Utils.is_i16b_array (11207+4*3328) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) ${result}.f_elements"#)))]
 pub(crate) fn ntt_layer_2_step(mut vec: PortableVector, zeta0: i16, zeta1: i16) -> PortableVector {
     ntt_step(&mut vec, zeta0, 0, 4);
     ntt_step(&mut vec, zeta0, 1, 5);
@@ -101,10 +105,10 @@ pub(crate) fn ntt_layer_2_step(mut vec: PortableVector, zeta0: i16, zeta1: i16) 
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 100")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                            Spec.Utils.is_i16b_array (11207+3*3328) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) ${result}.f_elements"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                            Spec.Utils.is_i16b_array (11207+3*3328) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) ${result}.f_elements"#)))]
 pub(crate) fn ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> PortableVector {
     ntt_step(&mut vec, zeta, 0, 8);
     ntt_step(&mut vec, zeta, 1, 9);
@@ -118,25 +122,27 @@ pub(crate) fn ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> PortableVe
 }
 
 #[inline(always)]
-#[hax_lib::fstar::before("[@@ \"opaque_to_smt\"]")]
-#[hax_lib::requires(fstar!(r#"v i < 16 /\ v j < 16 /\  v i <> v j /\ 
+#[cfg_attr(hax, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v i < 16 /\ v j < 16 /\  v i <> v j /\ 
                         Spec.Utils.is_i16b 1664 $zeta /\
-                        Spec.Utils.is_i16b_array (4*3328) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (4*3328) ${vec}_future.f_elements /\
+                        Spec.Utils.is_i16b_array (4*3328) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array (4*3328) ${vec}_future.f_elements /\
                                     (forall k. (k <> v i /\ k <> v j) ==>
                                          Seq.index ${vec}_future.f_elements k == Seq.index ${vec}.f_elements k) /\
                                     Spec.Utils.is_i16b 3328 (Seq.index ${vec}_future.f_elements (v i)) /\
                                     Spec.Utils.is_i16b 3328 (Seq.index ${vec}_future.f_elements (v j)) /\
-                                    Spec.Utils.inv_ntt_spec ${vec}.f_elements (v $zeta) (v $i) (v $j) ${vec}_future.f_elements"#))]
+                                    Spec.Utils.inv_ntt_spec ${vec}.f_elements (v $zeta) (v $i) (v $j) ${vec}_future.f_elements"#)))]
 pub(crate) fn inv_ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usize) {
     let a_minus_b = vec.elements[j] - vec.elements[i];
     let a_plus_b = vec.elements[j] + vec.elements[i];
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (v a_minus_b = v (Seq.index vec.f_elements (v j)) - v (Seq.index vec.f_elements (v i)));
                      assert (v a_plus_b = v (Seq.index vec.f_elements (v j)) + v (Seq.index vec.f_elements (v i)))"#
     );
     let o0 = barrett_reduce_element(a_plus_b);
     let o1 = montgomery_multiply_fe_by_fer(a_minus_b, zeta.classify());
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"
     calc (==) {
@@ -156,6 +162,7 @@ pub(crate) fn inv_ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usi
     );
     vec.elements[i] = o0;
     vec.elements[j] = o1;
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Seq.index vec.f_elements (v i) == o0);
                      assert (Seq.index vec.f_elements (v j) == o1)"#
@@ -163,11 +170,11 @@ pub(crate) fn inv_ntt_step(vec: &mut PortableVector, zeta: i16, i: usize, j: usi
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 200")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 200"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                             Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                            Spec.Utils.is_i16b_array (4*3328) ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
+                            Spec.Utils.is_i16b_array (4*3328) ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#)))]
 pub(crate) fn inv_ntt_layer_1_step(
     mut vec: PortableVector,
     zeta0: i16,
@@ -183,6 +190,7 @@ pub(crate) fn inv_ntt_layer_1_step(
     inv_ntt_step(&mut vec, zeta2, 9, 11);
     inv_ntt_step(&mut vec, zeta3, 12, 14);
     inv_ntt_step(&mut vec, zeta3, 13, 15);
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements 13));
         assert (Spec.Utils.is_i16b 3328 (Seq.index ${vec}.f_elements 15));
@@ -206,10 +214,10 @@ pub(crate) fn inv_ntt_layer_1_step(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 100")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                            Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                            Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#)))]
 pub(crate) fn inv_ntt_layer_2_step(
     mut vec: PortableVector,
     zeta0: i16,
@@ -227,10 +235,10 @@ pub(crate) fn inv_ntt_layer_2_step(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 100")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                            Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#))]
-#[hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#))]
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 100"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                            Spec.Utils.is_i16b_array 3328 ${vec}.f_elements"#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 ${result}.f_elements"#)))]
 pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> PortableVector {
     inv_ntt_step(&mut vec, zeta, 0, 8);
     inv_ntt_step(&mut vec, zeta, 1, 9);
@@ -264,12 +272,17 @@ pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> Portab
 /// The NIST FIPS 203 standard can be found at
 /// <https://csrc.nist.gov/pubs/fips/203/ipd>.
 #[inline(always)]
-#[hax_lib::fstar::options(
-    "--z3rlimit 250 --split_queries always --query_stats --ext context_prune"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::options(
+        "--z3rlimit 250 --split_queries always --query_stats --ext context_prune"
+    )
 )]
-#[hax_lib::fstar::before(
-    interface,
-    r#"
+#[cfg_attr(
+    hax,
+    hax_lib::fstar::before(
+        interface,
+        r#"
     let ntt_multiply_binomials_post
       (a b: Libcrux_ml_kem.Vector.Portable.Vector_type.t_PortableVector)
       (zeta: i16)
@@ -284,16 +297,17 @@ pub(crate) fn inv_ntt_layer_3_step(mut vec: PortableVector, zeta: i16) -> Portab
             ((v oi % 3329) == (((v ai * v bi + (v aj * v bj * v zeta * 169)) * 169) % 3329)) /\
             ((v oj % 3329) == (((v ai * v bj + v aj * v bi) * 169) % 3329))
 "#
+    )
 )]
-#[hax_lib::fstar::before("[@@ \"opaque_to_smt\"]")]
-#[hax_lib::requires(fstar!(r#"v i < 8 /\ Spec.Utils.is_i16b 1664 $zeta /\
+#[cfg_attr(hax, hax_lib::fstar::before("[@@ \"opaque_to_smt\"]"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"v i < 8 /\ Spec.Utils.is_i16b 1664 $zeta /\
         Spec.Utils.is_i16b_array 3328 ${a}.f_elements /\
         Spec.Utils.is_i16b_array 3328 ${b}.f_elements /\
-        Spec.Utils.is_i16b_array 3328 ${out}.f_elements "#))]
-#[hax_lib::ensures(|()| fstar!(r#"
+        Spec.Utils.is_i16b_array 3328 ${out}.f_elements "#)))]
+#[cfg_attr(hax, hax_lib::ensures(|()| fstar!(r#"
         Spec.Utils.is_i16b_array 3328 ${out}_future.f_elements /\
         Spec.Utils.modifies2_16 ${out}.f_elements ${out}_future.f_elements (sz 2 *! $i) ((sz 2 *! $i) +! sz 1) /\
-        ntt_multiply_binomials_post ${a} ${b} ${zeta} ${i} ${out}_future"#))]
+        ntt_multiply_binomials_post ${a} ${b} ${zeta} ${i} ${out}_future"#)))]
 pub(crate) fn ntt_multiply_binomials(
     a: &PortableVector,
     b: &PortableVector,
@@ -306,6 +320,7 @@ pub(crate) fn ntt_multiply_binomials(
     let aj = a.elements[2 * i + 1];
     let bj = b.elements[2 * i + 1];
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "assert(Spec.Utils.is_i16b 3328 $ai);
                      assert(Spec.Utils.is_i16b 3328 $bi);
@@ -314,28 +329,35 @@ pub(crate) fn ntt_multiply_binomials(
                      assert_norm (3328 * 3328 < pow2 31)"
     );
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bi"#);
 
     let ai_bi = (ai.as_i32()) * (bi.as_i32());
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bj"#);
 
     let aj_bj_ = (aj.as_i32()) * (bj.as_i32());
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 <= 3328 * pow2 15)"#);
 
     let aj_bj = montgomery_reduce_element(aj_bj_);
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 1664 $aj_bj $zeta"#);
 
     let aj_bj_zeta = (aj_bj.as_i32()) * (zeta.as_i32());
     let ai_bi_aj_bj = ai_bi + aj_bj_zeta;
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*1664) $ai_bi_aj_bj)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 1664 <= 3328 * pow2 15)"#);
 
     let o0 = montgomery_reduce_element(ai_bi_aj_bj);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"calc  ( == ) {
         v $o0 % 3329;
@@ -365,20 +387,25 @@ pub(crate) fn ntt_multiply_binomials(
         (((v $ai * v $bi) + ((v $aj * v $bj * 169 * v $zeta))) * 169) % 3329;
         }"#
     );
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $ai $bj"#);
 
     let ai_bj = (ai.as_i32()) * (bj.as_i32());
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"Spec.Utils.lemma_mul_i16b 3328 3328 $aj $bi"#);
 
     let aj_bi = (aj.as_i32()) * (bi.as_i32());
     let ai_bj_aj_bi = ai_bj + aj_bi;
 
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert(Spec.Utils.is_i32b (3328*3328 + 3328*3328) ai_bj_aj_bi) "#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert_norm (3328 * 3328 + 3328 * 3328 <= 3328 * pow2 15)"#);
 
     let o1 = montgomery_reduce_element(ai_bj_aj_bi);
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         "calc  ( == ) {
         v $o1 % 3329;
@@ -399,6 +426,7 @@ pub(crate) fn ntt_multiply_binomials(
     out.elements[2 * i] = o0;
     out.elements[2 * i + 1] = o1;
 
+    #[cfg(hax)]
     hax_lib::fstar!(
         r#"assert (Seq.index out.f_elements (2 * v i) == o0);
                      assert (Seq.index out.f_elements (2 * v i + 1) == o1);
@@ -410,14 +438,14 @@ pub(crate) fn ntt_multiply_binomials(
 }
 
 #[inline(always)]
-#[hax_lib::fstar::options("--z3rlimit 800 --split_queries always")]
-#[hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta0 /\
+#[cfg_attr(hax, hax_lib::fstar::options("--z3rlimit 800 --split_queries always"))]
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 $zeta0 /\
         Spec.Utils.is_i16b 1664 $zeta1 /\
         Spec.Utils.is_i16b 1664 $zeta2 /\
         Spec.Utils.is_i16b 1664 $zeta3 /\
         Spec.Utils.is_i16b_array 3328 ${lhs}.f_elements /\
-        Spec.Utils.is_i16b_array 3328 ${rhs}.f_elements "#))]
-#[hax_lib::ensures(|result| fstar!(r#"
+        Spec.Utils.is_i16b_array 3328 ${rhs}.f_elements "#)))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"
         Spec.Utils.is_i16b_array 3328 ${result}.f_elements /\
         (let nzeta0:i16 = Core_models.Ops.Arith.f_neg zeta0 in
          let nzeta1:i16 = Core_models.Ops.Arith.f_neg zeta1 in
@@ -436,7 +464,7 @@ pub(crate) fn ntt_multiply_binomials(
             ]
          in
          Spec.Utils.forall8 (fun i -> ntt_multiply_binomials_post ${lhs} ${rhs} (Seq.index zetas i) (sz i) $result))
-"#))]
+"#)))]
 pub(crate) fn ntt_multiply(
     lhs: &PortableVector,
     rhs: &PortableVector,
@@ -449,56 +477,98 @@ pub(crate) fn ntt_multiply(
     let nzeta1 = -zeta1;
     let nzeta2 = -zeta2;
     let nzeta3 = -zeta3;
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta0)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta1)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta2)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b 1664 nzeta3)"#);
     let mut out = zero();
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
     ntt_multiply_binomials(lhs, rhs, zeta0.classify(), 0, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
     ntt_multiply_binomials(lhs, rhs, nzeta0.classify(), 1, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
     ntt_multiply_binomials(lhs, rhs, zeta1.classify(), 2, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
     ntt_multiply_binomials(lhs, rhs, nzeta1.classify(), 3, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta1 (mk_usize 2) out)"#);
     ntt_multiply_binomials(lhs, rhs, zeta2.classify(), 4, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta1 (mk_usize 2) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta1 (mk_usize 3) out)"#);
     ntt_multiply_binomials(lhs, rhs, nzeta2.classify(), 5, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta1 (mk_usize 2) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta1 (mk_usize 3) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta2 (mk_usize 4) out)"#);
     ntt_multiply_binomials(lhs, rhs, zeta3.classify(), 6, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta1 (mk_usize 2) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta1 (mk_usize 3) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta2 (mk_usize 4) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta2 (mk_usize 5) out)"#);
     ntt_multiply_binomials(lhs, rhs, nzeta3.classify(), 7, &mut out);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (Spec.Utils.is_i16b_array 3328 out.f_elements)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta0 (mk_usize 0) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta0 (mk_usize 1) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta1 (mk_usize 2) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta1 (mk_usize 3) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta2 (mk_usize 4) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta2 (mk_usize 5) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs zeta3 (mk_usize 6) out)"#);
+    #[cfg(hax)]
     hax_lib::fstar!(r#"assert (ntt_multiply_binomials_post lhs rhs nzeta3 (mk_usize 7) out)"#);
     out
 }

--- a/libcrux-ml-kem/src/vector/portable/sampling.rs
+++ b/libcrux-ml-kem/src/vector/portable/sampling.rs
@@ -1,13 +1,14 @@
 use crate::vector::FIELD_MODULUS;
 
 #[inline(always)]
-#[hax_lib::requires(a.len() == 24 && result.len() == 16)]
-#[hax_lib::ensures(|res|
+#[cfg_attr(hax, hax_lib::requires(a.len() == 24 && result.len() == 16))]
+#[cfg_attr(hax, hax_lib::ensures(|res|
         fstar!(r#"Seq.length $result_future == Seq.length $result /\ v $res <= 16"#)
-    )]
+))]
 pub(crate) fn rej_sample(a: &[u8], result: &mut [i16]) -> usize {
     let mut sampled = 0;
     for i in 0..a.len() / 3 {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|i: usize| {
             fstar!(r#"Seq.length result == 16 /\ v $sampled <= v $i * 2"#)
         });

--- a/libcrux-ml-kem/src/vector/portable/serialize.rs
+++ b/libcrux-ml-kem/src/vector/portable/serialize.rs
@@ -12,8 +12,9 @@
 // we separate out the code that does the computation (in _int functions)
 // and code that updates arrays (in the outer functions).
 
-use super::vector_type::*;
 use libcrux_secrets::*;
+
+use super::vector_type::*;
 
 #[cfg_attr(
     hax,
@@ -141,9 +142,9 @@ let deserialize_1_lemma inputs =
 "
     )
 )]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 2}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_1(v: &[U8]) -> PortableVector {
     let result0 = (v[0] & 0x1).as_i16();
@@ -171,9 +172,9 @@ pub(crate) fn deserialize_1(v: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 8}
-"#))]
+"#)))]
 pub(crate) fn serialize_4_int(v: &[I16]) -> (U8, U8, U8, U8) {
     let result0 = ((v[1].as_u8()) << 4) | (v[0].as_u8());
     let result1 = ((v[3].as_u8()) << 4) | (v[2].as_u8());
@@ -238,9 +239,9 @@ pub(crate) fn serialize_4(v: PortableVector) -> [U8; 8] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 4}
-"#))]
+"#)))]
 pub(crate) fn deserialize_4_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16, I16, I16) {
     let v0 = (bytes[0] & 0x0F).as_i16();
     let v1 = ((bytes[0] >> 4) & 0x0F).as_i16();
@@ -308,9 +309,9 @@ let deserialize_4_lemma inputs =
 "
     )
 )]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 8}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_4(bytes: &[U8]) -> PortableVector {
     let v0_7 = deserialize_4_int(&bytes[0..4]);
@@ -324,9 +325,9 @@ pub(crate) fn deserialize_4(bytes: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 8}
-"#))]
+"#)))]
 pub(crate) fn serialize_5_int(v: &[I16]) -> (U8, U8, U8, U8, U8) {
     let r0 = (v[0] | v[1] << 5).as_u8();
     let r1 = (v[1] >> 3 | v[2] << 2 | v[3] << 7).as_u8();
@@ -346,9 +347,9 @@ pub(crate) fn serialize_5(v: PortableVector) -> [U8; 10] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 5}
-"#))]
+"#)))]
 pub(crate) fn deserialize_5_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16, I16, I16) {
     let v0 = (bytes[0] & 0x1F).as_i16();
     let v1 = ((bytes[1] & 0x3) << 3 | (bytes[0] >> 5)).as_i16();
@@ -361,9 +362,9 @@ pub(crate) fn deserialize_5_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16, 
     (v0, v1, v2, v3, v4, v5, v6, v7)
 }
 
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 10}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_5(bytes: &[U8]) -> PortableVector {
     let v0_7 = deserialize_5_int(&bytes[0..5]);
@@ -377,9 +378,9 @@ pub(crate) fn deserialize_5(bytes: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 4}
-"#))]
+"#)))]
 pub(crate) fn serialize_10_int(v: &[I16]) -> (U8, U8, U8, U8, U8) {
     let r0 = (v[0] & 0xFF).as_u8();
     let r1 = ((v[1] & 0x3F).as_u8()) << 2 | ((v[0] >> 8) & 0x03).as_u8();
@@ -441,9 +442,9 @@ pub(crate) fn serialize_10(v: PortableVector) -> [U8; 20] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 10}
-"#))]
+"#)))]
 pub(crate) fn deserialize_10_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16, I16, I16) {
     let r0 = ((bytes[1].as_i16() & 0x03) << 8 | (bytes[0].as_i16() & 0xFF)).as_i16();
     let r1 = ((bytes[2].as_i16() & 0x0F) << 6 | (bytes[1].as_i16() >> 2)).as_i16();
@@ -512,9 +513,9 @@ let deserialize_10_lemma inputs =
 "#
     )
 )]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 20}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_10(bytes: &[U8]) -> PortableVector {
     let v0_7 = deserialize_10_int(&bytes[0..10]);
@@ -528,9 +529,9 @@ pub(crate) fn deserialize_10(bytes: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 8}
-"#))]
+"#)))]
 pub(crate) fn serialize_11_int(v: &[I16]) -> (U8, U8, U8, U8, U8, U8, U8, U8, U8, U8, U8) {
     let r0 = v[0].as_u8();
     let r1 = ((v[1] & 0x1F).as_u8()) << 3 | ((v[0] >> 8).as_u8());
@@ -558,9 +559,9 @@ pub(crate) fn serialize_11(v: PortableVector) -> [U8; 22] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 11}
-"#))]
+"#)))]
 pub(crate) fn deserialize_11_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16, I16, I16) {
     let r0 = (bytes[1].as_i16() & 0x7) << 8 | bytes[0].as_i16();
     let r1 = (bytes[2].as_i16() & 0x3F) << 5 | (bytes[1].as_i16() >> 3);
@@ -575,9 +576,9 @@ pub(crate) fn deserialize_11_int(bytes: &[U8]) -> (I16, I16, I16, I16, I16, I16,
     (r0, r1, r2, r3, r4, r5, r6, r7)
 }
 
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 22}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_11(bytes: &[U8]) -> PortableVector {
     let v0_7 = deserialize_11_int(&bytes[0..11]);
@@ -591,9 +592,9 @@ pub(crate) fn deserialize_11(bytes: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${v.len() == 2}
-"#))]
+"#)))]
 pub(crate) fn serialize_12_int(v: &[I16]) -> (U8, U8, U8) {
     let r0 = (v[0] & 0xFF).as_u8();
     let r1 = ((v[0] >> 8) | ((v[1] & 0x0F) << 4)).as_u8();
@@ -658,9 +659,9 @@ pub(crate) fn serialize_12(v: PortableVector) -> [U8; 24] {
 }
 
 #[inline(always)]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 3}
-"#))]
+"#)))]
 pub(crate) fn deserialize_12_int(bytes: &[U8]) -> (I16, I16) {
     let byte0 = bytes[0].as_i16();
     let byte1 = bytes[1].as_i16();
@@ -726,9 +727,9 @@ let deserialize_12_lemma inputs =
 "
     )
 )]
-#[hax_lib::requires(fstar!(r#"
+#[cfg_attr(hax, hax_lib::requires(fstar!(r#"
      ${bytes.len() == 24}
-"#))]
+"#)))]
 #[inline(always)]
 pub(crate) fn deserialize_12(bytes: &[U8]) -> PortableVector {
     let v0_1 = deserialize_12_int(&bytes[0..3]);

--- a/libcrux-ml-kem/src/vector/portable/vector_type.rs
+++ b/libcrux-ml-kem/src/vector/portable/vector_type.rs
@@ -1,5 +1,6 @@
-use crate::vector::traits::FIELD_ELEMENTS_IN_VECTOR;
 use libcrux_secrets::*;
+
+use crate::vector::traits::FIELD_ELEMENTS_IN_VECTOR;
 
 /// Values having this type hold a representative 'x' of the ML-KEM field.
 /// We use 'fe' as a shorthand for this type.
@@ -11,7 +12,7 @@ pub struct PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Seq.create 16 (mk_i16 0)"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == Seq.create 16 (mk_i16 0)"#)))]
 pub fn zero() -> PortableVector {
     PortableVector {
         elements: [0i16; FIELD_ELEMENTS_IN_VECTOR].classify(),
@@ -19,15 +20,15 @@ pub fn zero() -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::ensures(|result| fstar!(r#"${result} == ${x}.f_elements"#))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result} == ${x}.f_elements"#)))]
 pub fn to_i16_array(x: PortableVector) -> [I16; 16] {
     x.elements
 }
 
 #[inline(always)]
-#[hax_lib::requires(array.len() == 16)]
-#[hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#))]
-#[hax_lib::fstar::verification_status(lax)]
+#[cfg_attr(hax, hax_lib::requires(array.len() == 16))]
+#[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"${result}.f_elements == $array"#)))]
+#[cfg_attr(hax, hax_lib::fstar::verification_status(lax))]
 pub fn from_i16_array(array: &[I16]) -> PortableVector {
     PortableVector {
         elements: array[0..16].try_into().unwrap(),
@@ -35,7 +36,7 @@ pub fn from_i16_array(array: &[I16]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(array.len() >= 32)]
+#[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
 pub(super) fn from_bytes(array: &[U8]) -> PortableVector {
     let mut elements = [I16(0); FIELD_ELEMENTS_IN_VECTOR];
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
@@ -45,13 +46,14 @@ pub(super) fn from_bytes(array: &[U8]) -> PortableVector {
 }
 
 #[inline(always)]
-#[hax_lib::requires(bytes.len() >= 32)]
-#[hax_lib::ensures(|_| future(bytes).len() == bytes.len())]
+#[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
+#[cfg_attr(hax, hax_lib::ensures(|_| future(bytes).len() == bytes.len()))]
 pub(super) fn to_bytes(x: PortableVector, bytes: &mut [U8]) {
     #[cfg(hax)]
     let _bytes_len = bytes.len();
 
     for i in 0..FIELD_ELEMENTS_IN_VECTOR {
+        #[cfg(hax)]
         hax_lib::loop_invariant!(|_i: usize| bytes.len() == _bytes_len);
         bytes[2 * i + 1] = (x.elements[i] >> 8).as_u8();
         bytes[2 * i] = x.elements[i].as_u8();

--- a/libcrux-ml-kem/src/vector/traits.rs
+++ b/libcrux-ml-kem/src/vector/traits.rs
@@ -10,9 +10,9 @@ pub const BARRETT_R: i32 = 1 << BARRETT_SHIFT;
 // The trait is duplicated for Eurydice to avoid the trait inheritance between Operations and Repr
 // This is needed because of this issue: https://github.com/AeneasVerif/eurydice/issues/111
 #[cfg(hax)]
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub trait Repr: Copy + Clone {
-    #[requires(true)]
+    #[cfg_attr(hax, hax_lib::requires(true))]
     fn repr(&self) -> [i16; 16];
 }
 
@@ -38,179 +38,179 @@ mod spec {
     }
 }
 
-#[hax_lib::attributes]
+#[cfg_attr(hax, hax_lib::attributes)]
 pub trait Operations: Copy + Clone + Repr {
     #[allow(non_snake_case)]
-    #[requires(true)]
-    #[ensures(|result| fstar!(r#"f_repr $result == Seq.create 16 (mk_i16 0)"#))]
+    #[cfg_attr(hax, hax_lib::requires(true))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"f_repr $result == Seq.create 16 (mk_i16 0)"#)))]
     fn ZERO() -> Self;
 
-    #[requires(array.len() == 16)]
-    #[ensures(|result| fstar!(r#"f_repr $result == $array"#))]
+    #[cfg_attr(hax, hax_lib::requires(array.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"f_repr $result == $array"#)))]
     fn from_i16_array(array: &[i16]) -> Self;
 
-    #[requires(true)]
-    #[ensures(|result| fstar!(r#"f_repr $x == $result"#))]
+    #[cfg_attr(hax, hax_lib::requires(true))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"f_repr $x == $result"#)))]
     fn to_i16_array(x: Self) -> [i16; 16];
 
-    #[requires(array.len() >= 32)]
+    #[cfg_attr(hax, hax_lib::requires(array.len() >= 32))]
     fn from_bytes(array: &[u8]) -> Self;
 
-    #[requires(bytes.len() >= 32)]
-    #[ensures(|_| future(bytes).len() == bytes.len())]
+    #[cfg_attr(hax, hax_lib::requires(bytes.len() >= 32))]
+    #[cfg_attr(hax, hax_lib::ensures(|_| future(bytes).len() == bytes.len()))]
     fn to_bytes(x: Self, bytes: &mut [u8]);
 
     // Basic arithmetic
-    #[requires(spec::add_pre(&lhs.repr(), &rhs.repr()))]
-    #[ensures(|result| spec::add_post(&lhs.repr(), &rhs.repr(), &result.repr()))]
+    #[cfg_attr(hax, hax_lib::requires(spec::add_pre(&lhs.repr(), &rhs.repr())))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| spec::add_post(&lhs.repr(), &rhs.repr(), &result.repr())))]
     fn add(lhs: Self, rhs: &Self) -> Self;
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (f_repr ${result}) i) == 
-         v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#))]
+         v (Seq.index (f_repr ${lhs}) i) - v (Seq.index (f_repr ${rhs}) i))"#)))]
     fn sub(lhs: Self, rhs: &Self) -> Self;
 
-    #[requires(fstar!(r#"forall i. i < 16 ==> 
-        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${vec}) i) * v c)"#))]
-    #[ensures(|result| fstar!(r#"forall i. i < 16 ==> 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall i. i < 16 ==> 
+        Spec.Utils.is_intb (pow2 15 - 1) (v (Seq.index (f_repr ${vec}) i) * v c)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall i. i < 16 ==> 
         (v (Seq.index (f_repr ${result}) i) == 
-         v (Seq.index (f_repr ${vec}) i) * v c)"#))]
+         v (Seq.index (f_repr ${vec}) i) * v c)"#)))]
     fn multiply_by_constant(vec: Self, c: i16) -> Self;
 
     // Modular operations
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (f_repr $v)"#))]
-    #[ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (f_repr $v)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array (pow2 12 - 1) (f_repr $v)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"f_repr $result == Spec.Utils.map_array (fun x -> if x >=. (mk_i16 3329) then x -! (mk_i16 3329) else x) (f_repr $v)"#)))]
     fn cond_subtract_3329(v: Self) -> Self;
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (f_repr $vector)"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 28296 (f_repr $vector)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr ${result}) /\
                 (forall i. (v (Seq.index (f_repr ${result}) i) % 3329) == 
-                           (v (Seq.index (f_repr ${vector})i) % 3329))"#))]
+                           (v (Seq.index (f_repr ${vector})i) % 3329))"#)))]
     fn barrett_reduce(vector: Self) -> Self;
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 constant"#))]
-    #[ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr ${result}) /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 constant"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr ${result}) /\
                 (forall i. i < 16 ==> ((v (Seq.index (f_repr ${result}) i) % 3329)==
-                                       (v (Seq.index (f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#))]
+                                       (v (Seq.index (f_repr ${vector}) i) * v ${constant} * 169) % 3329))"#)))]
     fn montgomery_multiply_by_constant(vector: Self, constant: i16) -> Self;
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr a)"#))]
-    #[ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==>
                                 (let x = Seq.index (f_repr ${a}) i in
                                  let y = Seq.index (f_repr ${result}) i in
-                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#))]
+                                 (v y >= 0 /\ v y <= 3328 /\ (v y % 3329 == v x % 3329)))"#)))]
     fn to_unsigned_representative(a: Self) -> Self;
 
     // Compression
-    #[requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
-        v (Seq.index (f_repr $a) i) < 3329"#))]
-    #[ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) 1"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
+        v (Seq.index (f_repr $a) i) < 3329"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) 1"#)))]
     fn compress_1(a: Self) -> Self;
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) /\
         (forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
-            v (Seq.index (f_repr $a) i) < 3329)"#))]
-    #[ensures(|result| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+            v (Seq.index (f_repr $a) i) < 3329)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
             v $COEFFICIENT_BITS == 5 \/
             v $COEFFICIENT_BITS == 10 \/
             v $COEFFICIENT_BITS == 11) ==>
-                (forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) (v $COEFFICIENT_BITS))"#))]
+                (forall (i:nat). i < 16 ==> bounded (Seq.index (f_repr $result) i) (v $COEFFICIENT_BITS))"#)))]
     fn compress<const COEFFICIENT_BITS: i32>(a: Self) -> Self;
 
-    #[hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==>
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"forall (i:nat). i < 16 ==>
                                     (let x = Seq.index (f_repr ${a}) i in 
-                                     (x == mk_i16 0 \/ x == mk_i16 1))"#))]
+                                     (x == mk_i16 0 \/ x == mk_i16 1))"#)))]
     fn decompress_1(a: Self) -> Self;
 
-    #[requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"(v $COEFFICIENT_BITS == 4 \/
         v $COEFFICIENT_BITS == 5 \/
         v $COEFFICIENT_BITS == 10 \/
         v $COEFFICIENT_BITS == 11) /\
     (forall (i:nat). i < 16 ==> v (Seq.index (f_repr $a) i) >= 0 /\
-        v (Seq.index (f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#))]
+        v (Seq.index (f_repr $a) i) < pow2 (v $COEFFICIENT_BITS))"#)))]
     fn decompress_ciphertext_coefficient<const COEFFICIENT_BITS: i32>(a: Self) -> Self;
 
     // NTT
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array (11207+5*3328) (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (11207+5*3328) (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+6*3328) (f_repr $out)"#)))]
     fn ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self;
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array (11207+4*3328) (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array (11207+4*3328) (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+5*3328) (f_repr $out)"#)))]
     fn ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self;
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
-                       Spec.Utils.is_i16b_array (11207+3*3328) (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta /\
+                       Spec.Utils.is_i16b_array (11207+3*3328) (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array (11207+4*3328) (f_repr $out)"#)))]
     fn ntt_layer_3_step(a: Self, zeta: i16) -> Self;
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\ 
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
-                       Spec.Utils.is_i16b_array (4 * 3328) (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array (4 * 3328) (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#)))]
     fn inv_ntt_layer_1_step(a: Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16) -> Self;
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
-                       Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+                       Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#)))]
     fn inv_ntt_layer_2_step(a: Self, zeta0: i16, zeta1: i16) -> Self;
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta/\
-                       Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta/\
+                       Spec.Utils.is_i16b_array 3328 (f_repr ${a})"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#)))]
     fn inv_ntt_layer_3_step(a: Self, zeta: i16) -> Self;
 
-    #[requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.Utils.is_i16b 1664 zeta0 /\ Spec.Utils.is_i16b 1664 zeta1 /\
                        Spec.Utils.is_i16b 1664 zeta2 /\ Spec.Utils.is_i16b 1664 zeta3 /\
                        Spec.Utils.is_i16b_array 3328 (f_repr ${lhs}) /\
-                       Spec.Utils.is_i16b_array 3328 (f_repr ${rhs}) "#))]
-    #[ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#))]
+                       Spec.Utils.is_i16b_array 3328 (f_repr ${rhs}) "#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|out| fstar!(r#"Spec.Utils.is_i16b_array 3328 (f_repr $out)"#)))]
     fn ntt_multiply(lhs: &Self, rhs: &Self, zeta0: i16, zeta1: i16, zeta2: i16, zeta3: i16)
         -> Self;
 
     // Serialization and deserialization
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a) ==> Spec.MLKEM.serialize_post 1 (f_repr $a) $result"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 1 (f_repr $a) ==> Spec.MLKEM.serialize_post 1 (f_repr $a) $result"#)))]
     fn serialize_1(a: Self) -> [u8; 2];
-    #[requires(a.len() == 2)]
-    #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (f_repr $result)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 2))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 2 ==> Spec.MLKEM.deserialize_post 1 $a (f_repr $result)"#)))]
     fn deserialize_1(a: &[u8]) -> Self;
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a) ==> Spec.MLKEM.serialize_post 4 (f_repr $a) $result"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 4 (f_repr $a) ==> Spec.MLKEM.serialize_post 4 (f_repr $a) $result"#)))]
     fn serialize_4(a: Self) -> [u8; 8];
-    #[requires(a.len() == 8)]
-    #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (f_repr $result)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 8))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 8 ==> Spec.MLKEM.deserialize_post 4 $a (f_repr $result)"#)))]
     fn deserialize_4(a: &[u8]) -> Self;
 
     fn serialize_5(a: Self) -> [u8; 10];
-    #[requires(a.len() == 10)]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 10))]
     fn deserialize_5(a: &[u8]) -> Self;
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a) ==> Spec.MLKEM.serialize_post 10 (f_repr $a) $result"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 10 (f_repr $a) ==> Spec.MLKEM.serialize_post 10 (f_repr $a) $result"#)))]
     fn serialize_10(a: Self) -> [u8; 20];
-    #[requires(a.len() == 20)]
-    #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (f_repr $result)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 20))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 20 ==> Spec.MLKEM.deserialize_post 10 $a (f_repr $result)"#)))]
     fn deserialize_10(a: &[u8]) -> Self;
 
     fn serialize_11(a: Self) -> [u8; 22];
-    #[requires(a.len() == 22)]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 22))]
     fn deserialize_11(a: &[u8]) -> Self;
 
-    #[requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a)"#))]
-    #[ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a) ==> Spec.MLKEM.serialize_post 12 (f_repr $a) $result"#))]
+    #[cfg_attr(hax, hax_lib::requires(fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a)"#)))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"Spec.MLKEM.serialize_pre 12 (f_repr $a) ==> Spec.MLKEM.serialize_post 12 (f_repr $a) $result"#)))]
     fn serialize_12(a: Self) -> [u8; 24];
-    #[requires(a.len() == 24)]
-    #[ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (f_repr $result)"#))]
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 24))]
+    #[cfg_attr(hax, hax_lib::ensures(|result| fstar!(r#"sz (Seq.length $a) =. sz 24 ==> Spec.MLKEM.deserialize_post 12 $a (f_repr $result)"#)))]
     fn deserialize_12(a: &[u8]) -> Self;
 
-    #[requires(a.len() == 24 && out.len() == 16)]
-    #[ensures(|result|
+    #[cfg_attr(hax, hax_lib::requires(a.len() == 24 && out.len() == 16))]
+    #[cfg_attr(hax, hax_lib::ensures(|result|
         fstar!(r#"Seq.length $out_future == Seq.length $out /\ v $result <= 16"#)
-    )]
+    ))]
     fn rej_sample(a: &[u8], out: &mut [i16]) -> usize;
 }


### PR DESCRIPTION
This PR makes `hax-lib` a `target.'cfg(hax)` dependency in `libcrux-intrinsics`, `libcrux-secrets`, `libcrux-sha3`, `libcrux-kmac`, `libcrux-ml-kem`, `libcrux-ml-dsa` and the main `libcrux` crate.
The one other crate that depends on `hax_lib`, `core-models`, is already a `target.'cfg(hax)` dependency in `libcrux-ml-dsa`, the only place where it is used. Therefore I did not touch it.

Default-feature builds on my machine of the crates listed above seem to work. So far so good!

TODO:
- [x] Validate functional builds beyond default features and for all target architectures. (I don't anticipate problems here, but want to make sure.)
- [x] Validate `cfg(hax)` builds still work and result in good extractions to F*.
- [ ] Look into #1341 while checking on the quality of F* extractions

Resolves #1575 

[skip changelog]