### PR TITLE
Fallible rng

### DIFF
--- a/crates/algorithms/ecdsa/CHANGELOG.md
+++ b/crates/algorithms/ecdsa/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): `PrivateKey::public_key` to derive the public key from a P-256 private key
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): `p256::rand::generate_key_pair` to generate a full P-256 key pair
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Widened the RNG bound on `rand`-feature functions from `CryptoRng` to
+  `TryCryptoRng` to support fallible RNGs
+
 ## [0.0.8] (2026-07-15)
 
 ### Changed

--- a/crates/algorithms/ecdsa/src/p256.rs
+++ b/crates/algorithms/ecdsa/src/p256.rs
@@ -1,9 +1,9 @@
 //! ECDSA on P-256
 
 use libcrux_p256::{
-    compressed_to_raw, ecdsa_sign_p256_sha2, ecdsa_sign_p256_sha384, ecdsa_sign_p256_sha512,
-    ecdsa_verif_p256_sha2, ecdsa_verif_p256_sha384, ecdsa_verif_p256_sha512, uncompressed_to_raw,
-    validate_private_key, validate_public_key,
+    compressed_to_raw, dh_initiator, ecdsa_sign_p256_sha2, ecdsa_sign_p256_sha384,
+    ecdsa_sign_p256_sha512, ecdsa_verif_p256_sha2, ecdsa_verif_p256_sha384,
+    ecdsa_verif_p256_sha512, uncompressed_to_raw, validate_private_key, validate_public_key,
 };
 
 use super::Error;
@@ -74,6 +74,18 @@ mod conversions {
     impl AsRef<[u8; 32]> for PrivateKey {
         fn as_ref(&self) -> &[u8; 32] {
             &self.0
+        }
+    }
+
+    impl PrivateKey {
+        /// Compute the [`PublicKey`] corresponding to this [`PrivateKey`].
+        pub fn public_key(&self) -> Result<PublicKey, Error> {
+            let mut public_key = [0u8; 64];
+            if dh_initiator(&mut public_key, &self.0) {
+                Ok(PublicKey(public_key))
+            } else {
+                Err(Error::InvalidScalar)
+            }
         }
     }
 
@@ -194,7 +206,7 @@ fn validate_private_key_slice(scalar: &[u8]) -> Result<PrivateKey, Error> {
 /// Prepare the nonce for EcDSA and validate the key
 #[cfg(feature = "rand")]
 pub mod rand {
-    use ::rand::CryptoRng;
+    use ::rand::TryCryptoRng;
 
     use super::*;
     use crate::RAND_LIMIT;
@@ -205,7 +217,7 @@ pub mod rand {
     ///
     /// Use [`Nonce::random`] or [`PrivateKey::random`] to generate a nonce or
     /// a private key instead.
-    pub fn random_scalar(rng: &mut impl CryptoRng) -> Result<[u8; 32], Error> {
+    pub fn random_scalar(rng: &mut impl TryCryptoRng) -> Result<[u8; 32], Error> {
         let mut value = [0u8; 32];
         for _ in 0..RAND_LIMIT {
             rng.try_fill_bytes(&mut value)
@@ -221,16 +233,25 @@ pub mod rand {
 
     impl Nonce {
         /// Generate a random nonce for ECDSA.
-        pub fn random(rng: &mut impl CryptoRng) -> Result<Self, Error> {
+        pub fn random(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
             random_scalar(rng).map(|s| Self(s))
         }
     }
 
     impl PrivateKey {
         /// Generate a random [`PrivateKey`] for ECDSA.
-        pub fn random(rng: &mut impl CryptoRng) -> Result<Self, Error> {
+        pub fn random(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
             random_scalar(rng).map(|s| Self(s))
         }
+    }
+
+    /// Generate a new ECDSA P-256 key pair.
+    pub fn generate_key_pair(
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<(PrivateKey, PublicKey), Error> {
+        let private_key = PrivateKey::random(rng)?;
+        let public_key = private_key.public_key()?;
+        Ok((private_key, public_key))
     }
 
     /// Sign the `payload` with the `private_key`.
@@ -238,7 +259,7 @@ pub mod rand {
         hash: DigestAlgorithm,
         payload: &[u8],
         private_key: &PrivateKey,
-        rng: &mut impl CryptoRng,
+        rng: &mut impl TryCryptoRng,
     ) -> Result<Signature, Error> {
         let nonce = Nonce(random_scalar(rng)?);
 

--- a/crates/algorithms/ecdsa/tests/self.rs
+++ b/crates/algorithms/ecdsa/tests/self.rs
@@ -7,9 +7,64 @@ mod rand {
         *,
     };
     use rand::rngs::SysRng;
-    use rand_core::UnwrapErr;
+    use rand_core::{TryRng, UnwrapErr};
 
     use crate::util::*;
+
+    /// An RNG that always fails, to exercise the fallible-`TryCryptoRng`
+    /// error path.
+    struct AlwaysFailingRng;
+
+    #[derive(Debug)]
+    struct AlwaysFailingError;
+
+    impl core::fmt::Display for AlwaysFailingError {
+        fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+            write!(f, "always fails")
+        }
+    }
+
+    impl core::error::Error for AlwaysFailingError {}
+
+    impl TryRng for AlwaysFailingRng {
+        type Error = AlwaysFailingError;
+
+        fn try_next_u32(&mut self) -> Result<u32, Self::Error> {
+            Err(AlwaysFailingError)
+        }
+
+        fn try_next_u64(&mut self) -> Result<u64, Self::Error> {
+            Err(AlwaysFailingError)
+        }
+
+        fn try_fill_bytes(&mut self, _dst: &mut [u8]) -> Result<(), Self::Error> {
+            Err(AlwaysFailingError)
+        }
+    }
+
+    impl rand::TryCryptoRng for AlwaysFailingRng {}
+
+    #[test]
+    fn generate_key_pair_and_sign_verify() {
+        let mut rng = UnwrapErr(SysRng);
+
+        let (sk, pk) = p256::rand::generate_key_pair(&mut rng).unwrap();
+        assert_eq!(&sk.public_key().unwrap().0, &pk.0);
+
+        let msg = b"a message to sign";
+        let sig = p256::rand::sign(DigestAlgorithm::Sha256, msg, &sk, &mut rng).unwrap();
+        p256::verify(DigestAlgorithm::Sha256, msg, &sig, &pk).unwrap();
+    }
+
+    #[test]
+    fn fallible_rng_error_propagates() {
+        let mut rng = AlwaysFailingRng;
+        let error = match p256::rand::generate_key_pair(&mut rng) {
+            Ok(_) => panic!("the RNG always fails, so key generation must fail too"),
+            Err(error) => error,
+        };
+        assert!(matches!(error, Error::RandError));
+    }
 
     #[test]
     fn test_self() {

--- a/crates/algorithms/ed25519/CHANGELOG.md
+++ b/crates/algorithms/ed25519/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Widened the RNG bound on `generate_key_pair` from `CryptoRng` to
+  `TryCryptoRng` to support fallible RNGs
+
 ## [0.0.9] (2026-07-15)
 
 ### Changed

--- a/crates/algorithms/ed25519/src/impl_hacl.rs
+++ b/crates/algorithms/ed25519/src/impl_hacl.rs
@@ -116,7 +116,7 @@ pub fn secret_to_public(pk: &mut [u8; 32], sk: &[u8; 32]) {
 
 #[cfg(feature = "rand")]
 pub fn generate_key_pair(
-    rng: &mut impl rand_core::CryptoRng,
+    rng: &mut impl rand_core::TryCryptoRng,
 ) -> Result<(SigningKey, VerificationKey), Error> {
     const LIMIT: usize = 100;
     let mut sk = [0u8; 32];

--- a/libcrux-ecdh/CHANGELOG.md
+++ b/libcrux-ecdh/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Widened the RNG bound on key generation functions from `CryptoRng` to
+  `TryCryptoRng` to support fallible RNGs
+
 ## [0.0.8] (2026-07-15)
 
 ### Added

--- a/libcrux-ecdh/src/ecdh.rs
+++ b/libcrux-ecdh/src/ecdh.rs
@@ -141,13 +141,13 @@ pub fn validate_scalar(alg: Algorithm, s: impl AsRef<[u8]>) -> Result<(), Error>
     }
 }
 
-use rand::{CryptoRng, Rng};
+use rand::TryCryptoRng;
 
 /// Generate a new private key scalar.
 ///
 /// The function returns the new scalar or an [`Error::KeyGenError`] if it was unable to
 /// generate a new key. If this happens, the provided `rng` is probably faulty.
-pub fn generate_secret(alg: Algorithm, rng: &mut (impl CryptoRng + Rng)) -> Result<Vec<u8>, Error> {
+pub fn generate_secret(alg: Algorithm, rng: &mut impl TryCryptoRng) -> Result<Vec<u8>, Error> {
     match alg {
         Algorithm::X25519 => x25519::generate_secret(rng).map(|k| k.0.to_vec()),
         Algorithm::P256 => p256_internal::generate_secret(rng).map(|k| k.0.to_vec()),
@@ -158,10 +158,7 @@ pub fn generate_secret(alg: Algorithm, rng: &mut (impl CryptoRng + Rng)) -> Resu
 /// Generate a fresh key pair.
 ///
 /// The function returns the (secret key, public key) tuple, or an [`Error`].
-pub fn key_gen(
-    alg: Algorithm,
-    rng: &mut (impl CryptoRng + Rng),
-) -> Result<(Vec<u8>, Vec<u8>), Error> {
+pub fn key_gen(alg: Algorithm, rng: &mut impl TryCryptoRng) -> Result<(Vec<u8>, Vec<u8>), Error> {
     let sk = generate_secret(alg, rng)?;
     let pk = secret_to_public(alg, &sk)?;
     Ok((sk, pk))

--- a/libcrux-ecdh/src/p256_internal.rs
+++ b/libcrux-ecdh/src/p256_internal.rs
@@ -1,6 +1,6 @@
 use alloc::format;
 
-use rand::{CryptoRng, Rng};
+use rand::TryCryptoRng;
 
 use super::Error;
 // P256 we only have in HACL
@@ -153,7 +153,7 @@ pub(crate) fn prepare_public_key(public_key: &[u8]) -> Result<PublicKey, Error> 
 }
 
 /// Generate a new p256 secret (scalar)
-pub fn generate_secret(rng: &mut (impl CryptoRng + Rng)) -> Result<PrivateKey, Error> {
+pub fn generate_secret(rng: &mut impl TryCryptoRng) -> Result<PrivateKey, Error> {
     const LIMIT: usize = 100;
     for _ in 0..LIMIT {
         let mut out = [0u8; 32];
@@ -169,7 +169,7 @@ pub fn generate_secret(rng: &mut (impl CryptoRng + Rng)) -> Result<PrivateKey, E
 }
 
 /// Generate a new P256 key pair
-pub fn key_gen(rng: &mut (impl CryptoRng + Rng)) -> Result<(PrivateKey, PublicKey), Error> {
+pub fn key_gen(rng: &mut impl TryCryptoRng) -> Result<(PrivateKey, PublicKey), Error> {
     let sk = generate_secret(rng)?;
     let pk = secret_to_public(&sk)?;
     Ok((sk, pk))

--- a/libcrux-ecdh/src/x25519.rs
+++ b/libcrux-ecdh/src/x25519.rs
@@ -2,7 +2,7 @@
 
 use alloc::format;
 
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 
 use super::Error;
 
@@ -126,7 +126,7 @@ pub fn secret_to_public(s: &PrivateKey) -> Result<PublicKey, Error> {
 }
 
 /// Generate a new x25519 secret.
-pub fn generate_secret(rng: &mut impl CryptoRng) -> Result<PrivateKey, Error> {
+pub fn generate_secret(rng: &mut impl TryCryptoRng) -> Result<PrivateKey, Error> {
     const LIMIT: usize = 100;
     for _ in 0..LIMIT {
         let mut out = [0u8; 32];
@@ -154,7 +154,7 @@ fn clamp(scalar: &mut [u8; 32]) {
 }
 
 /// Generate a new P256 key pair
-pub fn key_gen(rng: &mut impl CryptoRng) -> Result<(PrivateKey, PublicKey), Error> {
+pub fn key_gen(rng: &mut impl TryCryptoRng) -> Result<(PrivateKey, PublicKey), Error> {
     let sk = generate_secret(rng)?;
     let pk = secret_to_public(&sk)?;
     Ok((sk, pk))

--- a/libcrux-kem/CHANGELOG.md
+++ b/libcrux-kem/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [#1560](https://github.com/celabshq/libcrux/pull/1560): Reject malformed hybrid key encodings without panicking
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Widened the RNG bound on `key_gen`, `PublicKey::encapsulate` from
+  `CryptoRng` to `TryCryptoRng` to support fallible RNGs
+
 ## [0.0.9] (2026-07-15)
 
 ### Changed

--- a/libcrux-kem/src/kem.rs
+++ b/libcrux-kem/src/kem.rs
@@ -47,7 +47,7 @@ use libcrux_ecdh::{
 };
 use libcrux_ml_kem::{mlkem1024, mlkem512, mlkem768};
 use libcrux_sha3 as sha3;
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 #[cfg(feature = "codec")]
 use tls_codec::{TlsDeserialize, TlsSerialize, TlsSize};
 
@@ -450,7 +450,7 @@ impl PrivateKey {
 
 impl PublicKey {
     /// Encapsulate a shared secret to the provided `pk` and return the `(Key, Enc)` tuple.
-    pub fn encapsulate(&self, rng: &mut impl CryptoRng) -> Result<(Ss, Ct), Error> {
+    pub fn encapsulate(&self, rng: &mut impl TryCryptoRng) -> Result<(Ss, Ct), Error> {
         match self {
             PublicKey::X25519(pk) => {
                 let (new_sk, new_pk) = libcrux_ecdh::x25519_key_gen(rng)?;
@@ -753,12 +753,12 @@ pub fn secret_to_public(alg: Algorithm, sk: impl AsRef<[u8]>) -> Result<Vec<u8>,
 }
 
 fn gen_mlkem768(
-    rng: &mut impl CryptoRng,
+    rng: &mut impl TryCryptoRng,
 ) -> Result<(MlKem768PrivateKey, MlKem768PublicKey), Error> {
     Ok(mlkem768::generate_key_pair(random_array(rng)?).into_parts())
 }
 
-fn random_array<const L: usize>(rng: &mut impl CryptoRng) -> Result<[u8; L], Error> {
+fn random_array<const L: usize>(rng: &mut impl TryCryptoRng) -> Result<[u8; L], Error> {
     let mut seed = [0; L];
     rng.try_fill_bytes(&mut seed).map_err(|_| Error::KeyGen)?;
     Ok(seed)
@@ -769,7 +769,10 @@ fn random_array<const L: usize>(rng: &mut impl CryptoRng) -> Result<[u8; L], Err
 /// The function returns a fresh key or a [`Error::KeyGen`] error if
 /// * not enough entropy was available
 /// * it was not possible to generate a valid key within a reasonable amount of iterations.
-pub fn key_gen(alg: Algorithm, rng: &mut impl CryptoRng) -> Result<(PrivateKey, PublicKey), Error> {
+pub fn key_gen(
+    alg: Algorithm,
+    rng: &mut impl TryCryptoRng,
+) -> Result<(PrivateKey, PublicKey), Error> {
     match alg {
         Algorithm::X25519 => libcrux_ecdh::x25519_key_gen(rng)
             .map_err(|e| e.into())
@@ -807,7 +810,7 @@ pub fn key_gen(alg: Algorithm, rng: &mut impl CryptoRng) -> Result<(PrivateKey, 
 
         Algorithm::XWingKemDraft06 => {
             let mut seed = [0u8; 32];
-            rng.fill_bytes(&mut seed);
+            rng.try_fill_bytes(&mut seed).map_err(|_| Error::KeyGen)?;
 
             let (kp_m, pk_x, _) = xwing::expand_decap_key(&seed)?;
 
@@ -1083,7 +1086,9 @@ mod xwing {
     }
 }
 
-fn mlkem_rand(rng: &mut impl CryptoRng) -> Result<[u8; libcrux_ml_kem::SHARED_SECRET_SIZE], Error> {
+fn mlkem_rand(
+    rng: &mut impl TryCryptoRng,
+) -> Result<[u8; libcrux_ml_kem::SHARED_SECRET_SIZE], Error> {
     let mut seed = [0; libcrux_ml_kem::SHARED_SECRET_SIZE];
     rng.try_fill_bytes(&mut seed).map_err(|_| Error::KeyGen)?;
     Ok(seed)

--- a/libcrux-ml-kem/CHANGELOG.md
+++ b/libcrux-ml-kem/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Widened the RNG bound on `pqcp::crypto_kem_keypair`, `pqcp::crypto_kem_enc`,
+  `pqcp::crypto_kem_enc_struct`, and `incremental::rand::encapsulate1` from
+  `CryptoRng` to `TryCryptoRng` to support fallible RNGs
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): (Breaking) Widened the RNG bound on
+  `incremental::KeyPairCompressedBytes::generate` from `CryptoRng` to `TryCryptoRng`; it now
+  returns `Result<Self, Error>` instead of `Self`, matching `incremental::KeyPairBytes::generate`
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): (Breaking) Widened the RNG bound on
+  `pqcp::crypto_kem_keypair_struct` from `CryptoRng` to `TryCryptoRng`; it now returns
+  `Result<(), PQCPError>` instead of `()`, matching `pqcp::crypto_kem_keypair` and
+  `pqcp::crypto_kem_enc_struct`
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): (Breaking) Widened the RNG bound on
+  `mlkem512::rand::generate_key_pair`, `mlkem512::rand::encapsulate`,
+  `mlkem768::rand::generate_key_pair`, `mlkem768::rand::encapsulate`,
+  `mlkem1024::rand::generate_key_pair`, and `mlkem1024::rand::encapsulate` from `CryptoRng` to
+  `TryCryptoRng`; they now return `Result<_, libcrux_traits::kem::KEMError>` instead of the bare
+  value
+
+### Fixed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Fixed a pre-existing build failure when combining the `incremental` and
+  `rand` features, caused by `RngCore`/`TryRngCore` no longer being
+  re-exported from `rand`'s crate root as of `rand` 0.10
+
 ## [0.0.10] (2026-07-15)
 
 ### Changed

--- a/libcrux-ml-kem/src/lib.rs
+++ b/libcrux-ml-kem/src/lib.rs
@@ -70,6 +70,25 @@ pub use ind_cca::{MlKemSharedSecret, ENCAPS_SEED_SIZE, KEY_GENERATION_SEED_SIZE}
 // These types all have type aliases for the different variants.
 pub use types::{MlKemCiphertext, MlKemKeyPair, MlKemPrivateKey, MlKemPublicKey};
 
+/// The random number generator failed to provide sufficient randomness.
+///
+/// This is the only failure mode of the `rand` APIs: ML-KEM key generation,
+/// encapsulation, and decapsulation are otherwise infallible.
+#[cfg(all(not(eurydice), feature = "rand"))]
+#[cfg_attr(docsrs, doc(cfg(feature = "rand")))]
+#[derive(Debug)]
+pub struct RandomnessError;
+
+#[cfg(all(not(any(eurydice, hax)), feature = "rand"))]
+impl core::fmt::Display for RandomnessError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("the random number generator failed to provide sufficient randomness")
+    }
+}
+
+#[cfg(all(not(any(eurydice, hax)), feature = "rand"))]
+impl core::error::Error for RandomnessError {}
+
 cfg_kyber! {
     #[cfg(feature = "mlkem512")]
     #[cfg_attr(docsrs, doc(cfg(all(feature = "kyber", feature = "mlkem512"))))]

--- a/libcrux-ml-kem/src/mlkem.rs
+++ b/libcrux-ml-kem/src/mlkem.rs
@@ -158,7 +158,7 @@ macro_rules! impl_incr_key_size {
         }
 
         #[cfg(all(not(eurydice), feature = "rand"))]
-        use ::rand::{CryptoRng, RngCore};
+        use ::rand::TryCryptoRng;
 
         impl KeyPairBytes {
             /// Generate a new key pair.
@@ -174,14 +174,15 @@ macro_rules! impl_incr_key_size {
             /// Generate a new key pair.
             /// This uses unpacked keys and does not compress the keys.
             #[cfg(all(not(eurydice), feature = "rand"))]
-            pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+            pub fn generate(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
                 let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-                rng.fill_bytes(&mut randomness);
+                rng.try_fill_bytes(&mut randomness)
+                    .map_err(|_| Error::InsufficientRandomness)?;
                 let mut out = Self {
                     value: [0u8; key_pair_len()]
                 };
                 generate_key_pair(randomness, &mut out.value).unwrap();
-                out
+                Ok(out)
             }
 
             /// Get the raw bytes.
@@ -248,14 +249,15 @@ macro_rules! impl_incr_key_size {
             /// Generate a new key pair.
             /// This uses unpacked keys and does not compress the keys.
             #[cfg(all(not(eurydice), feature = "rand"))]
-            pub fn generate(rng: &mut (impl RngCore + CryptoRng)) -> Self {
+            pub fn generate(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
                 let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-                rng.fill_bytes(&mut randomness);
+                rng.try_fill_bytes(&mut randomness)
+                    .map_err(|_| Error::InsufficientRandomness)?;
                 let mut out = Self {
                     value: [0u8; key_pair_compressed_len()]
                 };
                 generate_key_pair_compressed(randomness, &mut out.value);
-                out
+                Ok(out)
             }
 
             /// Get the raw bytes.
@@ -369,7 +371,6 @@ macro_rules! impl_incr_key_size {
         #[cfg(feature = "rand")]
         pub mod rand {
             use super::*;
-            use ::rand::TryRngCore;
 
             /// Encapsulate the first part of the ciphertext.
             ///
@@ -377,7 +378,7 @@ macro_rules! impl_incr_key_size {
             /// the appropriate sizes.
             pub fn encapsulate1(
                 pk1: &[u8],
-                rng: &mut impl CryptoRng,
+                rng: &mut impl ::rand::TryCryptoRng,
                 state: &mut [u8],
                 shared_secret: &mut [u8],
             ) -> Result<Ciphertext1, Error> {

--- a/libcrux-ml-kem/src/mlkem1024.rs
+++ b/libcrux-ml-kem/src/mlkem1024.rs
@@ -473,7 +473,7 @@ pub fn validate_private_key(
 ///
 /// This function returns an [`MlKem1024KeyPair`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let ((secret_key, public_key), valid) = Spec.MLKEM.Instances.mlkem1024_generate_keypair $randomness in
         valid ==> (${res}.f_sk.f_value == secret_key /\ ${res}.f_pk.f_value == public_key)"#)
@@ -497,7 +497,7 @@ pub fn generate_key_pair(
 /// The input is a reference to an [`MlKem1024PublicKey`] and [`SHARED_SECRET_SIZE`]
 /// bytes of `randomness`.
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let ((ciphertext, shared_secret), valid) = Spec.MLKEM.Instances.mlkem1024_encapsulate ${public_key}.f_value $randomness in
         let (res_ciphertext, res_shared_secret) = $res in
@@ -529,7 +529,7 @@ pub fn encapsulate(
 /// Generates an [`MlKemSharedSecret`].
 /// The input is a reference to an [`MlKem1024PrivateKey`] and an [`MlKem1024Ciphertext`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let (shared_secret, valid) = Spec.MLKEM.Instances.mlkem1024_decapsulate ${private_key}.f_value ${ciphertext}.f_value in
         valid ==> $res == shared_secret"#)
@@ -562,46 +562,52 @@ pub fn decapsulate(
 ///
 /// The functions in this module are equivalent to the one in the main module,
 /// but sample their own randomness, provided a random number generator that
-/// implements `CryptoRng`.
+/// implements `TryCryptoRng`.
 ///
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
 pub mod rand {
     use super::{
         MlKem1024Ciphertext, MlKem1024KeyPair, MlKem1024PublicKey, MlKemSharedSecret,
-        KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
+        RandomnessError, KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
     };
-    use ::rand::CryptoRng;
+    use ::rand::TryCryptoRng;
 
     /// Generate ML-KEM 1024 Key Pair
     ///
-    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// The random number generator `rng` needs to implement `TryCryptoRng`
     /// to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem1024KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
-    pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem1024KeyPair {
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
+    pub fn generate_key_pair(
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<MlKem1024KeyPair, RandomnessError> {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::generate_key_pair(randomness)
+        Ok(super::generate_key_pair(randomness))
     }
 
     /// Encapsulate ML-KEM 1024
     ///
     /// Generates an ([`MlKem1024Ciphertext`], [`MlKemSharedSecret`]) tuple.
     /// The input is a reference to an [`MlKem1024PublicKey`].
-    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// The random number generator `rng` needs to implement `TryCryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
     pub fn encapsulate(
         public_key: &MlKem1024PublicKey,
-        rng: &mut impl CryptoRng,
-    ) -> (MlKem1024Ciphertext, MlKemSharedSecret) {
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<(MlKem1024Ciphertext, MlKemSharedSecret), RandomnessError> {
         let mut randomness = [0u8; SHARED_SECRET_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::encapsulate(public_key, randomness)
+        Ok(super::encapsulate(public_key, randomness))
     }
 }
 

--- a/libcrux-ml-kem/src/mlkem512.rs
+++ b/libcrux-ml-kem/src/mlkem512.rs
@@ -464,7 +464,7 @@ pub fn validate_private_key(
 ///
 /// This function returns an [`MlKem512KeyPair`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let ((secret_key, public_key), valid) = Spec.MLKEM.Instances.mlkem512_generate_keypair $randomness in
         valid ==> (${res}.f_sk.f_value == secret_key /\ ${res}.f_pk.f_value == public_key)"#)
@@ -486,7 +486,7 @@ pub fn generate_key_pair(randomness: [u8; KEY_GENERATION_SEED_SIZE]) -> MlKem512
 /// The input is a reference to an [`MlKem512PublicKey`] and [`SHARED_SECRET_SIZE`]
 /// bytes of `randomness`.
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let ((ciphertext, shared_secret), valid) = Spec.MLKEM.Instances.mlkem512_encapsulate ${public_key}.f_value $randomness in
         let (res_ciphertext, res_shared_secret) = $res in
@@ -518,7 +518,7 @@ pub fn encapsulate(
 /// Generates an [`MlKemSharedSecret`].
 /// The input is a reference to an [`MlKem512PrivateKey`] and an [`MlKem512Ciphertext`].
 #[cfg(not(eurydice))]
-#[hax_lib::fstar::verification_status(panic_free)]
+#[hax_lib::opaque]
 #[hax_lib::ensures(|res|
     fstar!(r#"let (shared_secret, valid) = Spec.MLKEM.Instances.mlkem512_decapsulate ${private_key}.f_value ${ciphertext}.f_value in
         valid ==> $res == shared_secret"#)
@@ -551,7 +551,7 @@ pub fn decapsulate(
 ///
 /// The functions in this module are equivalent to the one in the main module,
 /// but sample their own randomness, provided a random number generator that
-/// implements `CryptoRng`.
+/// implements `TryCryptoRng`.
 ///
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
@@ -560,37 +560,44 @@ pub mod rand {
         MlKem512Ciphertext, MlKem512KeyPair, MlKem512PublicKey, MlKemSharedSecret,
         KEY_GENERATION_SEED_SIZE, SHARED_SECRET_SIZE,
     };
-    use ::rand::CryptoRng;
+    use crate::RandomnessError;
+    use ::rand::TryCryptoRng;
 
     /// Generate ML-KEM 512 Key Pair
     ///
     /// The random number generator `rng` needs to implement
-    /// `CryptoRng` to sample the required randomness internally.
+    /// `TryCryptoRng` to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem512KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
-    pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem512KeyPair {
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
+    pub fn generate_key_pair(
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<MlKem512KeyPair, RandomnessError> {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::generate_key_pair(randomness)
+        Ok(super::generate_key_pair(randomness))
     }
 
     /// Encapsulate ML-KEM 512
     ///
     /// Generates an ([`MlKem512Ciphertext`], [`MlKemSharedSecret`]) tuple.
     /// The input is a reference to an [`MlKem512PublicKey`].
-    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// The random number generator `rng` needs to implement `TryCryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
     pub fn encapsulate(
         public_key: &MlKem512PublicKey,
-        rng: &mut impl CryptoRng,
-    ) -> (MlKem512Ciphertext, MlKemSharedSecret) {
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<(MlKem512Ciphertext, MlKemSharedSecret), RandomnessError> {
         let mut randomness = [0u8; SHARED_SECRET_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::encapsulate(public_key, randomness)
+        Ok(super::encapsulate(public_key, randomness))
     }
 }
 

--- a/libcrux-ml-kem/src/mlkem768.rs
+++ b/libcrux-ml-kem/src/mlkem768.rs
@@ -533,12 +533,13 @@ pub fn decapsulate(
 ///
 /// The functions in this module are equivalent to the one in the main module,
 /// but sample their own randomness, provided a random number generator that
-/// implements `CryptoRng`.
+/// implements `TryCryptoRng`.
 ///
 /// Decapsulation is not provided in this module as it does not require randomness.
 #[cfg(all(not(eurydice), feature = "rand"))]
 pub mod rand {
-    use ::rand::CryptoRng;
+    use crate::RandomnessError;
+    use ::rand::TryCryptoRng;
 
     use super::{
         MlKem768Ciphertext, MlKem768KeyPair, MlKem768PublicKey, MlKemSharedSecret,
@@ -547,33 +548,39 @@ pub mod rand {
 
     /// Generate ML-KEM 768 Key Pair
     ///
-    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// The random number generator `rng` needs to implement `TryCryptoRng`
     /// to sample the required randomness internally.
     ///
     /// This function returns an [`MlKem768KeyPair`].
-    #[hax_lib::fstar::verification_status(lax)]
-    pub fn generate_key_pair(rng: &mut impl CryptoRng) -> MlKem768KeyPair {
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
+    pub fn generate_key_pair(
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<MlKem768KeyPair, RandomnessError> {
         let mut randomness = [0u8; KEY_GENERATION_SEED_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::generate_key_pair(randomness)
+        Ok(super::generate_key_pair(randomness))
     }
 
     /// Encapsulate ML-KEM 768
     ///
     /// Generates an ([`MlKem768Ciphertext`], [`MlKemSharedSecret`]) tuple.
     /// The input is a reference to an [`MlKem768PublicKey`].
-    /// The random number generator `rng` needs to implement `CryptoRng`
+    /// The random number generator `rng` needs to implement `TryCryptoRng`
     /// to sample the required randomness internally.
-    #[hax_lib::fstar::verification_status(lax)]
+    // XXX: https://github.com/cryspen/hax/issues/2243
+    #[hax_lib::exclude]
     pub fn encapsulate(
         public_key: &MlKem768PublicKey,
-        rng: &mut impl CryptoRng,
-    ) -> (MlKem768Ciphertext, MlKemSharedSecret) {
+        rng: &mut impl TryCryptoRng,
+    ) -> Result<(MlKem768Ciphertext, MlKemSharedSecret), RandomnessError> {
         let mut randomness = [0u8; SHARED_SECRET_SIZE];
-        rng.fill_bytes(&mut randomness);
+        rng.try_fill_bytes(&mut randomness)
+            .map_err(|_| RandomnessError)?;
 
-        super::encapsulate(public_key, randomness)
+        Ok(super::encapsulate(public_key, randomness))
     }
 }
 

--- a/libcrux-ml-kem/src/pqcp.rs
+++ b/libcrux-ml-kem/src/pqcp.rs
@@ -62,7 +62,7 @@ macro_rules! pqcp_api {
         #[cfg(all(not(eurydice), feature = "pqcp"))]
         pub mod pqcp {
             #[cfg(feature = "rand")]
-            use ::rand::CryptoRng;
+            use ::rand::TryCryptoRng;
             use libcrux_traits::kem::arrayref::Kem;
 
             use super::*;
@@ -101,10 +101,11 @@ macro_rules! pqcp_api {
             pub fn crypto_kem_keypair(
                 pk: &mut [u8; PK_LEN],
                 sk: &mut [u8; SK_LEN],
-                rng: &mut impl CryptoRng,
+                rng: &mut impl TryCryptoRng,
             ) -> Result<(), PQCPError> {
                 let mut rand = [0u8; KEYGEN_SEED_LEN];
-                rng.fill_bytes(&mut rand);
+                rng.try_fill_bytes(&mut rand)
+                    .map_err(|_| PQCPError::KeyGeneration)?;
                 <$trait_implementer>::keygen(pk, sk, &rand).map_err(|_| PQCPError::KeyGeneration)
             }
 
@@ -133,10 +134,11 @@ macro_rules! pqcp_api {
                 ct: &mut [u8; CT_LEN],
                 ss: &mut [u8; SS_LEN],
                 pk: &[u8; PK_LEN],
-                rng: &mut impl CryptoRng,
+                rng: &mut impl TryCryptoRng,
             ) -> Result<(), PQCPError> {
                 let mut rand = [0u8; ENCAPS_SEED_LEN];
-                rng.fill_bytes(&mut rand);
+                rng.try_fill_bytes(&mut rand)
+                    .map_err(|_| PQCPError::Encapsulation)?;
                 <$trait_implementer>::encaps(ct, ss, pk, &rand)
                     .map_err(|_| PQCPError::Encapsulation)
             }
@@ -203,11 +205,13 @@ macro_rules! pqcp_unpacked_api {
             /// Key Pair in \"unpacked\" form (randomness generated internally)
             pub fn crypto_kem_keypair_struct(
                 key_pair: &mut $sk_type_unpacked,
-                rng: &mut impl ::rand::CryptoRng,
-            ) {
+                rng: &mut impl ::rand::TryCryptoRng,
+            ) -> Result<(), PQCPError> {
                 let mut randomness = [0u8; KEYGEN_SEED_LEN];
-                rng.fill_bytes(&mut randomness);
-                generate_key_pair_mut(randomness, key_pair)
+                rng.try_fill_bytes(&mut randomness)
+                    .map_err(|_| PQCPError::KeyGeneration)?;
+                generate_key_pair_mut(randomness, key_pair);
+                Ok(())
             }
 
             /// Serialize an unpacked public key
@@ -293,10 +297,11 @@ macro_rules! pqcp_unpacked_api {
                 ct: &mut [u8; CT_LEN],
                 ss: &mut [u8; SS_LEN],
                 pk: &$pk_type_unpacked,
-                rng: &mut impl ::rand::CryptoRng,
+                rng: &mut impl ::rand::TryCryptoRng,
             ) -> Result<(), PQCPError> {
                 let mut randomness = [0u8; ENCAPS_SEED_LEN];
-                rng.fill_bytes(&mut randomness);
+                rng.try_fill_bytes(&mut randomness)
+                    .map_err(|_| PQCPError::Encapsulation)?;
                 let (ciphertext, shared_secret) = super::encapsulate(pk, randomness);
                 ct.copy_from_slice(ciphertext.as_slice());
                 ss.copy_from_slice(shared_secret.as_slice());

--- a/libcrux-psq/CHANGELOG.md
+++ b/libcrux-psq/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): (Breaking) Widened the RNG bound throughout
+  the crate from `CryptoRng` to `TryCryptoRng` to support fallible RNGs. This affects
+  `DHPrivateKey::new`, `DHKeyPair::new`, `classic_mceliece::KeyPair::generate_key_pair`,
+  `PrincipalBuilder`, `RegistrationInitiator`, `Responder`, `QueryInitiator`, and the
+  builders (`build_query_initiator`, `build_registration_initiator`, `build_responder`), all of
+  which now return a `Result` (or propagate one) instead of panicking or being infallible
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Added a
+  `HandshakeError::InsufficientRandomness` variant, now used instead of the generic
+  `HandshakeError::CryptoError` when a `TryCryptoRng` fails to provide randomness
+
 ## [0.0.10] (2026-07-15)
 
 ### Changed

--- a/libcrux-psq/benches/psq_v2.rs
+++ b/libcrux-psq/benches/psq_v2.rs
@@ -11,7 +11,7 @@ use libcrux_psq::{
     },
     Channel, IntoSession,
 };
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 
 pub fn randombytes(n: usize) -> Vec<u8> {
     use rand::{rngs::SysRng, TryRng};
@@ -32,13 +32,14 @@ struct CommonSetup {
 impl CommonSetup {
     fn new() -> Self {
         let mut rng = rand::rng();
-        let responder_mlkem_keys = libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng);
+        let responder_mlkem_keys =
+            libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng).unwrap();
         #[cfg(feature = "classic-mceliece")]
         let responder_cmc_keys =
-            libcrux_psq::classic_mceliece::KeyPair::generate_key_pair(&mut rng);
+            libcrux_psq::classic_mceliece::KeyPair::generate_key_pair(&mut rng).unwrap();
 
-        let responder_ecdh_keys = DHKeyPair::new(&mut rng);
-        let initiator_ecdh_keys = DHKeyPair::new(&mut rng);
+        let responder_ecdh_keys = DHKeyPair::new(&mut rng).unwrap();
+        let initiator_ecdh_keys = DHKeyPair::new(&mut rng).unwrap();
 
         CommonSetup {
             responder_mlkem_keys,
@@ -648,7 +649,7 @@ fn build_responder<'a>(
     ctx: &'a [u8],
     aad_responder: &'a [u8],
     ciphersuite_id: CiphersuiteName,
-) -> Responder<'a, impl CryptoRng> {
+) -> Responder<'a, impl TryCryptoRng> {
     // Setup responder
     #[allow(unused_mut)] // we need it mutable for the CMC case
     let mut responder_cbuilder = CiphersuiteBuilder::new(ciphersuite_id)
@@ -674,7 +675,7 @@ fn build_responder<'a>(
 
 #[inline(always)]
 fn query_initiator<'a>(
-    rng: impl CryptoRng,
+    rng: impl TryCryptoRng,
     ctx: &'a [u8],
     aad_initiator: &'a [u8],
     responder_ecdh_keys: &'a DHKeyPair,
@@ -693,7 +694,7 @@ fn registration_initiator<'a>(
     aad_initiator_outer: &'a [u8],
     aad_initiator_inner: &'a [u8],
     ciphersuite_id: CiphersuiteName,
-) -> RegistrationInitiator<'a, impl CryptoRng> {
+) -> RegistrationInitiator<'a, impl TryCryptoRng> {
     #[allow(unused_mut)] // we need it mutable for the CMC case
     let mut initiator_cbuilder = CiphersuiteBuilder::new(ciphersuite_id)
         .longterm_x25519_keys(&setup.initiator_ecdh_keys)

--- a/libcrux-psq/fuzz/fuzz_targets/query_initiator_read_response.rs
+++ b/libcrux-psq/fuzz/fuzz_targets/query_initiator_read_response.rs
@@ -21,7 +21,7 @@ struct Setup {
 }
 
 static SETUP: LazyLock<Setup> = LazyLock::new(|| Setup {
-    responder_x25519_keys: DHKeyPair::new(&mut rand::rng()),
+    responder_x25519_keys: DHKeyPair::new(&mut rand::rng()).unwrap(),
 });
 
 fuzz_target!(|data: &[u8]| {

--- a/libcrux-psq/fuzz/fuzz_targets/registration_initiator_read_response.rs
+++ b/libcrux-psq/fuzz/fuzz_targets/registration_initiator_read_response.rs
@@ -28,8 +28,8 @@ struct Setup {
 static SETUP: LazyLock<Setup> = LazyLock::new(|| {
     let mut rng = rand::rng();
     Setup {
-        responder_x25519_keys: DHKeyPair::new(&mut rng),
-        initiator_x25519_keys: DHKeyPair::new(&mut rng),
+        responder_x25519_keys: DHKeyPair::new(&mut rng).unwrap(),
+        initiator_x25519_keys: DHKeyPair::new(&mut rng).unwrap(),
     }
 });
 

--- a/libcrux-psq/fuzz/fuzz_targets/responder_read_message.rs
+++ b/libcrux-psq/fuzz/fuzz_targets/responder_read_message.rs
@@ -30,8 +30,8 @@ struct Setup {
 static SETUP: LazyLock<Setup> = LazyLock::new(|| {
     let mut rng = rand::rng();
     Setup {
-        responder_x25519_keys: DHKeyPair::new(&mut rng),
-        responder_mlkem_keys: mlkem768::rand::generate_key_pair(&mut rng),
+        responder_x25519_keys: DHKeyPair::new(&mut rng).unwrap(),
+        responder_mlkem_keys: mlkem768::rand::generate_key_pair(&mut rng).unwrap(),
     }
 });
 

--- a/libcrux-psq/fuzz/fuzz_targets/transport_read_message.rs
+++ b/libcrux-psq/fuzz/fuzz_targets/transport_read_message.rs
@@ -34,8 +34,8 @@ struct TransportSetup {
 
 static TRANSPORT_SETUP: LazyLock<TransportSetup> = LazyLock::new(|| {
     let mut rng = rand::rng();
-    let responder_x25519_keys = DHKeyPair::new(&mut rng);
-    let initiator_x25519_keys = DHKeyPair::new(&mut rng);
+    let responder_x25519_keys = DHKeyPair::new(&mut rng).unwrap();
+    let initiator_x25519_keys = DHKeyPair::new(&mut rng).unwrap();
 
     let cname = CiphersuiteName::X25519_NONE_X25519_CHACHA20POLY1305_HKDFSHA256;
 

--- a/libcrux-psq/src/classic_mceliece.rs
+++ b/libcrux-psq/src/classic_mceliece.rs
@@ -84,13 +84,14 @@ pub struct KeyPair {
 
 impl KeyPair {
     /// Generate a new key pair.
-    pub fn generate_key_pair(rng: &mut impl rand::CryptoRng) -> Self {
+    pub fn generate_key_pair(rng: &mut impl rand::TryCryptoRng) -> Result<Self, KEMError> {
         let mut rng = McElieceRng::new(rng);
         let (pk, sk) = keypair_boxed(&mut rng);
-        Self {
+        rng.ok()?;
+        Ok(Self {
             pk: PublicKey(pk),
             sk: SecretKey(sk),
-        }
+        })
     }
 }
 
@@ -140,34 +141,61 @@ impl<'a> Serialize for SharedSecret<'a> {
 pub struct ClassicMcEliece;
 
 // This is only here because `classic-mceliece-rust` still depends on
-// `rand` version `0.8.0`.
-pub(crate) struct McElieceRng<'a, T: rand::CryptoRng> {
+// `rand` version `0.8.0`, whose `RngCore` interface is infallible. We bridge
+// our fallible `TryCryptoRng` through it by recording whether sampling
+// failed and letting the caller check `ok()` once
+// `classic-mceliece-rust` (which only calls the infallible `fill_bytes`)
+// returns, discarding whatever it produced from short-filled bytes.
+pub(crate) struct McElieceRng<'a, T: rand::TryCryptoRng> {
     inner_rng: &'a mut T,
+    failed: bool,
 }
 
-impl<'a, T: rand::CryptoRng> McElieceRng<'a, T> {
+impl<'a, T: rand::TryCryptoRng> McElieceRng<'a, T> {
     pub(crate) fn new(inner_rng: &'a mut T) -> Self {
-        Self { inner_rng }
+        Self {
+            inner_rng,
+            failed: false,
+        }
+    }
+
+    pub(crate) fn ok(&self) -> Result<(), KEMError> {
+        if self.failed {
+            Err(KEMError::InsufficientRandomness)
+        } else {
+            Ok(())
+        }
     }
 }
 
-impl<T: rand::CryptoRng> rand_old::RngCore for McElieceRng<'_, T> {
+impl<T: rand::TryCryptoRng> rand_old::RngCore for McElieceRng<'_, T> {
     fn next_u32(&mut self) -> u32 {
-        self.inner_rng.next_u32()
+        let mut buf = [0u8; 4];
+        if self.try_fill_bytes(&mut buf).is_err() {
+            self.failed = true;
+        }
+        u32::from_le_bytes(buf)
     }
     fn next_u64(&mut self) -> u64 {
-        self.inner_rng.next_u64()
+        let mut buf = [0u8; 8];
+        if self.try_fill_bytes(&mut buf).is_err() {
+            self.failed = true;
+        }
+        u64::from_le_bytes(buf)
     }
     fn fill_bytes(&mut self, dest: &mut [u8]) {
-        self.inner_rng.fill_bytes(dest)
+        if self.inner_rng.try_fill_bytes(dest).is_err() {
+            self.failed = true;
+        }
     }
     fn try_fill_bytes(&mut self, dest: &mut [u8]) -> Result<(), rand_old::Error> {
-        self.inner_rng.fill_bytes(dest);
-        Ok(())
+        self.inner_rng
+            .try_fill_bytes(dest)
+            .map_err(|_| rand_old::Error::new(std::io::Error::other("insufficient randomness")))
     }
 }
 
-impl<T: rand::CryptoRng> rand_old::CryptoRng for McElieceRng<'_, T> {}
+impl<T: rand::TryCryptoRng> rand_old::CryptoRng for McElieceRng<'_, T> {}
 
 impl KEM for ClassicMcEliece {
     /// The KEM's ciphertext.
@@ -181,20 +209,22 @@ impl KEM for ClassicMcEliece {
 
     /// Generate a pair of encapsulation and decapsulation keys.
     fn generate_key_pair(
-        rng: &mut impl rand::CryptoRng,
+        rng: &mut impl rand::TryCryptoRng,
     ) -> Result<KEMKeyPair<Sk<'static>, PublicKey>, KEMError> {
         let mut rng = McElieceRng::new(rng);
         let (pk, sk) = keypair_boxed(&mut rng);
+        rng.ok()?;
         Ok((sk, PublicKey(pk)))
     }
 
     /// Encapsulate a shared secret towards a given encapsulation key.
     fn encapsulate(
         ek: &Self::EncapsulationKey,
-        rng: &mut impl rand::CryptoRng,
+        rng: &mut impl rand::TryCryptoRng,
     ) -> Result<(Self::SharedSecret, Self::Ciphertext), KEMError> {
         let mut rng = McElieceRng::new(rng);
         let (enc, ss) = encapsulate_boxed(&ek.0, &mut rng);
+        rng.ok()?;
         Ok((SharedSecret(ss), Ciphertext(enc)))
     }
 

--- a/libcrux-psq/src/handshake.rs
+++ b/libcrux-psq/src/handshake.rs
@@ -31,6 +31,8 @@ pub enum HandshakeError {
     IdentifierMismatch,
     InvalidMessage,
     InvalidDHSecret,
+    /// The random number generator did not provide enough randomness.
+    InsufficientRandomness,
 }
 
 impl From<libcrux_ed25519::Error> for HandshakeError {

--- a/libcrux-psq/src/handshake/builder.rs
+++ b/libcrux-psq/src/handshake/builder.rs
@@ -1,4 +1,4 @@
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 
 use super::{
     builders::BuilderError as Error,
@@ -14,7 +14,7 @@ use crate::handshake::{
 
 const RECENT_KEYS_DEFAULT_BOUND: usize = 100;
 
-pub struct PrincipalBuilder<'a, Rng: CryptoRng> {
+pub struct PrincipalBuilder<'a, Rng: TryCryptoRng> {
     rng: Rng,
     context: &'a [u8],
     inner_aad: &'a [u8],
@@ -22,7 +22,7 @@ pub struct PrincipalBuilder<'a, Rng: CryptoRng> {
     responder_recent_keys_upper_bound: usize,
 }
 
-impl<'a, Rng: CryptoRng> PrincipalBuilder<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> PrincipalBuilder<'a, Rng> {
     /// Create a new builder.
     pub fn new(rng: Rng) -> Self {
         Self {

--- a/libcrux-psq/src/handshake/ciphersuite/initiator.rs
+++ b/libcrux-psq/src/handshake/ciphersuite/initiator.rs
@@ -1,6 +1,6 @@
 use libcrux_ed25519::{SigningKey as Ed25519SigningKey, VerificationKey as Ed25519VerificationKey};
 use libcrux_ml_dsa::ml_dsa_65::{MLDSA65KeyPair, MLDSA65SigningKey, MLDSA65VerificationKey};
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::SerializeBytes;
 
 #[cfg(feature = "classic-mceliece")]
@@ -68,7 +68,7 @@ impl<'a> From<&'a (Ed25519SigningKey, Ed25519VerificationKey)> for SigningKeyPai
 impl<'a> SigningKeyPair<'a> {
     pub(crate) fn sign(
         &self,
-        rng: &mut impl CryptoRng,
+        rng: &mut impl TryCryptoRng,
         tx: &Transcript,
     ) -> Result<Signature, HandshakeError> {
         let payload = tx
@@ -81,7 +81,8 @@ impl<'a> SigningKeyPair<'a> {
             }
             SigningKeyPair::MlDsa65(mldsasigning_key, _) => {
                 let mut randomness = [0u8; libcrux_ml_dsa::SIGNING_RANDOMNESS_SIZE];
-                rng.fill_bytes(&mut randomness);
+                rng.try_fill_bytes(&mut randomness)
+                    .map_err(|_| HandshakeError::InsufficientRandomness)?;
                 let sig = libcrux_ml_dsa::ml_dsa_65::sign(
                     mldsasigning_key,
                     &payload,
@@ -196,7 +197,7 @@ impl<'a> InitiatorCiphersuite<'a> {
 
     pub(crate) fn pq_encapsulate(
         &self,
-        rng: &mut impl CryptoRng,
+        rng: &mut impl TryCryptoRng,
     ) -> Result<
         PQOptionPair<
             <Self as CiphersuiteBase>::Ciphertext,
@@ -208,7 +209,8 @@ impl<'a> InitiatorCiphersuite<'a> {
             PqKemPublicKey::None => Ok((None, None)),
             PqKemPublicKey::MlKem(ml_kem_public_key) => {
                 let mut rand = [0u8; libcrux_ml_kem::ENCAPS_SEED_SIZE];
-                rng.fill_bytes(&mut rand);
+                rng.try_fill_bytes(&mut rand)
+                    .map_err(|_| HandshakeError::InsufficientRandomness)?;
                 let (ct, ss) = libcrux_ml_kem::mlkem768::encapsulate(ml_kem_public_key, rand);
 
                 Ok((
@@ -219,10 +221,14 @@ impl<'a> InitiatorCiphersuite<'a> {
             #[cfg(feature = "classic-mceliece")]
             PqKemPublicKey::Cmc(public_key) => {
                 use crate::classic_mceliece::ClassicMcEliece;
-                use libcrux_traits::kem::KEM;
+                use libcrux_traits::kem::{KEMError, KEM};
 
-                let (ss, ct) = <ClassicMcEliece as KEM>::encapsulate(public_key, rng)
-                    .map_err(|_| HandshakeError::CryptoError)?;
+                let (ss, ct) = <ClassicMcEliece as KEM>::encapsulate(public_key, rng).map_err(
+                    |e| match e {
+                        KEMError::InsufficientRandomness => HandshakeError::InsufficientRandomness,
+                        _ => HandshakeError::CryptoError,
+                    },
+                )?;
 
                 Ok((
                     Some(PQCiphertext::CMC(Box::new(ct))),

--- a/libcrux-psq/src/handshake/dhkem.rs
+++ b/libcrux-psq/src/handshake/dhkem.rs
@@ -3,7 +3,7 @@
 //! This module provides wrappers around KEM types, assuming a DH-KEM
 //! style API.
 use libcrux_ecdh::{secret_to_public, Algorithm};
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::{TlsDeserialize, TlsDeserializeBytes, TlsSerialize, TlsSerializeBytes, TlsSize};
 
 use crate::handshake::{
@@ -76,11 +76,11 @@ impl DHSharedSecret {
 
 impl DHPrivateKey {
     /// Creates a new KEM private key.
-    pub fn new(rng: &mut impl CryptoRng) -> Self {
-        Self(
+    pub fn new(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
+        Ok(Self(
             libcrux_ecdh::generate_secret(libcrux_ecdh::Algorithm::X25519, rng)
-                .expect("Insufficient Randomness"),
-        )
+                .map_err(|_| Error::InsufficientRandomness)?,
+        ))
     }
 
     /// Compute the KEM public key from the KEM private key.
@@ -126,10 +126,10 @@ impl ProvideAuthenticator for DHKeyPair {
 
 impl DHKeyPair {
     /// Generate a fresh Diffie-Hellman key pair.
-    pub fn new(rng: &mut impl CryptoRng) -> Self {
-        let sk = DHPrivateKey::new(rng);
+    pub fn new(rng: &mut impl TryCryptoRng) -> Result<Self, Error> {
+        let sk = DHPrivateKey::new(rng)?;
         let pk = sk.to_public();
-        Self { sk, pk }
+        Ok(Self { sk, pk })
     }
 
     /// Provide reference to the Diffie-Hellman private key.

--- a/libcrux-psq/src/handshake/initiator/query.rs
+++ b/libcrux-psq/src/handshake/initiator/query.rs
@@ -1,6 +1,6 @@
 use std::io::Cursor;
 
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::{Deserialize, Serialize, Size, VLByteSlice};
 
 use super::InitiatorOuterPayloadOut;
@@ -48,9 +48,9 @@ impl<'a> QueryInitiator<'a> {
         responder_longterm_ecdh_pk: &'a DHPublicKey,
         ctx: &[u8],
         outer_aad: &'a [u8],
-        mut rng: impl CryptoRng,
+        mut rng: impl TryCryptoRng,
     ) -> Result<Self, Error> {
-        let initiator_ephemeral_keys = DHKeyPair::new(&mut rng);
+        let initiator_ephemeral_keys = DHKeyPair::new(&mut rng)?;
 
         let (tx0, k0) = derive_k0(
             responder_longterm_ecdh_pk,

--- a/libcrux-psq/src/handshake/initiator/registration.rs
+++ b/libcrux-psq/src/handshake/initiator/registration.rs
@@ -1,6 +1,6 @@
 use std::{io::Cursor, mem::take};
 
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::{Deserialize, Serialize, Size, VLByteSlice};
 
 use super::{InitiatorInnerPayloadOut, InitiatorOuterPayloadOut};
@@ -20,7 +20,7 @@ use crate::{
     traits::{Channel, IntoSession},
 };
 
-pub struct RegistrationInitiator<'a, Rng: CryptoRng> {
+pub struct RegistrationInitiator<'a, Rng: TryCryptoRng> {
     ciphersuite: InitiatorCiphersuite<'a>,
     inner_aad: &'a [u8],
     outer_aad: &'a [u8],
@@ -49,7 +49,7 @@ pub(crate) enum RegistrationInitiatorState {
     ToTransport(Box<ToTransportState>),
 }
 
-impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> RegistrationInitiator<'a, Rng> {
     /// Create a new [`RegistrationInitiator`].
     pub(crate) fn new(
         ciphersuite: InitiatorCiphersuite<'a>,
@@ -58,7 +58,7 @@ impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
         outer_aad: &'a [u8],
         mut rng: Rng,
     ) -> Result<Self, Error> {
-        let initiator_ephemeral_keys = DHKeyPair::new(&mut rng);
+        let initiator_ephemeral_keys = DHKeyPair::new(&mut rng)?;
 
         let (tx0, k0) = derive_k0(
             ciphersuite.kex,
@@ -234,7 +234,7 @@ impl<'a, Rng: CryptoRng> RegistrationInitiator<'a, Rng> {
     }
 }
 
-impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for RegistrationInitiator<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> Channel<Error, HandshakeMessage> for RegistrationInitiator<'a, Rng> {
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let mut old_state = self.write_state()?;
 
@@ -322,7 +322,7 @@ impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for RegistrationInitia
     }
 }
 
-impl<'a, Rng: CryptoRng> IntoSession for RegistrationInitiator<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> IntoSession for RegistrationInitiator<'a, Rng> {
     fn into_session(self) -> Result<Session, SessionError> {
         let RegistrationInitiatorState::ToTransport(state) = self.state else {
             return Err(SessionError::IntoSession);

--- a/libcrux-psq/src/handshake/responder.rs
+++ b/libcrux-psq/src/handshake/responder.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, io::Cursor, mem::take};
 
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::{
     Deserialize, Serialize, Size, TlsDeserialize, TlsSerialize, TlsSize, VLByteSlice, VLBytes,
 };
@@ -65,7 +65,7 @@ pub(crate) enum ResponderState {
     ToTransport(Box<ToTransportState>),
 }
 
-pub struct Responder<'a, Rng: CryptoRng> {
+pub struct Responder<'a, Rng: TryCryptoRng> {
     pub(crate) state: ResponderState,
     ciphersuite: ResponderCiphersuite<'a>,
     working_ciphersuite: Option<CiphersuiteName>,
@@ -88,7 +88,7 @@ pub struct ResponderRegistrationPayload(pub VLBytes);
 #[derive(TlsSerialize, TlsSize)]
 pub struct ResponderRegistrationPayloadOut<'a>(VLByteSlice<'a>);
 
-impl<'a, Rng: CryptoRng> Responder<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> Responder<'a, Rng> {
     /// Returns the most recent initiator authenticator for out-of-band
     /// verification, if any.
     ///
@@ -347,7 +347,7 @@ impl<'a, Rng: CryptoRng> Responder<'a, Rng> {
         payload: &[u8],
     ) -> Result<(DHPublicKey, MessageCiphertext), Error> {
         let state = take(&mut self.state);
-        let responder_ephemeral_ecdh_keys = DHKeyPair::new(&mut self.rng);
+        let responder_ephemeral_ecdh_keys = DHKeyPair::new(&mut self.rng)?;
 
         let message_contents = match state {
             ResponderState::RespondQuery(respond_query_state) => self.query(
@@ -437,7 +437,7 @@ impl<'a, Rng: CryptoRng> Responder<'a, Rng> {
     }
 }
 
-impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for Responder<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> Channel<Error, HandshakeMessage> for Responder<'a, Rng> {
     fn write_message(&mut self, payload: &[u8], out: &mut [u8]) -> Result<usize, Error> {
         let (responder_ephemeral_ecdh_pk, message_contents) =
             self.prepare_message_contents(payload)?;
@@ -505,7 +505,7 @@ impl<'a, Rng: CryptoRng> Channel<Error, HandshakeMessage> for Responder<'a, Rng>
     }
 }
 
-impl<'a, Rng: CryptoRng> IntoSession for Responder<'a, Rng> {
+impl<'a, Rng: TryCryptoRng> IntoSession for Responder<'a, Rng> {
     fn into_session(self) -> Result<Session, SessionError> {
         let ResponderState::ToTransport(mut state) = self.state else {
             return Err(SessionError::IntoSession);

--- a/libcrux-psq/src/handshake/transcript.rs
+++ b/libcrux-psq/src/handshake/transcript.rs
@@ -1,4 +1,4 @@
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 use tls_codec::{
     Serialize, SerializeBytes, TlsDeserialize, TlsSerialize, TlsSerializeBytes, TlsSize,
 };
@@ -106,7 +106,7 @@ pub(crate) fn sign_tx1<'a>(
     authenticator: Auth<'a>,
     responder_pq_pk: Option<PQEncapsulationKey>,
     pq_encaps: &[u8],
-    rng: &mut impl CryptoRng,
+    rng: &mut impl TryCryptoRng,
 ) -> Result<(Option<Signature>, Transcript), Error> {
     let tx1 = tx1(
         tx0,

--- a/libcrux-psq/src/lib.rs
+++ b/libcrux-psq/src/lib.rs
@@ -16,12 +16,13 @@
 //! let mut rng = rand::rng();
 //!
 //! // External setup: Responder keys
-//! let responder_mlkem_keys = libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng);
+//! let responder_mlkem_keys =
+//!     libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng).unwrap();
 //!
-//! let responder_ecdh_keys = DHKeyPair::new(&mut rng);
+//! let responder_ecdh_keys = DHKeyPair::new(&mut rng).unwrap();
 //!
 //! // External setup: Initiator keys
-//! let initiator_ecdh_keys = DHKeyPair::new(&mut rng);
+//! let initiator_ecdh_keys = DHKeyPair::new(&mut rng).unwrap();
 //!
 //! let ctx = b"Test Context";
 //! let aad_initiator_query = b"Test Data Initiator Query";

--- a/libcrux-psq/tests/registration.rs
+++ b/libcrux-psq/tests/registration.rs
@@ -194,13 +194,14 @@ impl CommonSetup {
 
     fn new() -> Self {
         let mut rng = rand::rng();
-        let responder_mlkem_keys = libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng);
+        let responder_mlkem_keys =
+            libcrux_ml_kem::mlkem768::rand::generate_key_pair(&mut rng).unwrap();
         #[cfg(feature = "classic-mceliece")]
         let responder_cmc_keys =
-            libcrux_psq::classic_mceliece::KeyPair::generate_key_pair(&mut rng);
+            libcrux_psq::classic_mceliece::KeyPair::generate_key_pair(&mut rng).unwrap();
 
-        let responder_x25519_keys = DHKeyPair::new(&mut rng);
-        let initiator_x25519_keys = DHKeyPair::new(&mut rng);
+        let responder_x25519_keys = DHKeyPair::new(&mut rng).unwrap();
+        let initiator_x25519_keys = DHKeyPair::new(&mut rng).unwrap();
 
         let mut rand = [0u8; libcrux_ml_dsa::KEY_GENERATION_RANDOMNESS_SIZE];
         rng.fill(&mut rand);

--- a/traits/CHANGELOG.md
+++ b/traits/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): Added a `KEMError::InsufficientRandomness`
+  variant for KEM implementations that sample randomness from a fallible RNG
+- [#1584](https://github.com/celabshq/libcrux/pull/1584): (Breaking) Widened the RNG bound on
+  `kem::KEM::generate_key_pair` and `kem::KEM::encapsulate` from `CryptoRng` to `TryCryptoRng` to
+  support fallible RNGs
+
 ## [0.0.8] (2026-07-15)
 
 ### Changed

--- a/traits/src/kem.rs
+++ b/traits/src/kem.rs
@@ -8,7 +8,7 @@ pub mod slice;
 #[cfg(feature = "generic-tests")]
 pub mod tests;
 
-use rand::CryptoRng;
+use rand::TryCryptoRng;
 
 /// A KEM keypair.
 pub type KeyPair<DK, EK> = (DK, EK);
@@ -22,6 +22,8 @@ pub enum KEMError {
     Encapsulation,
     /// An error that occurred during decapsulation.
     Decapsulation,
+    /// The random number generator did not provide enough randomness.
+    InsufficientRandomness,
 }
 
 /// This trait captures the required interface of a key encapsulation
@@ -38,13 +40,13 @@ pub trait KEM {
 
     /// Generate a pair of encapsulation and decapsulation keys.
     fn generate_key_pair(
-        rng: &mut impl CryptoRng,
+        rng: &mut impl TryCryptoRng,
     ) -> Result<KeyPair<Self::DecapsulationKey, Self::EncapsulationKey>, KEMError>;
 
     /// Encapsulate a shared secret towards a given encapsulation key.
     fn encapsulate(
         ek: &Self::EncapsulationKey,
-        rng: &mut impl CryptoRng,
+        rng: &mut impl TryCryptoRng,
     ) -> Result<(Self::SharedSecret, Self::Ciphertext), KEMError>;
 
     /// Decapsulate a shared secret.


### PR DESCRIPTION
This PR allows fallible rngs in some more places. We should do it everywhere and also update the code underneath to actually propagate errors. But this is a first, non-intrusive pass.

This also adds some DER functionality so that we can actually use the P256 EcDSA crate.