### PR TITLE
[p256] const visibility change and derive_ecdh doc addition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   post-quantum and PQ/T-hybrid algorithms of
   [draft-ietf-hpke-pq](https://datatracker.ietf.org/doc/html/draft-ietf-hpke-pq-04),
   in the **libcrux provider only**, behind the new `draft-ietf-hpke-pq` feature.
+- (libcrux-p256) [#1586](https://github.com/celabshq/libcrux/pull/1586): Expose constants used in `Ecdh*` trait implementations
 
 
 ## [0.0.5] (2026-07-15)

--- a/crates/algorithms/p256/CHANGELOG.md
+++ b/crates/algorithms/p256/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- [#1586](https://github.com/celabshq/libcrux/pull/1586): Expose constants used in `Ecdh*` trait implementations
+
 ## [0.0.8] (2026-07-15)
 
 ### Changed 

--- a/crates/algorithms/p256/src/ecdh_api.rs
+++ b/crates/algorithms/p256/src/ecdh_api.rs
@@ -29,6 +29,20 @@ impl libcrux_traits::ecdh::arrayref::EcdhArrayref<RAND_LEN, SECRET_LEN, PUBLIC_L
             .ok_or(libcrux_traits::ecdh::arrayref::SecretToPublicError::InvalidSecret)
     }
 
+    /// Derive the ECDH output point.
+    ///
+    /// This computes the point `derived = secret * public` and writes its affine
+    /// representation `x||y` into `derived`. Each coordinate is represented as a 32-byte
+    /// array in big-endian format. As a result, the `derived` array has a length of 64 bytes
+    /// ([`PUBLIC_LEN`]).
+    ///
+    /// The ECDH shared secret is the x coordinate, i.e., `derived[..32]`.
+    ///
+    /// This shared secret is NOT (!) safe for use as a key and needs to be processed in a
+    /// round of key derivation, to ensure both that the output is uniformly random and that
+    /// unknown key share attacks can not happen.
+    ///
+    /// On error, the contents of derived are unspecified and may have been overwritten.
     fn derive_ecdh(
         derived: &mut [U8; PUBLIC_LEN],
         public: &[u8; PUBLIC_LEN],

--- a/crates/algorithms/p256/src/ecdh_api.rs
+++ b/crates/algorithms/p256/src/ecdh_api.rs
@@ -1,8 +1,8 @@
 use super::{POINT_LEN, SCALAR_LEN};
 
-const RAND_LEN: usize = SCALAR_LEN;
-const SECRET_LEN: usize = SCALAR_LEN;
-const PUBLIC_LEN: usize = POINT_LEN;
+pub const RAND_LEN: usize = SCALAR_LEN;
+pub const SECRET_LEN: usize = SCALAR_LEN;
+pub const PUBLIC_LEN: usize = POINT_LEN;
 
 pub use libcrux_traits::ecdh::{arrayref::EcdhArrayref, owned::EcdhOwned, slice::EcdhSlice};
 

--- a/traits/src/ecdh/arrayref.rs
+++ b/traits/src/ecdh/arrayref.rs
@@ -36,7 +36,7 @@ pub trait EcdhArrayref<const RAND_LEN: usize, const SECRET_LEN: usize, const PUB
     /// secret value.
     ///
     /// This value is NOT (!) safe for use as a key and needs to be processed in a round of key
-    /// derivation, to ensure both that the output is uniformly random and that unkown key share
+    /// derivation, to ensure both that the output is uniformly random and that unknown key share
     /// attacks can not happen.
     fn derive_ecdh(
         derived: &mut [U8; PUBLIC_LEN],


### PR DESCRIPTION
This PR makes the constants that are used in the `Ecdh` trait implementations public.

It also adds a comment on the `derive_ecdh` method that clarifies that this returns the complete point `x||y`.

While this now documents what the method returns, I would still argue for changing the return of this method to just provide `x`. This would be in-line with the definition in NIST SP 800-56 ([5.7.1.2][sp]) or SEC 1 ([3.3.1][sec1]) and would then reflect what is stated on the `Ecdh` trait,
https://github.com/celabshq/libcrux/blob/5caed1132ad6f0f10f329a2fe665b7a6ca9b8fa5/traits/src/ecdh/arrayref.rs#L35-L36

as the shared secret is defined as `x` in the linked references.

[sp]: https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf
[sec1]: https://www.secg.org/sec1-v2.pdf